### PR TITLE
feat: add limit option for pnl command

### DIFF
--- a/pkg/cmd/pnl.go
+++ b/pkg/cmd/pnl.go
@@ -21,7 +21,7 @@ import (
 func init() {
 	PnLCmd.Flags().String("exchange", "", "target exchange")
 	PnLCmd.Flags().String("symbol", "BTCUSDT", "trading symbol")
-	PnLCmd.Flags().Int("limit", 500, "number of orders")
+	PnLCmd.Flags().Int("limit", 500, "number of trades")
 	RootCmd.AddCommand(PnLCmd)
 }
 

--- a/pkg/cmd/pnl.go
+++ b/pkg/cmd/pnl.go
@@ -21,6 +21,7 @@ import (
 func init() {
 	PnLCmd.Flags().String("exchange", "", "target exchange")
 	PnLCmd.Flags().String("symbol", "BTCUSDT", "trading symbol")
+	PnLCmd.Flags().Int("limit", 500, "number of orders")
 	RootCmd.AddCommand(PnLCmd)
 }
 
@@ -46,6 +47,11 @@ var PnLCmd = &cobra.Command{
 			return err
 		}
 
+		limit, err := cmd.Flags().GetInt("limit")
+		if err != nil {
+			return err
+		}
+
 		exchange, err := cmdutil.NewExchange(exchangeName)
 		if err != nil {
 			return err
@@ -67,6 +73,7 @@ var PnLCmd = &cobra.Command{
 			trades, err = tradeService.Query(service.QueryTradesOptions{
 				Exchange: exchange.Name(),
 				Symbol:   symbol,
+				Limit:	  limit,
 			})
 		}
 

--- a/pkg/service/trade.go
+++ b/pkg/service/trade.go
@@ -163,13 +163,13 @@ func (s *TradeService) QueryForTradingFeeCurrency(ex types.ExchangeName, symbol 
 	return s.scanRows(rows)
 }
 
-// Only return 500 items.
 type QueryTradesOptions struct {
 	Exchange types.ExchangeName
 	Symbol   string
 	LastGID  int64
 	// ASC or DESC
 	Ordering string
+	Limit	 int
 }
 
 func (s *TradeService) Query(options QueryTradesOptions) ([]types.Trade, error) {
@@ -225,7 +225,7 @@ func queryTradesSQL(options QueryTradesOptions) string {
 
 	sql += ` ORDER BY gid ` + ordering
 
-	sql += ` LIMIT ` + strconv.Itoa(500)
+	sql += ` LIMIT ` + strconv.Itoa(options.Limit)
 	return sql
 }
 

--- a/pkg/service/trade_test.go
+++ b/pkg/service/trade_test.go
@@ -27,23 +27,23 @@ func Test_queryTradingVolumeSQL(t *testing.T) {
 
 func Test_queryTradesSQL(t *testing.T) {
 	t.Run("generate order by clause by Ordering option", func(t *testing.T) {
-		assert.Equal(t, "SELECT * FROM trades ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{}))
-		assert.Equal(t, "SELECT * FROM trades ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{Ordering: "ASC"}))
-		assert.Equal(t, "SELECT * FROM trades ORDER BY gid DESC LIMIT 500", queryTradesSQL(QueryTradesOptions{Ordering: "DESC"}))
+		assert.Equal(t, "SELECT * FROM trades ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{Limit: 500}))
+		assert.Equal(t, "SELECT * FROM trades ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{Ordering: "ASC", Limit: 500}))
+		assert.Equal(t, "SELECT * FROM trades ORDER BY gid DESC LIMIT 500", queryTradesSQL(QueryTradesOptions{Ordering: "DESC", Limit: 500}))
 	})
 
 	t.Run("filter by exchange name", func(t *testing.T) {
-		assert.Equal(t, "SELECT * FROM trades WHERE exchange = :exchange ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{Exchange: "max"}))
+		assert.Equal(t, "SELECT * FROM trades WHERE exchange = :exchange ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{Exchange: "max", Limit: 500}))
 	})
 
 	t.Run("filter by symbol", func(t *testing.T) {
-		assert.Equal(t, "SELECT * FROM trades WHERE symbol = :symbol ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{Symbol: "eth"}))
+		assert.Equal(t, "SELECT * FROM trades WHERE symbol = :symbol ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{Symbol: "eth", Limit: 500}))
 	})
 
 	t.Run("GID ordering", func(t *testing.T) {
-		assert.Equal(t, "SELECT * FROM trades WHERE gid > :gid ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{LastGID: 1}))
-		assert.Equal(t, "SELECT * FROM trades WHERE gid > :gid ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{LastGID: 1, Ordering: "ASC"}))
-		assert.Equal(t, "SELECT * FROM trades WHERE gid < :gid ORDER BY gid DESC LIMIT 500", queryTradesSQL(QueryTradesOptions{LastGID: 1, Ordering: "DESC"}))
+		assert.Equal(t, "SELECT * FROM trades WHERE gid > :gid ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{LastGID: 1, Limit: 500}))
+		assert.Equal(t, "SELECT * FROM trades WHERE gid > :gid ORDER BY gid ASC LIMIT 500", queryTradesSQL(QueryTradesOptions{LastGID: 1, Ordering: "ASC", Limit: 500}))
+		assert.Equal(t, "SELECT * FROM trades WHERE gid < :gid ORDER BY gid DESC LIMIT 500", queryTradesSQL(QueryTradesOptions{LastGID: 1, Ordering: "DESC", Limit: 500}))
 	})
 
 	t.Run("convert all options", func(t *testing.T) {
@@ -52,6 +52,7 @@ func Test_queryTradesSQL(t *testing.T) {
 			Symbol:   "btc",
 			LastGID:  123,
 			Ordering: "DESC",
+			Limit:	  500,
 		}))
 	})
 }


### PR DESCRIPTION
Usage: `bbgo pnl --exchange max --symbol BTCUSDT --limit 7000`

To calculate profit and loss for specified limit of orders