### PR TITLE
minor: move maxapi.Response to util package

### DIFF
--- a/pkg/util/http_response.go
+++ b/pkg/util/http_response.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+// Response is wrapper for standard http.Response and provides
+// more methods.
+type Response struct {
+	*http.Response
+
+	// Body overrides the composited Body field.
+	Body []byte
+}
+
+// newResponse is a wrapper of the http.Response instance, it reads the response body and close the file.
+func NewResponse(r *http.Response) (response *Response, err error) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.Body.Close()
+	response = &Response{Response: r, Body: body}
+	return response, err
+}
+
+// String converts response body to string.
+// An empty string will be returned if error.
+func (r *Response) String() string {
+	return string(r.Body)
+}
+
+func (r *Response) DecodeJSON(o interface{}) error {
+	return json.Unmarshal(r.Body, o)
+}

--- a/pkg/util/http_response_test.go
+++ b/pkg/util/http_response_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResponse_DecodeJSON(t *testing.T) {
+	type temp struct {
+		Name string `json:"name"`
+	}
+	json := `{"name":"Test Name","a":"a"}`
+	reader := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+	resp, err := NewResponse(&http.Response{
+		StatusCode: 200,
+		Body:       reader,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, json, resp.String())
+
+	var result temp
+	assert.NoError(t, resp.DecodeJSON(&result))
+	assert.Equal(t, "Test Name", result.Name)
+}


### PR DESCRIPTION
The `Response` struct is general and could be shared with other exchange implementations, like FTX integration. I move it to util package and add unit test on it.