### PR TITLE
fix(max): use global trade side here, not string

### DIFF
--- a/pkg/exchange/max/stream.go
+++ b/pkg/exchange/max/stream.go
@@ -194,7 +194,7 @@ func convertWebSocketTrade(t max.TradeUpdate) (*types.Trade, error) {
 		Price:         price,
 		Quantity:      quantity,
 		Side:          side,
-		IsBuyer:       side == "bid" || side == "buy",
+		IsBuyer:       side == types.SideTypeBuy,
 		IsMaker:       t.Maker,
 		Fee:           fee,
 		FeeCurrency:   toGlobalCurrency(t.FeeCurrency),


### PR DESCRIPTION
in pkg/exchange/max/stream.go:
```
func convertWebSocketTrade(t max.TradeUpdate) (*types.Trade, error) {
        // skip trade ID that is the same. however this should not happen
        var side = toGlobalSideType(t.Side)
```

We should use global side here, not string based side. 