### PR TITLE
Fix bollgrid balance calculation

### DIFF
--- a/pkg/strategy/bollgrid/strategy.go
+++ b/pkg/strategy/bollgrid/strategy.go
@@ -142,12 +142,12 @@ func (s *Strategy) generateGridBuyOrders(session *bbgo.ExchangeSession) ([]types
 			Price:       price,
 			TimeInForce: "GTC",
 		}
-		quotaQuantity := fixedpoint.NewFromFloat(order.Quantity).MulFloat64(price)
-		if quoteBalance < quotaQuantity {
+		quoteQuantity := fixedpoint.NewFromFloat(order.Quantity).MulFloat64(price)
+		if quoteBalance < quoteQuantity {
 			log.Infof("quote balance %f is not enough, stop generating buy orders", quoteBalance.Float64())
 			break
 		}
-		quoteBalance = quotaQuantity.Sub(quotaQuantity)
+		quoteBalance = quoteBalance.Sub(quoteQuantity)
 		log.Infof("submitting order: %s", order.String())
 		orders = append(orders, order)
 	}


### PR DESCRIPTION
剛剛發現之前的 PR 不小心把 `quoteBalance = quotaBalance.Sub(quotaQuantity)` 寫成 `quoteBalance = quotaQuantity.Sub(quotaQuantity)`，造成每次都只會生出一張單，現在修好了～