### PR TITLE
feature: orderbook snapshot checksum

### DIFF
--- a/pkg/exchange/ftx/websocket_messages.go
+++ b/pkg/exchange/ftx/websocket_messages.go
@@ -3,7 +3,9 @@ package ftx
 import (
 	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -65,13 +67,13 @@ func (r rawResponse) toSubscribedResp() subscribedResponse {
 	}
 }
 
-func (r rawResponse) toDataResponse() (dataResponse, error) {
-	o := dataResponse{
+func (r rawResponse) toOrderBookResponse() (orderBookResponse, error) {
+	o := orderBookResponse{
 		mandatoryFields: r.mandatoryFields,
 	}
 
 	if err := json.Unmarshal(r.Data, &o); err != nil {
-		return dataResponse{}, err
+		return orderBookResponse{}, err
 	}
 
 	sec, dec := math.Modf(o.Time)
@@ -85,7 +87,7 @@ type subscribedResponse struct {
 	mandatoryFields
 }
 
-type dataResponse struct {
+type orderBookResponse struct {
 	mandatoryFields
 
 	Action string `json:"action"`
@@ -96,12 +98,130 @@ type dataResponse struct {
 
 	Checksum uint32 `json:"checksum"`
 
+	// best 100 orders. Ex. {[100,1], [50, 2]}
 	Bids [][]json.Number `json:"bids"`
 
+	// best 100 orders. Ex. {[51, 1], [102, 3]}
 	Asks [][]json.Number `json:"asks"`
 }
 
-func toGlobalOrderBook(r dataResponse) (types.OrderBook, error) {
+// only 100 orders so we use linear search here
+func (r *orderBookResponse) update(orderUpdates orderBookResponse) {
+	r.Checksum = orderUpdates.Checksum
+	r.updateBids(orderUpdates.Bids)
+	r.updateAsks(orderUpdates.Asks)
+}
+
+func (r *orderBookResponse) updateAsks(asks [][]json.Number) {
+	higherPrice := func(dst, src float64) bool {
+		return dst < src
+	}
+	for _, o := range asks {
+		if remove := o[1] == "0"; remove {
+			r.Asks = removePrice(r.Asks, o[0])
+		} else {
+			r.Asks = upsertPriceVolume(r.Asks, o, higherPrice)
+		}
+	}
+}
+
+func (r *orderBookResponse) updateBids(bids [][]json.Number) {
+	lessPrice := func(dst, src float64) bool {
+		return dst > src
+	}
+	for _, o := range bids {
+		if remove := o[1] == "0"; remove {
+			r.Bids = removePrice(r.Bids, o[0])
+		} else {
+			r.Bids = upsertPriceVolume(r.Bids, o, lessPrice)
+		}
+	}
+}
+
+func upsertPriceVolume(dst [][]json.Number, src []json.Number, priceComparator func(dst float64, src float64) bool) [][]json.Number {
+	for i, pv := range dst {
+		dstPrice := pv[0]
+		srcPrice := src[0]
+
+		// update volume
+		if dstPrice == srcPrice {
+			pv[1] = src[1]
+			return dst
+		}
+
+		// The value must be a number which is verified by json.Unmarshal, so the err
+		// should never happen.
+		dstPriceNum, err := strconv.ParseFloat(string(dstPrice), 64)
+		if err != nil {
+			logger.WithError(err).Errorf("unexpected price %s", dstPrice)
+			continue
+		}
+		srcPriceNum, err := strconv.ParseFloat(string(srcPrice), 64)
+		if err != nil {
+			logger.WithError(err).Errorf("unexpected price updates %s", srcPrice)
+			continue
+		}
+
+		if !priceComparator(dstPriceNum, srcPriceNum) {
+			return insertAt(dst, i, src)
+		}
+	}
+
+	return append(dst, src)
+}
+
+func insertAt(dst [][]json.Number, id int, pv []json.Number) (result [][]json.Number) {
+	result = append(result, dst[:id]...)
+	result = append(result, pv)
+	result = append(result, dst[id:]...)
+	return
+}
+
+func removePrice(dst [][]json.Number, price json.Number) [][]json.Number {
+	for i, pv := range dst {
+		if pv[0] == price {
+			return append(dst[:i], dst[i+1:]...)
+		}
+	}
+
+	return dst
+}
+
+func (r orderBookResponse) verifyChecksum() error {
+	if crc32Val := crc32.ChecksumIEEE([]byte(checksumString(r.Bids, r.Asks))); crc32Val != r.Checksum {
+		return fmt.Errorf("expected checksum %d, actual checksum %d: %w", r.Checksum, crc32Val, errUnmatchedChecksum)
+	}
+	return nil
+}
+
+// <best_bid_price>:<best_bid_size>:<best_ask_price>:<best_ask_size>...
+func checksumString(bids, asks [][]json.Number) string {
+	sb := strings.Builder{}
+	appendNumber := func(pv []json.Number) {
+		if sb.Len() != 0 {
+			sb.WriteString(":")
+		}
+		sb.WriteString(string(pv[0]))
+		sb.WriteString(":")
+		sb.WriteString(string(pv[1]))
+	}
+
+	bidsLen := len(bids)
+	asksLen := len(asks)
+	for i := 0; i < bidsLen || i < asksLen; i++ {
+		if i < bidsLen {
+			appendNumber(bids[i])
+		}
+		if i < asksLen {
+			appendNumber(asks[i])
+		}
+	}
+	return sb.String()
+}
+
+var errUnmatchedChecksum = fmt.Errorf("unmatched checksum")
+
+func toGlobalOrderBook(r orderBookResponse) (types.OrderBook, error) {
 	bids, err := toPriceVolumeSlice(r.Bids)
 	if err != nil {
 		return types.OrderBook{}, fmt.Errorf("can't convert bids to priceVolumeSlice: %w", err)


### PR DESCRIPTION
Verify the orderbook snapshot checksum. However there's a bug of order update checksum. I'm not sure if I have to maintain the whole orderbook or just verify the update message. But it's not an important issue. Let's do that next time.