### PR TITLE
Remove --config argument in balances command

### DIFF
--- a/pkg/cmd/balances.go
+++ b/pkg/cmd/balances.go
@@ -43,9 +43,6 @@ var balancesCmd = &cobra.Command{
 		}
 
 		environ := bbgo.NewEnvironment()
-		if err := environ.ConfigureDatabase(ctx); err != nil {
-			return err
-		}
 
 		if err := environ.ConfigureExchangeSessions(userConfig); err != nil {
 			return err

--- a/pkg/cmd/balances.go
+++ b/pkg/cmd/balances.go
@@ -33,12 +33,20 @@ var balancesCmd = &cobra.Command{
 			return errors.New("--config option is required")
 		}
 
-		if _, err := os.Stat(configFile); os.IsNotExist(err) {
-			return err
-		}
-
-		userConfig, err := bbgo.Load(configFile, false)
-		if err != nil {
+		// if config file exists, use the config loaded from the config file.
+		// otherwise, use a empty config object
+		var userConfig *bbgo.Config
+		if _, err := os.Stat(configFile); err == nil {
+			// load successfully
+			userConfig, err = bbgo.Load(configFile, false)
+			if err != nil {
+				return err
+			}
+		} else if os.IsNotExist(err) {
+			// config file doesn't exist
+			userConfig = &bbgo.Config{}
+		} else {
+			// other error
 			return err
 		}
 


### PR DESCRIPTION
The current `balances` command needs to be executed with the `--config <config_file>`, but the config file is NOT needed to create the session. So I delete the code which reads the config file. In this way, you can get the balance by running `bbgo balances --session=max`.