### PR TITLE
feature: query closed orders

### DIFF
--- a/pkg/exchange/ftx/exchange_test.go
+++ b/pkg/exchange/ftx/exchange_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -58,4 +59,224 @@ func TestExchange_QueryAccountBalances(t *testing.T) {
 	resp, err = ex.QueryAccountBalances(context.Background())
 	assert.EqualError(t, err, "ftx returns querying balances failure")
 	assert.Nil(t, resp)
+}
+
+func TestExchange_QueryOpenOrders(t *testing.T) {
+	successResp := `
+{
+  "success": true,
+  "result": [
+    {
+      "createdAt": "2019-03-05T09:56:55.728933+00:00",
+      "filledSize": 10,
+      "future": "XRP-PERP",
+      "id": 9596912,
+      "market": "XRP-PERP",
+      "price": 0.306525,
+      "avgFillPrice": 0.306526,
+      "remainingSize": 31421,
+      "side": "sell",
+      "size": 31431,
+      "status": "open",
+      "type": "limit",
+      "reduceOnly": false,
+      "ioc": false,
+      "postOnly": false,
+      "clientId": null
+    }
+  ]
+}
+`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, successResp)
+	}))
+	defer ts.Close()
+
+	ex := NewExchange("", "", "")
+	serverURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	ex.restEndpoint = serverURL
+	resp, err := ex.QueryOpenOrders(context.Background(), "XRP-PREP")
+	assert.NoError(t, err)
+	assert.Len(t, resp, 1)
+	assert.Equal(t, "XRP-PERP", resp[0].Symbol)
+}
+
+func TestExchange_QueryClosedOrders(t *testing.T) {
+	t.Run("no closed orders", func(t *testing.T) {
+		successResp := `{"success": true, "result": []}`
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, successResp)
+		}))
+		defer ts.Close()
+
+		ex := NewExchange("", "", "")
+		serverURL, err := url.Parse(ts.URL)
+		assert.NoError(t, err)
+		ex.restEndpoint = serverURL
+		resp, err := ex.QueryClosedOrders(context.Background(), "BTC-PERP", time.Time{}, time.Time{}, 100)
+		assert.NoError(t, err)
+
+		assert.Len(t, resp, 0)
+	})
+	t.Run("one closed order", func(t *testing.T) {
+		successResp := `
+{
+  "success": true,
+  "result": [
+    {
+      "avgFillPrice": 10135.25,
+      "clientId": null,
+      "createdAt": "2019-06-27T15:24:03.101197+00:00",
+      "filledSize": 0.001,
+      "future": "BTC-PERP",
+      "id": 257132591,
+      "ioc": false,
+      "market": "BTC-PERP",
+      "postOnly": false,
+      "price": 10135.25,
+      "reduceOnly": false,
+      "remainingSize": 0.0,
+      "side": "buy",
+      "size": 0.001,
+      "status": "closed",
+      "type": "limit"
+    }
+  ],
+  "hasMoreData": false
+}
+`
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, successResp)
+		}))
+		defer ts.Close()
+
+		ex := NewExchange("", "", "")
+		serverURL, err := url.Parse(ts.URL)
+		assert.NoError(t, err)
+		ex.restEndpoint = serverURL
+		resp, err := ex.QueryClosedOrders(context.Background(), "BTC-PERP", time.Time{}, time.Time{}, 100)
+		assert.NoError(t, err)
+		assert.Len(t, resp, 1)
+		assert.Equal(t, "BTC-PERP", resp[0].Symbol)
+	})
+
+	t.Run("sort the order", func(t *testing.T) {
+		successResp := `
+{
+  "success": true,
+  "result": [
+    {
+			"status": "closed",
+      "createdAt": "2020-09-01T15:24:03.101197+00:00",
+      "id": 789
+    },
+    {
+			"status": "closed",
+      "createdAt": "2019-03-27T15:24:03.101197+00:00",
+      "id": 123
+    },
+    {
+			"status": "closed",
+      "createdAt": "2019-06-27T15:24:03.101197+00:00",
+      "id": 456
+    },
+    {
+			"status": "new",
+      "createdAt": "2019-06-27T15:24:03.101197+00:00",
+      "id": 999
+    }
+  ],
+  "hasMoreData": false
+}
+`
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, successResp)
+		}))
+		defer ts.Close()
+
+		ex := NewExchange("", "", "")
+		serverURL, err := url.Parse(ts.URL)
+		assert.NoError(t, err)
+		ex.restEndpoint = serverURL
+		resp, err := ex.QueryClosedOrders(context.Background(), "BTC-PERP", time.Time{}, time.Time{}, 100)
+		assert.NoError(t, err)
+		assert.Len(t, resp, 3)
+
+		expectedOrderID := []uint64{123, 456, 789}
+		for i, o := range resp {
+			assert.Equal(t, expectedOrderID[i], o.OrderID)
+		}
+	})
+
+	t.Run("receive duplicated orders", func(t *testing.T) {
+		successRespOne := `
+{
+  "success": true,
+  "result": [
+    {
+			"status": "closed",
+      "createdAt": "2020-09-01T15:24:03.101197+00:00",
+      "id": 123
+    }
+  ],
+  "hasMoreData": true
+}
+`
+
+		successRespTwo := `
+{
+  "success": true,
+  "result": [
+    {
+			"clientId": "ignored-by-created-at",
+			"status": "closed",
+      "createdAt": "1999-09-01T15:24:03.101197+00:00",
+      "id": 999
+    },
+    {
+			"clientId": "ignored-by-duplicated-id",
+			"status": "closed",
+      "createdAt": "2020-09-02T15:24:03.101197+00:00",
+      "id": 123
+    },
+    {
+			"clientId": "ignored-duplicated-entry",
+			"status": "closed",
+      "createdAt": "2020-09-01T15:24:03.101197+00:00",
+      "id": 123
+    },
+    {
+			"status": "closed",
+      "createdAt": "2020-09-02T15:24:03.101197+00:00",
+      "id": 456
+    }
+  ],
+  "hasMoreData": false
+}
+`
+		i := 0
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if i == 0 {
+				i++
+				fmt.Fprintln(w, successRespOne)
+				return
+			}
+			fmt.Fprintln(w, successRespTwo)
+		}))
+		defer ts.Close()
+
+		ex := NewExchange("", "", "")
+		serverURL, err := url.Parse(ts.URL)
+		assert.NoError(t, err)
+		ex.restEndpoint = serverURL
+		resp, err := ex.QueryClosedOrders(context.Background(), "BTC-PERP", time.Time{}, time.Time{}, 100)
+		assert.NoError(t, err)
+		assert.Len(t, resp, 2)
+		expectedOrderID := []uint64{123, 456}
+		for i, o := range resp {
+			assert.Equal(t, expectedOrderID[i], o.OrderID)
+		}
+	})
 }

--- a/pkg/exchange/ftx/rest_order_request.go
+++ b/pkg/exchange/ftx/rest_order_request.go
@@ -117,11 +117,14 @@ func (r *orderRequest) OpenOrders(ctx context.Context, market string) (ordersRes
 }
 
 func (r *orderRequest) OrdersHistory(ctx context.Context, market string, start, end time.Time, limit int) (ordersHistoryResponse, error) {
-	p := map[string]interface{}{
-		"market": market,
-		"limit":  limit,
-	}
+	p := make(map[string]interface{})
 
+	if limit > 0 {
+		p["limit"] = limit
+	}
+	if len(market) > 0 {
+		p["market"] = market
+	}
 	if start != (time.Time{}) {
 		p["start_time"] = start.UnixNano() / int64(time.Second)
 	}

--- a/pkg/exchange/ftx/rest_order_request.go
+++ b/pkg/exchange/ftx/rest_order_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 type orderRequest struct {
@@ -110,6 +111,37 @@ func (r *orderRequest) OpenOrders(ctx context.Context, market string) (ordersRes
 	var o ordersResponse
 	if err := json.Unmarshal(resp.Body, &o); err != nil {
 		return ordersResponse{}, fmt.Errorf("failed to unmarshal open orders response body to json: %w", err)
+	}
+
+	return o, nil
+}
+
+func (r *orderRequest) OrdersHistory(ctx context.Context, market string, start, end time.Time, limit int) (ordersHistoryResponse, error) {
+	p := map[string]interface{}{
+		"market": market,
+		"limit":  limit,
+	}
+
+	if start != (time.Time{}) {
+		p["start_time"] = start.UnixNano() / int64(time.Second)
+	}
+	if end != (time.Time{}) {
+		p["end_time"] = start.UnixNano() / int64(time.Second)
+	}
+
+	resp, err := r.
+		Method("GET").
+		ReferenceURL("api/orders/history").
+		Payloads(p).
+		DoAuthenticatedRequest(ctx)
+
+	if err != nil {
+		return ordersHistoryResponse{}, err
+	}
+
+	var o ordersHistoryResponse
+	if err := json.Unmarshal(resp.Body, &o); err != nil {
+		return ordersHistoryResponse{}, fmt.Errorf("failed to unmarshal orders history response body to json: %w", err)
 	}
 
 	return o, nil

--- a/pkg/exchange/ftx/rest_responses.go
+++ b/pkg/exchange/ftx/rest_responses.go
@@ -12,6 +12,12 @@ type balances struct {
 	} `json:"result"`
 }
 
+type ordersHistoryResponse struct {
+	Success     bool    `json:"success"`
+	Result      []order `json:"result"`
+	HasMoreData bool    `json:"hasMoreData"`
+}
+
 type ordersResponse struct {
 	Success bool `json:"success"`
 


### PR DESCRIPTION
The time range precision is second, so I will always -1 second to query next page data. I dedupe by created-at and order ID. Note that if the order status is not `closed`, I will skip the order. Please help me to ensure the logic. Thanks.