### PR TITLE
refactor: use fixedpoint to store fee

### DIFF
--- a/pkg/backtest/matching.go
+++ b/pkg/backtest/matching.go
@@ -47,8 +47,8 @@ type SimplePriceMatching struct {
 
 	Account *types.Account
 
-	MakerCommission float64 `json:"makerCommission"`
-	TakerCommission float64 `json:"takerCommission"`
+	MakerCommission fixedpoint.Value `json:"makerCommission"`
+	TakerCommission fixedpoint.Value `json:"takerCommission"`
 
 	tradeUpdateCallbacks   []func(trade types.Trade)
 	orderUpdateCallbacks   []func(order types.Order)
@@ -205,9 +205,9 @@ func (m *SimplePriceMatching) newTradeFromOrder(order types.Order, isMaker bool)
 	// MAX uses 0.050% for maker and 0.15% for taker
 	var commission = DefaultFeeRate
 	if isMaker && m.Account.MakerCommission > 0 {
-		commission = 0.0001 * m.Account.MakerCommission // binance uses 10~15
+		commission = fixedpoint.NewFromFloat(0.0001).Mul(m.Account.MakerCommission).Float64() // binance uses 10~15
 	} else if m.Account.TakerCommission > 0 {
-		commission = 0.0001 * m.Account.TakerCommission // binance uses 10~15
+		commission = fixedpoint.NewFromFloat(0.0001).Mul(m.Account.TakerCommission).Float64() // binance uses 10~15
 	}
 
 	var fee float64

--- a/pkg/bbgo/config.go
+++ b/pkg/bbgo/config.go
@@ -113,8 +113,8 @@ func (t Backtest) ParseStartTime() (time.Time, error) {
 }
 
 type BacktestAccount struct {
-	MakerCommission  float64                   `json:"makerCommission"`
-	TakerCommission  float64                   `json:"takerCommission"`
+	MakerCommission  fixedpoint.Value          `json:"makerCommission"`
+	TakerCommission  fixedpoint.Value          `json:"takerCommission"`
 	BuyerCommission  int                       `json:"buyerCommission"`
 	SellerCommission int                       `json:"sellerCommission"`
 	Balances         BacktestAccountBalanceMap `json:"balances" yaml:"balances"`

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -378,8 +378,8 @@ func (e *Exchange) QueryAccount(ctx context.Context) (*types.Account, error) {
 	}
 
 	a := &types.Account{
-		MakerCommission: float64(account.MakerCommission),
-		TakerCommission: float64(account.TakerCommission),
+		MakerCommission: fixedpoint.NewFromInt64(account.MakerCommission),
+		TakerCommission: fixedpoint.NewFromInt64(account.TakerCommission),
 	}
 	a.UpdateBalances(balances)
 	return a, nil

--- a/pkg/exchange/ftx/exchange.go
+++ b/pkg/exchange/ftx/exchange.go
@@ -75,8 +75,8 @@ func (e *Exchange) QueryAccount(ctx context.Context) (*types.Account, error) {
 
 	bps := fixedpoint.NewFromFloat(10000)
 	a := &types.Account{
-		MakerCommission: fixedpoint.NewFromFloat(resp.Result.MakerFee).Mul(bps).Float64(),
-		TakerCommission: fixedpoint.NewFromFloat(resp.Result.TakerFee).Mul(bps).Float64(),
+		MakerCommission: fixedpoint.NewFromFloat(resp.Result.MakerFee).Mul(bps),
+		TakerCommission: fixedpoint.NewFromFloat(resp.Result.TakerFee).Mul(bps),
 	}
 
 	balances, err := e.QueryAccountBalances(ctx)

--- a/pkg/exchange/ftx/exchange_test.go
+++ b/pkg/exchange/ftx/exchange_test.go
@@ -365,6 +365,6 @@ func TestExchange_QueryAccount(t *testing.T) {
 	expected.Locked = expected.Locked.Sub(expected.Available)
 	assert.Equal(t, expected, b)
 
-	assert.Equal(t, 0.0002*10000, resp.MakerCommission)
-	assert.Equal(t, 0.0005*10000, resp.TakerCommission)
+	assert.Equal(t, fixedpoint.NewFromFloat(0.0002).Mul(fixedpoint.NewFromInt64(10000)), resp.MakerCommission)
+	assert.Equal(t, fixedpoint.NewFromFloat(0.0005).Mul(fixedpoint.NewFromInt64(10000)), resp.TakerCommission)
 }

--- a/pkg/types/account.go
+++ b/pkg/types/account.go
@@ -103,9 +103,9 @@ type Account struct {
 	sync.Mutex `json:"-"`
 
 	// bps. 0.15% fee will be 15.
-	MakerCommission float64 `json:"makerCommission,omitempty"`
-	TakerCommission float64 `json:"takerCommission,omitempty"`
-	AccountType     string  `json:"accountType,omitempty"`
+	MakerCommission fixedpoint.Value `json:"makerCommission,omitempty"`
+	TakerCommission fixedpoint.Value `json:"takerCommission,omitempty"`
+	AccountType     string           `json:"accountType,omitempty"`
 
 	balances BalanceMap
 }


### PR DESCRIPTION
The fractional part of FTX fee is 8 digits, so it's better to store and calculate by fixedpoint.