### PR TITLE
REFACTOR: remove bps from the fee calc #1

### DIFF
--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -377,9 +377,10 @@ func (e *Exchange) QueryAccount(ctx context.Context) (*types.Account, error) {
 		}
 	}
 
+	// binance use 15 -> 0.15%, so we convert it to 0.0015
 	a := &types.Account{
-		MakerCommission: fixedpoint.NewFromInt64(account.MakerCommission),
-		TakerCommission: fixedpoint.NewFromInt64(account.TakerCommission),
+		MakerCommission: fixedpoint.NewFromFloat(float64(account.MakerCommission) * 0.0001),
+		TakerCommission: fixedpoint.NewFromFloat(float64(account.TakerCommission) * 0.0001),
 	}
 	a.UpdateBalances(balances)
 	return a, nil

--- a/pkg/exchange/ftx/exchange.go
+++ b/pkg/exchange/ftx/exchange.go
@@ -73,10 +73,9 @@ func (e *Exchange) QueryAccount(ctx context.Context) (*types.Account, error) {
 		return nil, fmt.Errorf("ftx returns querying balances failure")
 	}
 
-	bps := fixedpoint.NewFromFloat(10000)
 	a := &types.Account{
-		MakerCommission: fixedpoint.NewFromFloat(resp.Result.MakerFee).Mul(bps),
-		TakerCommission: fixedpoint.NewFromFloat(resp.Result.TakerFee).Mul(bps),
+		MakerCommission: fixedpoint.NewFromFloat(resp.Result.MakerFee),
+		TakerCommission: fixedpoint.NewFromFloat(resp.Result.TakerFee),
 	}
 
 	balances, err := e.QueryAccountBalances(ctx)

--- a/pkg/exchange/ftx/exchange_test.go
+++ b/pkg/exchange/ftx/exchange_test.go
@@ -365,6 +365,6 @@ func TestExchange_QueryAccount(t *testing.T) {
 	expected.Locked = expected.Locked.Sub(expected.Available)
 	assert.Equal(t, expected, b)
 
-	assert.Equal(t, fixedpoint.NewFromFloat(0.0002).Mul(fixedpoint.NewFromInt64(10000)), resp.MakerCommission)
-	assert.Equal(t, fixedpoint.NewFromFloat(0.0005).Mul(fixedpoint.NewFromInt64(10000)), resp.TakerCommission)
+	assert.Equal(t, fixedpoint.NewFromFloat(0.0002), resp.MakerCommission)
+	assert.Equal(t, fixedpoint.NewFromFloat(0.0005), resp.TakerCommission)
 }

--- a/pkg/exchange/max/exchange.go
+++ b/pkg/exchange/max/exchange.go
@@ -415,8 +415,8 @@ func (e *Exchange) QueryAccount(ctx context.Context) (*types.Account, error) {
 	//  "maker_fee": 0.0005 -> 0.05%
 	//  "taker_fee": 0.0015 -> 0.15%
 	a := &types.Account{
-		MakerCommission: fixedpoint.NewFromFloat(vipLevel.Current.MakerFee * 10000.0), // 0.15% = 0.0015, 0.0015 * 10000 = 15
-		TakerCommission: fixedpoint.NewFromFloat(vipLevel.Current.TakerFee * 10000.0), // 0.15% = 0.0015, 0.0015 * 10000 = 15
+		MakerCommission: fixedpoint.NewFromFloat(vipLevel.Current.MakerFee), // 0.15% = 0.0015
+		TakerCommission: fixedpoint.NewFromFloat(vipLevel.Current.TakerFee), // 0.15% = 0.0015
 	}
 
 	a.UpdateBalances(balances)


### PR DESCRIPTION
this could make the fee calculation easier, we will just present the precentage.