### PR TITLE
fix:add missing query string

### DIFF
--- a/pkg/cmd/deposit.go
+++ b/pkg/cmd/deposit.go
@@ -89,6 +89,7 @@ var depositsCmd = &cobra.Command{
 			return err
 		}
 
+		log.Infof("%d histories", len(histories))
 		for _, h := range histories {
 			log.Infof("deposit history: %+v", h)
 		}

--- a/pkg/cmd/orders.go
+++ b/pkg/cmd/orders.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -24,13 +25,46 @@ var listOrdersCmd = &cobra.Command{
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
-		session, err := cmd.Flags().GetString("session")
-		if err != nil {
-			return fmt.Errorf("can't get session from flags: %w", err)
-		}
-		ex, err := newExchange(session)
+
+		configFile, err := cmd.Flags().GetString("config")
 		if err != nil {
 			return err
+		}
+
+		if len(configFile) == 0 {
+			return fmt.Errorf("--config option is required")
+		}
+
+		// if config file exists, use the config loaded from the config file.
+		// otherwise, use a empty config object
+		var userConfig *bbgo.Config
+		if _, err := os.Stat(configFile); err == nil {
+			// load successfully
+			userConfig, err = bbgo.Load(configFile, false)
+			if err != nil {
+				return err
+			}
+		} else if os.IsNotExist(err) {
+			// config file doesn't exist
+			userConfig = &bbgo.Config{}
+		} else {
+			// other error
+			return err
+		}
+		environ := bbgo.NewEnvironment()
+
+		if err := environ.ConfigureExchangeSessions(userConfig); err != nil {
+			return err
+		}
+
+		sessionName, err := cmd.Flags().GetString("session")
+		if err != nil {
+			return err
+		}
+
+		session, ok := environ.Session(sessionName)
+		if !ok {
+			return fmt.Errorf("session %s not found", sessionName)
 		}
 		symbol, err := cmd.Flags().GetString("symbol")
 		if err != nil {
@@ -48,12 +82,15 @@ var listOrdersCmd = &cobra.Command{
 		var os []types.Order
 		switch status {
 		case "open":
-			os, err = ex.QueryOpenOrders(ctx, symbol)
+			os, err = session.Exchange.QueryOpenOrders(ctx, symbol)
 			if err != nil {
 				return err
 			}
 		case "closed":
-			panic("not implemented")
+			os, err = session.Exchange.QueryClosedOrders(ctx, symbol, time.Now().Add(-3*24*time.Hour), time.Now(), 0)
+			if err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("invalid status %s", status)
 		}

--- a/pkg/exchange/ftx/rest_order_request.go
+++ b/pkg/exchange/ftx/rest_order_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -101,7 +102,7 @@ func (r *orderRequest) OpenOrders(ctx context.Context, market string) (ordersRes
 	resp, err := r.
 		Method("GET").
 		ReferenceURL("api/orders").
-		Payloads(map[string]interface{}{"market": market}).
+		Query(map[string]string{"market": market}).
 		DoAuthenticatedRequest(ctx)
 
 	if err != nil {
@@ -116,26 +117,26 @@ func (r *orderRequest) OpenOrders(ctx context.Context, market string) (ordersRes
 	return o, nil
 }
 
-func (r *orderRequest) OrdersHistory(ctx context.Context, market string, start, end time.Time, limit int) (ordersHistoryResponse, error) {
-	p := make(map[string]interface{})
+func (r *orderRequest) OrdersHistory(ctx context.Context, market string, start, end time.Time, limit int64) (ordersHistoryResponse, error) {
+	q := make(map[string]string)
 
 	if limit > 0 {
-		p["limit"] = limit
+		q["limit"] = strconv.FormatInt(limit, 10)
 	}
 	if len(market) > 0 {
-		p["market"] = market
+		q["market"] = market
 	}
 	if start != (time.Time{}) {
-		p["start_time"] = start.UnixNano() / int64(time.Second)
+		q["start_time"] = strconv.FormatInt(start.Unix(), 10)
 	}
 	if end != (time.Time{}) {
-		p["end_time"] = start.UnixNano() / int64(time.Second)
+		q["end_time"] = strconv.FormatInt(end.Unix(), 10)
 	}
 
 	resp, err := r.
 		Method("GET").
 		ReferenceURL("api/orders/history").
-		Payloads(p).
+		Query(q).
 		DoAuthenticatedRequest(ctx)
 
 	if err != nil {

--- a/pkg/exchange/ftx/rest_wallet_request.go
+++ b/pkg/exchange/ftx/rest_wallet_request.go
@@ -4,16 +4,31 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"time"
 )
 
 type walletRequest struct {
 	*restRequest
 }
 
-func (r *walletRequest) DepositHistory(ctx context.Context) (depositHistoryResponse, error) {
+func (r *walletRequest) DepositHistory(ctx context.Context, since time.Time, until time.Time, limit int) (depositHistoryResponse, error) {
+	q := make(map[string]string)
+	if limit > 0 {
+		q["limit"] = strconv.Itoa(limit)
+	}
+
+	if since != (time.Time{}) {
+		q["start_time"] = strconv.FormatInt(since.Unix(), 10)
+	}
+	if until != (time.Time{}) {
+		q["end_time"] = strconv.FormatInt(until.Unix(), 10)
+	}
+
 	resp, err := r.
 		Method("GET").
 		ReferenceURL("api/wallet/deposits").
+		Query(q).
 		DoAuthenticatedRequest(ctx)
 
 	if err != nil {


### PR DESCRIPTION
I forgot to assign query string, so I use default values of all GET operations.

Note that I also support the `lastOrderID` in the `QueryClosedOrders`. Please check the logic again thanks.