### PR TITLE
binance: set TimeInForce to GTC by default

### DIFF
--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -538,6 +538,11 @@ func (e *Exchange) submitMarginOrder(ctx context.Context, order types.SubmitOrde
 	if len(order.TimeInForce) > 0 {
 		// TODO: check the TimeInForce value
 		req.TimeInForce(binance.TimeInForceType(order.TimeInForce))
+	} else {
+		switch order.Type {
+		case types.OrderTypeLimit, types.OrderTypeStopLimit:
+			req.TimeInForce(binance.TimeInForceTypeGTC)
+		}
 	}
 
 	response, err := req.Do(ctx)
@@ -614,6 +619,11 @@ func (e *Exchange) submitSpotOrder(ctx context.Context, order types.SubmitOrder)
 	if len(order.TimeInForce) > 0 {
 		// TODO: check the TimeInForce value
 		req.TimeInForce(binance.TimeInForceType(order.TimeInForce))
+	} else {
+		switch order.Type {
+		case types.OrderTypeLimit, types.OrderTypeStopLimit:
+			req.TimeInForce(binance.TimeInForceTypeGTC)
+		}
 	}
 
 	response, err := req.Do(ctx)


### PR DESCRIPTION
Binance does not allow submitting order without TimeInForce set for
certain order types. Set TimeInforce to GTC (Good-Til-Cancel) by
default.