### PR TITLE
Track created orders when error occurs

### DIFF
--- a/pkg/strategy/bollgrid/strategy.go
+++ b/pkg/strategy/bollgrid/strategy.go
@@ -350,7 +350,7 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 		}
 	})
 
-	session.Stream.OnConnect(func() {
+	session.Stream.OnStart(func() {
 		log.Infof("connected, submitting the first round of the orders")
 		s.updateOrders(orderExecutor, session)
 	})

--- a/pkg/strategy/bollgrid/strategy.go
+++ b/pkg/strategy/bollgrid/strategy.go
@@ -248,12 +248,12 @@ func (s *Strategy) placeGridOrders(orderExecutor bbgo.OrderExecutor, session *bb
 	orders := append(sellOrders, buyOrders...)
 
 	createdOrders, err := orderExecutor.SubmitOrders(context.Background(), orders...)
-	if err != nil {
-		log.WithError(err).Errorf("can not place orders")
-		return
-	}
 	s.activeOrders.Add(createdOrders...)
 	s.orders.Add(createdOrders...)
+
+	if err != nil {
+		log.WithError(err).Errorf("can not place orders")
+	}
 }
 
 func (s *Strategy) updateOrders(orderExecutor bbgo.OrderExecutor, session *bbgo.ExchangeSession) {

--- a/pkg/strategy/bollgrid/strategy.go
+++ b/pkg/strategy/bollgrid/strategy.go
@@ -240,20 +240,23 @@ func (s *Strategy) placeGridOrders(orderExecutor bbgo.OrderExecutor, session *bb
 	if err != nil {
 		log.Warn(err.Error())
 	}
+	createdSellOrders, err := orderExecutor.SubmitOrders(context.Background(), sellOrders...)
+	if err != nil {
+		log.WithError(err).Errorf("can not place sell orders")
+	}
+
 	buyOrders, err := s.generateGridBuyOrders(session)
 	if err != nil {
 		log.Warn(err.Error())
 	}
+	createdBuyOrders, err := orderExecutor.SubmitOrders(context.Background(), buyOrders...)
+	if err != nil {
+		log.WithError(err).Errorf("can not place buy orders")
+	}
 
-	orders := append(sellOrders, buyOrders...)
-
-	createdOrders, err := orderExecutor.SubmitOrders(context.Background(), orders...)
+	createdOrders := append(createdSellOrders, createdBuyOrders...)
 	s.activeOrders.Add(createdOrders...)
 	s.orders.Add(createdOrders...)
-
-	if err != nil {
-		log.WithError(err).Errorf("can not place orders")
-	}
 }
 
 func (s *Strategy) updateOrders(orderExecutor bbgo.OrderExecutor, session *bbgo.ExchangeSession) {


### PR DESCRIPTION
當 `orderExecutor.SubmitOrders(orders...)` 發生錯誤時，其中有一些 order 可能還是被成功送出了，所以前兩個 commit 把 grid 跟 bollgrid 裡面的 `createdOrders` 都加入追蹤

而第三個 commit 是把 bollgrid 裡面送出 sell orders 跟 buy orders 的部分分開，因為如果把 `[sellOrders..., buyOrders...]` 一起送出，當 sellOrders 裡面有任何一筆送出失敗了（可能訂單金額太小、餘額不足等等），那 buyOrders 就完全不會被送出去。但如果 sellOrders 是因為餘額不足而送出失敗，那 buyOrders 其實還是可以正常送出，所以這邊把他們分開送