### PR TITLE
migration: extend symbol column length to 10

### DIFF
--- a/migrations/mysql/20210416230730_klines_symbol_length.sql
+++ b/migrations/mysql/20210416230730_klines_symbol_length.sql
@@ -1,0 +1,25 @@
+-- +up
+ALTER TABLE `klines`
+MODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;
+
+ALTER TABLE `okex_klines`
+MODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;
+
+ALTER TABLE `binance_klines`
+MODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;
+
+ALTER TABLE `max_klines`
+MODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;
+
+-- +down
+ALTER TABLE `klines`
+MODIFY COLUMN `symbol` VARCHAR(7) NOT NULL;
+
+ALTER TABLE `okex_klines`
+MODIFY COLUMN `symbol` VARCHAR(7) NOT NULL;
+
+ALTER TABLE `binance_klines`
+MODIFY COLUMN `symbol` VARCHAR(7) NOT NULL;
+
+ALTER TABLE `max_klines`
+MODIFY COLUMN `symbol` VARCHAR(7) NOT NULL;


### PR DESCRIPTION
Originally the length of symbol column in MySQL is 7 (VARCHAR(7)). However, we have the SANDUSDT and LINKUSDT trading pairs, which is longer than 7 characters.