### PR TITLE
Extend volume and symbol size for DOGEUSDT in binance

### DIFF
--- a/migrations/mysql/20210421091430_increase_symbol_length.sql
+++ b/migrations/mysql/20210421091430_increase_symbol_length.sql
@@ -1,0 +1,25 @@
+-- +up
+ALTER TABLE `klines`
+MODIFY COLUMN `symbol` VARCHAR(12) NOT NULL;
+
+ALTER TABLE `okex_klines`
+MODIFY COLUMN `symbol` VARCHAR(12) NOT NULL;
+
+ALTER TABLE `binance_klines`
+MODIFY COLUMN `symbol` VARCHAR(12) NOT NULL;
+
+ALTER TABLE `max_klines`
+MODIFY COLUMN `symbol` VARCHAR(12) NOT NULL;
+
+-- +down
+ALTER TABLE `klines`
+MODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;
+
+ALTER TABLE `okex_klines`
+MODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;
+
+ALTER TABLE `binance_klines`
+MODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;
+
+ALTER TABLE `max_klines`
+MODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;

--- a/migrations/mysql/20210421095030_increase_decimal_length.sql
+++ b/migrations/mysql/20210421095030_increase_decimal_length.sql
@@ -1,0 +1,25 @@
+-- +up
+ALTER TABLE `klines`
+MODIFY COLUMN `volume` decimal(20,8) unsigned NOT NULL DEFAULT '0.00000000';
+
+ALTER TABLE `okex_klines`
+MODIFY COLUMN `volume` decimal(20,8) unsigned NOT NULL DEFAULT '0.00000000';
+
+ALTER TABLE `binance_klines`
+MODIFY COLUMN `volume` decimal(20,8) unsigned NOT NULL DEFAULT '0.00000000';
+
+ALTER TABLE `max_klines`
+MODIFY COLUMN `volume` decimal(20,8) unsigned NOT NULL DEFAULT '0.00000000';
+
+-- +down
+ALTER TABLE `klines`
+MODIFY COLUMN `volume` decimal(16,8) unsigned NOT NULL DEFAULT '0.00000000';
+
+ALTER TABLE `okex_klines`
+MODIFY COLUMN `volume` decimal(16,8) unsigned NOT NULL DEFAULT '0.00000000';
+
+ALTER TABLE `binance_klines`
+MODIFY COLUMN `volume` decimal(16,8) unsigned NOT NULL DEFAULT '0.00000000';
+
+ALTER TABLE `max_klines`
+MODIFY COLUMN `volume` decimal(16,8) unsigned NOT NULL DEFAULT '0.00000000';

--- a/pkg/migrations/mysql/20210416230730_klines_symbol_length.go
+++ b/pkg/migrations/mysql/20210416230730_klines_symbol_length.go
@@ -1,0 +1,64 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/c9s/rockhopper"
+)
+
+func init() {
+	AddMigration(upKlinesSymbolLength, downKlinesSymbolLength)
+
+}
+
+func upKlinesSymbolLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is applied.
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `klines`\nMODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `okex_klines`\nMODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `binance_klines`\nMODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `max_klines`\nMODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func downKlinesSymbolLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is rolled back.
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `klines`\nMODIFY COLUMN `symbol` VARCHAR(7) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `okex_klines`\nMODIFY COLUMN `symbol` VARCHAR(7) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `binance_klines`\nMODIFY COLUMN `symbol` VARCHAR(7) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `max_klines`\nMODIFY COLUMN `symbol` VARCHAR(7) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/pkg/migrations/mysql/20210421091430_increase_symbol_length.go
+++ b/pkg/migrations/mysql/20210421091430_increase_symbol_length.go
@@ -1,0 +1,64 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/c9s/rockhopper"
+)
+
+func init() {
+	AddMigration(upIncreaseSymbolLength, downIncreaseSymbolLength)
+
+}
+
+func upIncreaseSymbolLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is applied.
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `klines`\nMODIFY COLUMN `symbol` VARCHAR(12) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `okex_klines`\nMODIFY COLUMN `symbol` VARCHAR(12) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `binance_klines`\nMODIFY COLUMN `symbol` VARCHAR(12) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `max_klines`\nMODIFY COLUMN `symbol` VARCHAR(12) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func downIncreaseSymbolLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is rolled back.
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `klines`\nMODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `okex_klines`\nMODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `binance_klines`\nMODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `max_klines`\nMODIFY COLUMN `symbol` VARCHAR(10) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/pkg/migrations/mysql/20210421095030_increase_decimal_length.go
+++ b/pkg/migrations/mysql/20210421095030_increase_decimal_length.go
@@ -1,0 +1,64 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/c9s/rockhopper"
+)
+
+func init() {
+	AddMigration(upIncreaseDecimalLength, downIncreaseDecimalLength)
+
+}
+
+func upIncreaseDecimalLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is applied.
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `klines`\nMODIFY COLUMN `volume` decimal(20,8) unsigned NOT NULL DEFAULT '0.00000000';")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `okex_klines`\nMODIFY COLUMN `volume` decimal(20,8) unsigned NOT NULL DEFAULT '0.00000000';")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `binance_klines`\nMODIFY COLUMN `volume` decimal(20,8) unsigned NOT NULL DEFAULT '0.00000000';")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `max_klines`\nMODIFY COLUMN `volume` decimal(20,8) unsigned NOT NULL DEFAULT '0.00000000';")
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func downIncreaseDecimalLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is rolled back.
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `klines`\nMODIFY COLUMN `volume` decimal(16,8) unsigned NOT NULL DEFAULT '0.00000000';")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `okex_klines`\nMODIFY COLUMN `volume` decimal(16,8) unsigned NOT NULL DEFAULT '0.00000000';")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `binance_klines`\nMODIFY COLUMN `volume` decimal(16,8) unsigned NOT NULL DEFAULT '0.00000000';")
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE `max_klines`\nMODIFY COLUMN `volume` decimal(16,8) unsigned NOT NULL DEFAULT '0.00000000';")
+	if err != nil {
+		return err
+	}
+
+	return err
+}


### PR DESCRIPTION
The volume amount between 4/12 to 4/20 has been increased above the original design of 16 digits. Increase it to 20.

Also symbol length might not be able to hold some new currency pairs like ALICEUSDT or AUCTIONBUSD(11). Increase the length to 12 to be able to hold longer symbol pairs.