### PR TITLE
Fix: Correct the Order FILLED event on binance

### DIFF
--- a/pkg/exchange/binance/parse.go
+++ b/pkg/exchange/binance/parse.go
@@ -106,6 +106,7 @@ func (e *ExecutionReportEvent) Order() (*types.Order, error) {
 	switch e.CurrentExecutionType {
 	case "NEW", "CANCELED", "REJECTED", "EXPIRED":
 	case "REPLACED":
+	case "TRADE": // For Order FILLED status. And the order has been completed.
 	default:
 		return nil, errors.New("execution report type is not for order")
 	}

--- a/pkg/exchange/binance/stream.go
+++ b/pkg/exchange/binance/stream.go
@@ -169,6 +169,17 @@ func NewStream(client *binance.Client) *Stream {
 			}
 
 			stream.EmitTradeUpdate(*trade)
+
+			order, err := e.Order()
+			if err != nil {
+				log.WithError(err).Error("order convert error")
+				return
+			}
+
+			// Update Order with FILLED event
+			if (order.Status == types.OrderStatusFilled) {
+				stream.EmitOrderUpdate(*order)
+			}
 		}
 	})
 


### PR DESCRIPTION
Resolve #229 

The root cause was the order FILLED event did not be triggered. So, the order did not be completed and the grid did not run correctly.

I found some document. I think the FILLED was part of `TRADE` in `execution type`.

> TRADE - Part of the order or all of the order's quantity has filled.

> Order Status: `FILLED`  -> The order has been completed.

ref: https://github.com/binance/binance-spot-api-docs/blob/master/user-data-stream.md
ref: https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#enum-definitions

FILLED with TRADE type
```json
{
  "e": "executionReport",
  "E": 1620827285499,
  "s": "DOGEUSDT",
  "c": "x-NSUYEBKMe6596f86-90cb-4fb3-8ea",
  "S": "BUY",
  "o": "LIMIT",
  "f": "GTC",
  "q": "40.00000000",
  "p": "0.49250000",
  "P": "0.00000000",
  "F": "0.00000000",
  "g": -1,
  "C": "",
  "x": "TRADE",
  "X": "FILLED",
  "r": "NONE",
  "i": 969251111,
  "l": "40.00000000",
  "z": "40.00000000",
  "L": "0.49250000",
  "n": "0.00002222",
  "N": "BNB",
  "T": 1620827285498,
  "t": 204906079,
  "I": 2139290677,
  "w": false,
  "m": true,
  "M": true,
  "O": 1620827206872,
  "Z": "19.70000000",
  "Y": "19.70000000",
  "Q": "0.00000000"
}
```

