### PR TITLE
fix(ftxExchange): setup a symbol mapping table

### DIFF
--- a/pkg/exchange/ftx/convert.go
+++ b/pkg/exchange/ftx/convert.go
@@ -20,6 +20,10 @@ func toGlobalSymbol(original string) string {
 	return strings.ReplaceAll(TrimUpperString(original), "/", "")
 }
 
+func toLocalSymbol(original string) string {
+	return symbolMap[original]
+}
+
 func TrimUpperString(original string) string {
 	return strings.ToUpper(strings.TrimSpace(original))
 }

--- a/pkg/exchange/ftx/exchange.go
+++ b/pkg/exchange/ftx/exchange.go
@@ -301,7 +301,7 @@ func (e *Exchange) SubmitOrders(ctx context.Context, orders ...types.SubmitOrder
 	// TODO: currently only support limit and market order
 	// TODO: support time in force
 	for _, so := range orders {
-		if so.TimeInForce != "GTC" {
+		if so.TimeInForce != "GTC" && so.TimeInForce != "" {
 			return createdOrders, fmt.Errorf("unsupported TimeInForce %s. only support GTC", so.TimeInForce)
 		}
 		or, err := e.newRest().PlaceOrder(ctx, PlaceOrderPayload{

--- a/pkg/exchange/ftx/stream.go
+++ b/pkg/exchange/ftx/stream.go
@@ -109,7 +109,7 @@ func (s *Stream) Subscribe(channel types.Channel, symbol string, _ types.Subscri
 	s.addSubscription(websocketRequest{
 		Operation: subscribe,
 		Channel:   orderBookChannel,
-		Market:    TrimUpperString(symbol),
+		Market:    toLocalSymbol(TrimUpperString(symbol)),
 	})
 }
 

--- a/pkg/exchange/ftx/websocket_messages.go
+++ b/pkg/exchange/ftx/websocket_messages.go
@@ -55,9 +55,10 @@ type websocketRequest struct {
 }
 */
 type loginArgs struct {
-	Key       string `json:"key"`
-	Signature string `json:"sign"`
-	Time      int64  `json:"time"`
+	Key        string `json:"key"`
+	Signature  string `json:"sign"`
+	Time       int64  `json:"time"`
+	SubAccount string `json:"subaccount"`
 }
 
 func newLoginRequest(key, secret string, t time.Time) websocketRequest {
@@ -361,7 +362,7 @@ func toGlobalOrderBook(r orderBookResponse) (types.OrderBook, error) {
 	}
 	return types.OrderBook{
 		// ex. BTC/USDT
-		Symbol: strings.ToUpper(r.Market),
+		Symbol: toGlobalSymbol(strings.ToUpper(r.Market)),
 		Bids:   bids,
 		Asks:   asks,
 	}, nil

--- a/pkg/exchange/ftx/websocket_messages_test.go
+++ b/pkg/exchange/ftx/websocket_messages_test.go
@@ -58,7 +58,7 @@ func Test_orderBookResponse_toGlobalOrderBook(t *testing.T) {
 
 	b, err := toGlobalOrderBook(r)
 	assert.NoError(t, err)
-	assert.Equal(t, "BTC/USDT", b.Symbol)
+	assert.Equal(t, "BTCUSDT", b.Symbol)
 	isValid, err := b.IsValid()
 	assert.True(t, isValid)
 	assert.NoError(t, err)


### PR DESCRIPTION
ftx uses BTC/USDT symbol styles, however bbgo uses the BTCUSDT style
We setup a mapping table in Markets() to make conversion