### PR TITLE
Fix: nil pointer exception in indicator creation, add stoch util func

### DIFF
--- a/pkg/exchange/binance/depthframe.go
+++ b/pkg/exchange/binance/depthframe.go
@@ -164,7 +164,7 @@ func (f *DepthFrame) PushEvent(e DepthEvent) {
 
 		go f.once.Do(func() {
 			if err := f.loadDepthSnapshot(); err != nil {
-				log.WithError(err).Error("%s depth snapshot load failed, resetting..", f.Symbol)
+				log.WithError(err).Errorf("%s depth snapshot load failed, resetting..", f.Symbol)
 				f.emitReset()
 			}
 		})


### PR DESCRIPTION
if not ok, `inc` will be `nil`. Should not use `:=` in this case, otherwise the original `inc` will still be `nil` and returned back.  
add stoch indicator creating function.
also fix the error format when depth is not loaded