### PR TITLE
fix generateGridSellOrders with ProfitSpread for begining

### DIFF
--- a/pkg/strategy/grid/strategy.go
+++ b/pkg/strategy/grid/strategy.go
@@ -206,7 +206,7 @@ func (s *Strategy) generateGridSellOrders(session *bbgo.ExchangeSession) ([]type
 			Type:        types.OrderTypeLimit,
 			Market:      s.Market,
 			Quantity:    quantity.Float64(),
-			Price:       price.Float64(),
+			Price:       price.Float64() + s.ProfitSpread.Float64(),
 			TimeInForce: "GTC",
 			GroupID:     s.groupID,
 		})


### PR DESCRIPTION

if the program launched with tokens, it will sell the token with grid price. but it should take care of ProfitSpread to make sure it's working as epected for adding ProfitSpread  for buying price assumption.




