### PR TITLE
binance: parse OrderTrade event stream & add futures client connection

### DIFF
--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -3,6 +3,7 @@ package binance
 import (
 	"context"
 	"fmt"
+	"github.com/adshao/go-binance/v2/futures"
 	"net/http"
 	"os"
 	"strconv"
@@ -14,7 +15,6 @@ import (
 	"github.com/adshao/go-binance/v2"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
@@ -27,7 +27,6 @@ const BNB = "BNB"
 // 50 per 10 seconds = 5 per second
 var orderLimiter = rate.NewLimiter(5, 5)
 
-
 var log = logrus.WithFields(logrus.Fields{
 	"exchange": "binance",
 })
@@ -35,6 +34,7 @@ var log = logrus.WithFields(logrus.Fields{
 func init() {
 	_ = types.Exchange(&Exchange{})
 	_ = types.MarginExchange(&Exchange{})
+	_ = types.FuturesExchange(&Exchange{})
 
 	// FIXME: this is not effected since dotenv is loaded in the rootCmd, not in the init function
 	if ok, _ := strconv.ParseBool(os.Getenv("DEBUG_BINANCE_STREAM")); ok {
@@ -46,20 +46,38 @@ type Exchange struct {
 	types.MarginSettings
 	types.FuturesSettings
 
-	key, secret string
-	Client      *binance.Client
+	key, secret   string
+	Client        *binance.Client // Spot & Margin
+	futuresClient *futures.Client // USDT-M Futures
+	// deliveryClient	*delivery.Client // Coin-M Futures
 }
 
 func New(key, secret string) *Exchange {
 	var client = binance.NewClient(key, secret)
 	client.HTTPClient = &http.Client{Timeout: 15 * time.Second}
-
 	_, _ = client.NewSetServerTimeService().Do(context.Background())
-	return &Exchange{
-		key:    key,
-		secret: secret,
 
-		Client: client,
+	var futuresClient = binance.NewFuturesClient(key, secret)
+	futuresClient.HTTPClient = &http.Client{Timeout: 15 * time.Second}
+	_, _ = futuresClient.NewSetServerTimeService().Do(context.Background())
+
+	var err error
+	_, err = client.NewSetServerTimeService().Do(context.Background())
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = futuresClient.NewSetServerTimeService().Do(context.Background())
+	if err != nil {
+		panic(err)
+	}
+
+	return &Exchange{
+		key:           key,
+		secret:        secret,
+		Client:        client,
+		futuresClient: futuresClient,
+		// deliveryClient: deliveryClient,
 	}
 }
 
@@ -152,8 +170,9 @@ func (e *Exchange) QueryAveragePrice(ctx context.Context, symbol string) (float6
 }
 
 func (e *Exchange) NewStream() types.Stream {
-	stream := NewStream(e.Client)
+	stream := NewStream(e.Client, e.futuresClient)
 	stream.MarginSettings = e.MarginSettings
+	stream.FuturesSettings = e.FuturesSettings
 	return stream
 }
 
@@ -179,7 +198,6 @@ func (e *Exchange) QueryIsolatedMarginAccount(ctx context.Context, symbols ...st
 
 	return toGlobalIsolatedMarginAccount(account), nil
 }
-
 
 func (e *Exchange) Withdrawal(ctx context.Context, asset string, amount fixedpoint.Value, address string, options *types.WithdrawalOptions) error {
 	req := e.Client.NewCreateWithdrawService()
@@ -700,7 +718,7 @@ func (e *Exchange) submitSpotOrder(ctx context.Context, order types.SubmitOrder)
 
 func (e *Exchange) SubmitOrders(ctx context.Context, orders ...types.SubmitOrder) (createdOrders types.OrderSlice, err error) {
 	for _, order := range orders {
-		if err := orderLimiter.Wait(ctx) ; err != nil {
+		if err := orderLimiter.Wait(ctx); err != nil {
 			log.WithError(err).Errorf("order rate limiter wait error")
 		}
 
@@ -847,7 +865,7 @@ func (e *Exchange) QueryTrades(ctx context.Context, symbol string, options *type
 	}
 
 	for _, t := range remoteTrades {
-		localTrade, err := ToGlobalTrade(*t, e.IsMargin)
+		localTrade, err := toGlobalTrade(*t, e.IsMargin)
 		if err != nil {
 			log.WithError(err).Errorf("can not convert binance trade: %+v", t)
 			continue

--- a/pkg/exchange/binance/parse.go
+++ b/pkg/exchange/binance/parse.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/adshao/go-binance/v2/futures"
 	"time"
 
 	"github.com/adshao/go-binance/v2"
@@ -292,15 +293,23 @@ func ParseEvent(message string) (interface{}, error) {
 
 	case "depthUpdate":
 		return parseDepthEvent(val)
-	
+
 	case "markPriceUpdate":
 		var event MarkPriceUpdateEvent
 		err := json.Unmarshal([]byte(message), &event)
 		return &event, err
-         case "continuousKline":
-                 var event ContinuousKLineEvent
-                 err := json.Unmarshal([]byte(message), &event)
-                 return &event, err
+
+	// Binance futures data --------------
+	case "continuousKline":
+		var event ContinuousKLineEvent
+		err := json.Unmarshal([]byte(message), &event)
+		return &event, err
+
+	case "ORDER_TRADE_UPDATE":
+		var event OrderTradeUpdateEvent
+		err := json.Unmarshal([]byte(message), &event)
+		return &event, err
+
 	default:
 		id := val.GetInt("id")
 		if id > 0 {
@@ -470,6 +479,37 @@ type KLine struct {
 	Closed         bool  `json:"x"`
 }
 
+/*
+
+kline
+
+{
+  "e": "kline",     // KLineEvent type
+  "E": 123456789,   // KLineEvent time
+  "s": "BNBBTC",    // Symbol
+  "k": {
+    "t": 123400000, // Kline start time
+    "T": 123460000, // Kline close time
+    "s": "BNBBTC",  // Symbol
+    "i": "1m",      // Interval
+    "f": 100,       // First trade ID
+    "L": 200,       // Last trade ID
+    "o": "0.0010",  // Open price
+    "c": "0.0020",  // Close price
+    "h": "0.0025",  // High price
+    "l": "0.0015",  // Low price
+    "v": "1000",    // Base asset volume
+    "n": 100,       // Number of trades
+    "x": false,     // Is this kline closed?
+    "q": "1.0000",  // Quote asset volume
+    "V": "500",     // Taker buy base asset volume
+    "Q": "0.500",   // Taker buy quote asset volume
+    "B": "123456"   // Ignore
+  }
+}
+
+*/
+
 type KLineEvent struct {
 	EventBase
 	Symbol string `json:"s"`
@@ -497,18 +537,17 @@ func (k *KLine) KLine() types.KLine {
 	}
 }
 
-
 type MarkPriceUpdateEvent struct {
 	EventBase
 
-	Symbol        string `json:"s"`
+	Symbol string `json:"s"`
 
-	MarkPrice	fixedpoint.Value  `json:"p"`
-	IndexPrice	fixedpoint.Value  `json:"i"`
-	EstimatedPrice	fixedpoint.Value  `json:"P"`
-	
-	FundingRate	fixedpoint.Value  `json:"r"`
-	NextFundingTime	int64		  `json:"T"`
+	MarkPrice      fixedpoint.Value `json:"p"`
+	IndexPrice     fixedpoint.Value `json:"i"`
+	EstimatedPrice fixedpoint.Value `json:"P"`
+
+	FundingRate     fixedpoint.Value `json:"r"`
+	NextFundingTime int64            `json:"T"`
 }
 
 /*
@@ -558,36 +597,123 @@ type ContinuousKLineEvent struct {
 }
 */
 
-/*
+// Similar to the ExecutionReportEvent's fields. But with totally different json key.
+// e.g., Stop price. So that, we can not merge them.
+type OrderTrade struct {
+	Symbol           string `json:"s"`
+	ClientOrderID    string `json:"c"`
+	Side             string `json:"S"`
+	OrderType        string `json:"o"`
+	TimeInForce      string `json:"f"`
+	OriginalQuantity string `json:"q"`
+	OriginalPrice    string `json:"p"`
 
-kline
+	AveragePrice         string `json:"ap"`
+	StopPrice            string `json:"sp"`
+	CurrentExecutionType string `json:"x"`
+	CurrentOrderStatus   string `json:"X"`
 
-{
-  "e": "kline",     // KLineEvent type
-  "E": 123456789,   // KLineEvent time
-  "s": "BNBBTC",    // Symbol
-  "k": {
-    "t": 123400000, // Kline start time
-    "T": 123460000, // Kline close time
-    "s": "BNBBTC",  // Symbol
-    "i": "1m",      // Interval
-    "f": 100,       // First trade ID
-    "L": 200,       // Last trade ID
-    "o": "0.0010",  // Open price
-    "c": "0.0020",  // Close price
-    "h": "0.0025",  // High price
-    "l": "0.0015",  // Low price
-    "v": "1000",    // Base asset volume
-    "n": 100,       // Number of trades
-    "x": false,     // Is this kline closed?
-    "q": "1.0000",  // Quote asset volume
-    "V": "500",     // Taker buy base asset volume
-    "Q": "0.500",   // Taker buy quote asset volume
-    "B": "123456"   // Ignore
-  }
+	OrderId                        int64  `json:"i"`
+	OrderLastFilledQuantity        string `json:"l"`
+	OrderFilledAccumulatedQuantity string `json:"z"`
+	LastFilledPrice                string `json:"L"`
+
+	CommissionAmount string `json:"n"`
+	CommissionAsset  string `json:"N"`
+
+	OrderTradeTime int64 `json:"T"`
+	TradeId        int64 `json:"t"`
+
+	BidsNotional string `json:"b"`
+	AskNotional  string `json:"a"`
+
+	IsMaker      bool `json:"m"`
+	IsReduceOnly bool ` json:"r"`
+
+	StopPriceWorkingType string `json:"wt"`
+	OriginalOrderType    string `json:"ot"`
+	PositionSide         string `json:"ps"`
+	RealizedProfit       string `json:"rp"`
 }
 
-*/
+type OrderTradeUpdateEvent struct {
+	EventBase
+	Transaction int64      `json:"T"`
+	OrderTrade  OrderTrade `json:"o"`
+}
+
+// {
+
+// 	"e":"ORDER_TRADE_UPDATE",     // Event Type
+// 	"E":1568879465651,            // Event Time
+// 	"T":1568879465650,            // Transaction Time
+// 	"o":{
+// 	  "s":"BTCUSDT",              // Symbol
+// 	  "c":"TEST",                 // Client Order Id
+// 		// special client order id:
+// 		// starts with "autoclose-": liquidation order
+// 		// "adl_autoclose": ADL auto close order
+// 	  "S":"SELL",                 // Side
+// 	  "o":"TRAILING_STOP_MARKET", // Order Type
+// 	  "f":"GTC",                  // Time in Force
+// 	  "q":"0.001",                // Original Quantity
+// 	  "p":"0",                    // Original Price
+// 	  "ap":"0",                   // Average Price
+// 	  "sp":"7103.04",             // Stop Price. Please ignore with TRAILING_STOP_MARKET order
+// 	  "x":"NEW",                  // Execution Type
+// 	  "X":"NEW",                  // Order Status
+// 	  "i":8886774,                // Order Id
+// 	  "l":"0",                    // Order Last Filled Quantity
+// 	  "z":"0",                    // Order Filled Accumulated Quantity
+// 	  "L":"0",                    // Last Filled Price
+// 	  "N":"USDT",             // Commission Asset, will not push if no commission
+// 	  "n":"0",                // Commission, will not push if no commission
+// 	  "T":1568879465651,          // Order Trade Time
+// 	  "t":0,                      // Trade Id
+// 	  "b":"0",                    // Bids Notional
+// 	  "a":"9.91",                 // Ask Notional
+// 	  "m":false,                  // Is this trade the maker side?
+// 	  "R":false,                  // Is this reduce only
+// 	  "wt":"CONTRACT_PRICE",      // Stop Price Working Type
+// 	  "ot":"TRAILING_STOP_MARKET",    // Original Order Type
+// 	  "ps":"LONG",                        // Position Side
+// 	  "cp":false,                     // If Close-All, pushed with conditional order
+// 	  "AP":"7476.89",             // Activation Price, only puhed with TRAILING_STOP_MARKET order
+// 	  "cr":"5.0",                 // Callback Rate, only puhed with TRAILING_STOP_MARKET order
+// 	  "rp":"0"                            // Realized Profit of the trade
+// 	}
+
+//   }
+
+func (e *OrderTradeUpdateEvent) OrderFutures() (*types.Order, error) {
+
+	switch e.OrderTrade.CurrentExecutionType {
+	case "NEW", "CANCELED", "EXPIRED":
+	case "CALCULATED - Liquidation Execution":
+	case "TRADE": // For Order FILLED status. And the order has been completed.
+	default:
+		return nil, errors.New("execution report type is not for futures order")
+	}
+
+	orderCreationTime := time.Unix(0, e.OrderTrade.OrderTradeTime*int64(time.Millisecond))
+	return &types.Order{
+		Exchange: types.ExchangeBinance,
+		SubmitOrder: types.SubmitOrder{
+			Symbol:        e.OrderTrade.Symbol,
+			ClientOrderID: e.OrderTrade.ClientOrderID,
+			Side:          toGlobalFuturesSideType(futures.SideType(e.OrderTrade.Side)),
+			Type:          toGlobalFuturesOrderType(futures.OrderType(e.OrderTrade.OrderType)),
+			Quantity:      util.MustParseFloat(e.OrderTrade.OriginalQuantity),
+			Price:         util.MustParseFloat(e.OrderTrade.OriginalPrice),
+			TimeInForce:   e.OrderTrade.TimeInForce,
+		},
+		OrderID:          uint64(e.OrderTrade.OrderId),
+		Status:           toGlobalFuturesOrderStatus(futures.OrderStatusType(e.OrderTrade.CurrentOrderStatus)),
+		ExecutedQuantity: util.MustParseFloat(e.OrderTrade.OrderFilledAccumulatedQuantity),
+		CreationTime:     types.Time(orderCreationTime),
+	}, nil
+}
+
 type EventBase struct {
 	Event string `json:"e"` // event
 	Time  int64  `json:"E"`

--- a/pkg/exchange/binance/stream_callbacks.go
+++ b/pkg/exchange/binance/stream_callbacks.go
@@ -54,6 +54,16 @@ func (s *Stream) EmitContinuousKLineEvent(e *ContinuousKLineEvent) {
 	}
 }
 
+func (s *Stream) OnContinuousKLineClosedEvent(cb func(e *ContinuousKLineEvent)) {
+	s.continuousKLineClosedEventCallbacks = append(s.continuousKLineClosedEventCallbacks, cb)
+}
+
+func (s *Stream) EmitContinuousKLineClosedEvent(e *ContinuousKLineEvent) {
+	for _, cb := range s.continuousKLineClosedEventCallbacks {
+		cb(e)
+	}
+}
+
 func (s *Stream) OnBalanceUpdateEvent(cb func(event *BalanceUpdateEvent)) {
 	s.balanceUpdateEventCallbacks = append(s.balanceUpdateEventCallbacks, cb)
 }
@@ -94,6 +104,16 @@ func (s *Stream) EmitExecutionReportEvent(event *ExecutionReportEvent) {
 	}
 }
 
+func (s *Stream) OnOrderTradeUpdateEvent(cb func(e *OrderTradeUpdateEvent)) {
+	s.orderTradeUpdateEventCallbacks = append(s.orderTradeUpdateEventCallbacks, cb)
+}
+
+func (s *Stream) EmitOrderTradeUpdateEvent(e *OrderTradeUpdateEvent) {
+	for _, cb := range s.orderTradeUpdateEventCallbacks {
+		cb(e)
+	}
+}
+
 type StreamEventHub interface {
 	OnDepthEvent(cb func(e *DepthEvent))
 
@@ -105,6 +125,8 @@ type StreamEventHub interface {
 
 	OnContinuousKLineEvent(cb func(e *ContinuousKLineEvent))
 
+	OnContinuousKLineClosedEvent(cb func(e *ContinuousKLineEvent))
+
 	OnBalanceUpdateEvent(cb func(event *BalanceUpdateEvent))
 
 	OnOutboundAccountInfoEvent(cb func(event *OutboundAccountInfoEvent))
@@ -112,4 +134,6 @@ type StreamEventHub interface {
 	OnOutboundAccountPositionEvent(cb func(event *OutboundAccountPositionEvent))
 
 	OnExecutionReportEvent(cb func(event *ExecutionReportEvent))
+
+	OnOrderTradeUpdateEvent(cb func(e *OrderTradeUpdateEvent))
 }


### PR DESCRIPTION
No.3 part of #333 to support binance futures.

1. binance: add user stream event parser & toGlobalType converter
```
modified:   pkg/exchange/binance/parse.go
modified:   pkg/exchange/binance/convert.go
```
2. binance: add exchange futures  client stream connection
```
modified:   pkg/exchange/binance/exchange.go
modified:   pkg/exchange/binance/stream.go
modified:   pkg/exchange/binance/stream_callbacks.go
```