### PR TITLE
binance: support submit futures order

### DIFF
--- a/pkg/bbgo/session.go
+++ b/pkg/bbgo/session.go
@@ -161,6 +161,10 @@ type ExchangeSession struct {
 	IsolatedMargin       bool   `json:"isolatedMargin,omitempty" yaml:"isolatedMargin,omitempty"`
 	IsolatedMarginSymbol string `json:"isolatedMarginSymbol,omitempty" yaml:"isolatedMarginSymbol,omitempty"`
 
+	Futures               bool   `json:"futures,omitempty" yaml:"futures"`
+	IsolatedFutures       bool   `json:"isolatedFutures,omitempty" yaml:"isolatedFutures,omitempty"`
+	IsolatedFuturesSymbol string `json:"isolatedFuturesSymbol,omitempty" yaml:"isolatedFuturesSymbol,omitempty"`
+
 	// ---------------------------
 	// Runtime fields
 	// ---------------------------
@@ -688,6 +692,19 @@ func InitExchangeSession(name string, session *ExchangeSession) error {
 			marginExchange.UseIsolatedMargin(session.IsolatedMarginSymbol)
 		} else {
 			marginExchange.UseMargin()
+		}
+	}
+
+	if session.Futures {
+		futuresExchange, ok := exchange.(types.FuturesExchange)
+		if !ok {
+			return fmt.Errorf("exchange %s does not support futures", exchangeName)
+		}
+
+		if session.IsolatedFutures {
+			futuresExchange.UseIsolatedFutures(session.IsolatedFuturesSymbol)
+		} else {
+			futuresExchange.UseFutures()
 		}
 	}
 

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -600,6 +600,95 @@ func (e *Exchange) submitMarginOrder(ctx context.Context, order types.SubmitOrde
 	return createdOrder, err
 }
 
+func (e *Exchange) submitFuturesOrder(ctx context.Context, order types.SubmitOrder) (*types.Order, error) {
+	orderType, err := toLocalFuturesOrderType(order.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	req := e.futuresClient.NewCreateOrderService().
+		Symbol(order.Symbol).
+		Type(orderType).
+		Side(futures.SideType(order.Side))
+
+	clientOrderID := newSpotClientOrderID(order.ClientOrderID)
+	if len(clientOrderID) > 0 {
+		req.NewClientOrderID(clientOrderID)
+	}
+
+	// use response result format
+	req.NewOrderResponseType(futures.NewOrderRespTypeRESULT)
+	// if e.IsIsolatedFutures {
+	// 	req.IsIsolated(e.IsIsolatedFutures)
+	// }
+
+	if len(order.QuantityString) > 0 {
+		req.Quantity(order.QuantityString)
+	} else if order.Market.Symbol != "" {
+		req.Quantity(order.Market.FormatQuantity(order.Quantity))
+	} else {
+		req.Quantity(strconv.FormatFloat(order.Quantity, 'f', 8, 64))
+	}
+
+	// set price field for limit orders
+	switch order.Type {
+	case types.OrderTypeStopLimit, types.OrderTypeLimit, types.OrderTypeLimitMaker:
+		if len(order.PriceString) > 0 {
+			req.Price(order.PriceString)
+		} else if order.Market.Symbol != "" {
+			req.Price(order.Market.FormatPrice(order.Price))
+		}
+	}
+
+	// set stop price
+	switch order.Type {
+
+	case types.OrderTypeStopLimit, types.OrderTypeStopMarket:
+		if len(order.StopPriceString) == 0 {
+			return nil, fmt.Errorf("stop price string can not be empty")
+		}
+
+		req.StopPrice(order.StopPriceString)
+	}
+
+	// could be IOC or FOK
+	if len(order.TimeInForce) > 0 {
+		// TODO: check the TimeInForce value
+		req.TimeInForce(futures.TimeInForceType(order.TimeInForce))
+	} else {
+		switch order.Type {
+		case types.OrderTypeLimit, types.OrderTypeStopLimit:
+			req.TimeInForce(futures.TimeInForceTypeGTC)
+		}
+	}
+
+	response, err := req.Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("futures order creation response: %+v", response)
+
+	createdOrder, err := toGlobalFuturesOrder(&futures.Order{
+		Symbol:           response.Symbol,
+		OrderID:          response.OrderID,
+		ClientOrderID:    response.ClientOrderID,
+		Price:            response.Price,
+		OrigQuantity:     response.OrigQuantity,
+		ExecutedQuantity: response.ExecutedQuantity,
+		// CummulativeQuoteQuantity: response.CummulativeQuoteQuantity,
+		Status:      response.Status,
+		TimeInForce: response.TimeInForce,
+		Type:        response.Type,
+		Side:        response.Side,
+		// UpdateTime:               response.TransactTime,
+		// Time:                     response.TransactTime,
+		// IsIsolated:               response.IsIsolated,
+	}, true)
+
+	return createdOrder, err
+}
+
 // BBGO is a broker on Binance
 const spotBrokerID = "NSUYEBKM"
 
@@ -725,6 +814,8 @@ func (e *Exchange) SubmitOrders(ctx context.Context, orders ...types.SubmitOrder
 		var createdOrder *types.Order
 		if e.IsMargin {
 			createdOrder, err = e.submitMarginOrder(ctx, order)
+		} else if e.IsFutures {
+			createdOrder, err = e.submitFuturesOrder(ctx, order)
 		} else {
 			createdOrder, err = e.submitSpotOrder(ctx, order)
 		}

--- a/pkg/types/margin.go
+++ b/pkg/types/margin.go
@@ -4,11 +4,12 @@ import "github.com/c9s/bbgo/pkg/fixedpoint"
 
 type FuturesExchange interface {
 	UseFutures()
+	UseIsolatedFutures(symbol string)
 	GetFuturesSettings() FuturesSettings
 }
 
 type FuturesSettings struct {
-	IsFutures bool
+	IsFutures             bool
 	IsIsolatedFutures     bool
 	IsolatedFuturesSymbol string
 }
@@ -25,9 +26,7 @@ func (s *FuturesSettings) UseIsolatedFutures(symbol string) {
 	s.IsFutures = true
 	s.IsIsolatedFutures = true
 	s.IsolatedFuturesSymbol = symbol
-
 }
-
 
 type MarginExchange interface {
 	UseMargin()


### PR DESCRIPTION
No.4 part of #333 to support binance futures.
1. bbgo: add session Futures & types: add FuturesExchange
```
modified:   pkg/bbgo/session.go
modified:   pkg/types/margin.go
```
2. binance: add SubmitFuturesOrder and related conversions
```
modified:   pkg/exchange/binance/convert.go
modified:   pkg/exchange/binance/exchange.go
```