### PR TITLE
types: add global structs for futures

### DIFF
--- a/pkg/types/account.go
+++ b/pkg/types/account.go
@@ -217,7 +217,6 @@ type Account struct {
 
 	TotalAccountValue fixedpoint.Value `json:"totalAccountValue,omitempty"`
 
-	// Futures fields
 	CanDeposit  bool `json:"canDeposit"`
 	CanTrade    bool `json:"canTrade"`
 	CanWithdraw bool `json:"canWithdraw"`
@@ -227,18 +226,18 @@ type Account struct {
 
 type FuturesAccountInfo struct {
 	// Futures fields
-	Assets                      []FuturesUserAsset `json:"assets"`
-	FeeTier                     int                `json:"feeTier"`
-	MaxWithdrawAmount           fixedpoint.Value   `json:"maxWithdrawAmount"`
-	Positions                   PositionMap        `json:"positions"`
-	TotalInitialMargin          fixedpoint.Value   `json:"totalInitialMargin"`
-	TotalMaintMargin            fixedpoint.Value   `json:"totalMaintMargin"`
-	TotalMarginBalance          fixedpoint.Value   `json:"totalMarginBalance"`
-	TotalOpenOrderInitialMargin fixedpoint.Value   `json:"totalOpenOrderInitialMargin"`
-	TotalPositionInitialMargin  fixedpoint.Value   `json:"totalPositionInitialMargin"`
-	TotalUnrealizedProfit       fixedpoint.Value   `json:"totalUnrealizedProfit"`
-	TotalWalletBalance          fixedpoint.Value   `json:"totalWalletBalance"`
-	UpdateTime                  int64              `json:"updateTime"`
+	Assets                      map[Asset]FuturesUserAsset `json:"assets"`
+	FeeTier                     int                        `json:"feeTier"`
+	MaxWithdrawAmount           fixedpoint.Value           `json:"maxWithdrawAmount"`
+	Positions                   PositionMap                `json:"positions"`
+	TotalInitialMargin          fixedpoint.Value           `json:"totalInitialMargin"`
+	TotalMaintMargin            fixedpoint.Value           `json:"totalMaintMargin"`
+	TotalMarginBalance          fixedpoint.Value           `json:"totalMarginBalance"`
+	TotalOpenOrderInitialMargin fixedpoint.Value           `json:"totalOpenOrderInitialMargin"`
+	TotalPositionInitialMargin  fixedpoint.Value           `json:"totalPositionInitialMargin"`
+	TotalUnrealizedProfit       fixedpoint.Value           `json:"totalUnrealizedProfit"`
+	TotalWalletBalance          fixedpoint.Value           `json:"totalWalletBalance"`
+	UpdateTime                  int64                      `json:"updateTime"`
 }
 
 func NewAccount() *Account {

--- a/pkg/types/account.go
+++ b/pkg/types/account.go
@@ -206,6 +206,7 @@ type Account struct {
 	sync.Mutex `json:"-"`
 
 	AccountType AccountType `json:"accountType,omitempty"`
+	FuturesInfo *FuturesAccountInfo
 
 	MakerFeeRate fixedpoint.Value `json:"makerFeeRate,omitempty"`
 	TakerFeeRate fixedpoint.Value `json:"takerFeeRate,omitempty"`
@@ -216,7 +217,28 @@ type Account struct {
 
 	TotalAccountValue fixedpoint.Value `json:"totalAccountValue,omitempty"`
 
+	// Futures fields
+	CanDeposit  bool `json:"canDeposit"`
+	CanTrade    bool `json:"canTrade"`
+	CanWithdraw bool `json:"canWithdraw"`
+
 	balances BalanceMap
+}
+
+type FuturesAccountInfo struct {
+	// Futures fields
+	Assets                      []FuturesUserAsset `json:"assets"`
+	FeeTier                     int                `json:"feeTier"`
+	MaxWithdrawAmount           fixedpoint.Value   `json:"maxWithdrawAmount"`
+	Positions                   PositionMap        `json:"positions"`
+	TotalInitialMargin          fixedpoint.Value   `json:"totalInitialMargin"`
+	TotalMaintMargin            fixedpoint.Value   `json:"totalMaintMargin"`
+	TotalMarginBalance          fixedpoint.Value   `json:"totalMarginBalance"`
+	TotalOpenOrderInitialMargin fixedpoint.Value   `json:"totalOpenOrderInitialMargin"`
+	TotalPositionInitialMargin  fixedpoint.Value   `json:"totalPositionInitialMargin"`
+	TotalUnrealizedProfit       fixedpoint.Value   `json:"totalUnrealizedProfit"`
+	TotalWalletBalance          fixedpoint.Value   `json:"totalWalletBalance"`
+	UpdateTime                  int64              `json:"updateTime"`
 }
 
 func NewAccount() *Account {

--- a/pkg/types/margin.go
+++ b/pkg/types/margin.go
@@ -28,6 +28,19 @@ func (s *FuturesSettings) UseIsolatedFutures(symbol string) {
 	s.IsolatedFuturesSymbol = symbol
 }
 
+// FuturesUserAsset define cross/isolated futures account asset
+type FuturesUserAsset struct {
+	Asset                  string           `json:"asset"`
+	InitialMargin          fixedpoint.Value `json:"initialMargin"`
+	MaintMargin            fixedpoint.Value `json:"maintMargin"`
+	MarginBalance          fixedpoint.Value `json:"marginBalance"`
+	MaxWithdrawAmount      fixedpoint.Value `json:"maxWithdrawAmount"`
+	OpenOrderInitialMargin fixedpoint.Value `json:"openOrderInitialMargin"`
+	PositionInitialMargin  fixedpoint.Value `json:"positionInitialMargin"`
+	UnrealizedProfit       fixedpoint.Value `json:"unrealizedProfit"`
+	WalletBalance          fixedpoint.Value `json:"walletBalance"`
+}
+
 type MarginExchange interface {
 	UseMargin()
 	UseIsolatedMargin(symbol string)

--- a/pkg/types/position.go
+++ b/pkg/types/position.go
@@ -15,6 +15,11 @@ type ExchangeFee struct {
 	TakerFeeRate fixedpoint.Value
 }
 
+type PositionRisk struct {
+	Leverage         fixedpoint.Value `json:"leverage"`
+	LiquidationPrice fixedpoint.Value `json:"liquidationPrice"`
+}
+
 type Position struct {
 	Symbol        string `json:"symbol"`
 	BaseCurrency  string `json:"baseCurrency"`
@@ -35,7 +40,6 @@ type Position struct {
 
 	// Futures data fields
 	Isolated               bool             `json:"isolated"`
-	Leverage               fixedpoint.Value `json:"leverage"`
 	InitialMargin          fixedpoint.Value `json:"initialMargin"`
 	MaintMargin            fixedpoint.Value `json:"maintMargin"`
 	OpenOrderInitialMargin fixedpoint.Value `json:"openOrderInitialMargin"`
@@ -48,6 +52,7 @@ type Position struct {
 	Notional               fixedpoint.Value `json:"notional"`
 	IsolatedWallet         fixedpoint.Value `json:"isolatedWallet"`
 	UpdateTime             int64            `json:"updateTime"`
+	PositionRisk           PositionRisk
 
 	sync.Mutex
 }

--- a/pkg/types/position.go
+++ b/pkg/types/position.go
@@ -39,20 +39,9 @@ type Position struct {
 	ExchangeFeeRates map[ExchangeName]ExchangeFee `json:"exchangeFeeRates"`
 
 	// Futures data fields
-	Isolated               bool             `json:"isolated"`
-	InitialMargin          fixedpoint.Value `json:"initialMargin"`
-	MaintMargin            fixedpoint.Value `json:"maintMargin"`
-	OpenOrderInitialMargin fixedpoint.Value `json:"openOrderInitialMargin"`
-	PositionInitialMargin  fixedpoint.Value `json:"positionInitialMargin"`
-	UnrealizedProfit       fixedpoint.Value `json:"unrealizedProfit"`
-	EntryPrice             fixedpoint.Value `json:"entryPrice"`
-	MaxNotional            fixedpoint.Value `json:"maxNotional"`
-	PositionSide           string           `json:"positionSide"`
-	PositionAmt            fixedpoint.Value `json:"positionAmt"`
-	Notional               fixedpoint.Value `json:"notional"`
-	IsolatedWallet         fixedpoint.Value `json:"isolatedWallet"`
-	UpdateTime             int64            `json:"updateTime"`
-	PositionRisk           PositionRisk
+	Isolated     bool  `json:"isolated"`
+	UpdateTime   int64 `json:"updateTime"`
+	PositionRisk *PositionRisk
 
 	sync.Mutex
 }


### PR DESCRIPTION
1. types: add FuturesAccountInfo
```
modified:   pkg/types/account.go
```
2. types: add FuturesUserAsset
```
modified:   pkg/types/margin.go
```
3. types: add PositionRisk
```
modified:   pkg/types/position.go
```