### PR TITLE
binance: add futures stream

### DIFF
--- a/pkg/exchange/binance/convert.go
+++ b/pkg/exchange/binance/convert.go
@@ -154,20 +154,20 @@ func toGlobalFuturesBalance(balances []*futures.Balance) types.BalanceMap {
 	return retBalances
 }
 
-func toGlobalFuturesPositions(positions []*futures.AccountPosition) types.PositionMap {
-	retPositions := make(types.PositionMap)
-	for _, position := range positions {
-		retPositions[position.Symbol] = types.Position{
-			Isolated: position.Isolated,
+func toGlobalFuturesPositions(futuresPositions []*futures.AccountPosition) types.FuturesPositionMap {
+	retFuturesPositions := make(types.FuturesPositionMap)
+	for _, futuresPosition := range futuresPositions {
+		retFuturesPositions[futuresPosition.Symbol] = types.FuturesPosition{ //TODO: types.FuturesPosition
+			Isolated: futuresPosition.Isolated,
 			PositionRisk: &types.PositionRisk{
-				Leverage: fixedpoint.MustNewFromString(position.Leverage),
+				Leverage: fixedpoint.MustNewFromString(futuresPosition.Leverage),
 			},
-			Symbol:     position.Symbol,
-			UpdateTime: position.UpdateTime,
+			Symbol:     futuresPosition.Symbol,
+			UpdateTime: futuresPosition.UpdateTime,
 		}
 	}
 
-	return retPositions
+	return retFuturesPositions
 }
 
 func toGlobalFuturesUserAssets(assets []*futures.AccountAsset) (retAssets map[types.Asset]types.FuturesUserAsset) {

--- a/pkg/exchange/binance/stream_callbacks.go
+++ b/pkg/exchange/binance/stream_callbacks.go
@@ -124,6 +124,26 @@ func (s *Stream) EmitOrderTradeUpdateEvent(e *OrderTradeUpdateEvent) {
 	}
 }
 
+func (s *Stream) OnAccountUpdateEvent(cb func(e *AccountUpdateEvent)) {
+	s.accountUpdateEventCallbacks = append(s.accountUpdateEventCallbacks, cb)
+}
+
+func (s *Stream) EmitAccountUpdateEvent(e *AccountUpdateEvent) {
+	for _, cb := range s.accountUpdateEventCallbacks {
+		cb(e)
+	}
+}
+
+func (s *Stream) OnAccountConfigUpdateEvent(cb func(e *AccountConfigUpdateEvent)) {
+	s.accountConfigUpdateEventCallbacks = append(s.accountConfigUpdateEventCallbacks, cb)
+}
+
+func (s *Stream) EmitAccountConfigUpdateEvent(e *AccountConfigUpdateEvent) {
+	for _, cb := range s.accountConfigUpdateEventCallbacks {
+		cb(e)
+	}
+}
+
 type StreamEventHub interface {
 	OnDepthEvent(cb func(e *DepthEvent))
 
@@ -148,4 +168,8 @@ type StreamEventHub interface {
 	OnBookTickerEvent(cb func(event *BookTickerEvent))
 
 	OnOrderTradeUpdateEvent(cb func(e *OrderTradeUpdateEvent))
+
+	OnAccountUpdateEvent(cb func(e *AccountUpdateEvent))
+
+	OnAccountConfigUpdateEvent(cb func(e *AccountConfigUpdateEvent))
 }

--- a/pkg/types/account.go
+++ b/pkg/types/account.go
@@ -121,6 +121,7 @@ func (m AssetMap) SlackAttachment() slack.Attachment {
 
 type BalanceMap map[string]Balance
 type PositionMap map[string]Position
+type FuturesPositionMap map[string]FuturesPosition
 
 func (m BalanceMap) String() string {
 	var ss []string
@@ -229,7 +230,7 @@ type FuturesAccountInfo struct {
 	Assets                      map[Asset]FuturesUserAsset `json:"assets"`
 	FeeTier                     int                        `json:"feeTier"`
 	MaxWithdrawAmount           fixedpoint.Value           `json:"maxWithdrawAmount"`
-	Positions                   PositionMap                `json:"positions"`
+	Positions                   FuturesPositionMap         `json:"positions"`
 	TotalInitialMargin          fixedpoint.Value           `json:"totalInitialMargin"`
 	TotalMaintMargin            fixedpoint.Value           `json:"totalMaintMargin"`
 	TotalMarginBalance          fixedpoint.Value           `json:"totalMarginBalance"`

--- a/pkg/types/position.go
+++ b/pkg/types/position.go
@@ -39,6 +39,27 @@ type Position struct {
 	FeeRate          *ExchangeFee                 `json:"feeRate,omitempty"`
 	ExchangeFeeRates map[ExchangeName]ExchangeFee `json:"exchangeFeeRates"`
 
+	sync.Mutex
+}
+
+type FuturesPosition struct {
+	Symbol        string `json:"symbol"`
+	BaseCurrency  string `json:"baseCurrency"`
+	QuoteCurrency string `json:"quoteCurrency"`
+
+	Market Market `json:"market"`
+
+	Base        fixedpoint.Value `json:"base"`
+	Quote       fixedpoint.Value `json:"quote"`
+	AverageCost fixedpoint.Value `json:"averageCost"`
+
+	// ApproximateAverageCost adds the computed fee in quote in the average cost
+	// This is used for calculating net profit
+	ApproximateAverageCost fixedpoint.Value `json:"approximateAverageCost"`
+
+	FeeRate          *ExchangeFee                 `json:"feeRate,omitempty"`
+	ExchangeFeeRates map[ExchangeName]ExchangeFee `json:"exchangeFeeRates"`
+
 	// Futures data fields
 	Isolated     bool  `json:"isolated"`
 	UpdateTime   int64 `json:"updateTime"`

--- a/pkg/types/standardstream_callbacks.go
+++ b/pkg/types/standardstream_callbacks.go
@@ -124,23 +124,23 @@ func (stream *StandardStream) EmitBookSnapshot(book SliceOrderBook) {
 	}
 }
 
-func (stream *StandardStream) OnPositionUpdate(cb func(position PositionMap)) {
-	stream.PositionUpdateCallbacks = append(stream.PositionUpdateCallbacks, cb)
+func (stream *StandardStream) OnFuturesPositionUpdate(cb func(futuresPositions FuturesPositionMap)) {
+	stream.FuturesPositionUpdateCallbacks = append(stream.FuturesPositionUpdateCallbacks, cb)
 }
 
-func (stream *StandardStream) EmitPositionUpdate(position PositionMap) {
-	for _, cb := range stream.PositionUpdateCallbacks {
-		cb(position)
+func (stream *StandardStream) EmitFuturesPositionUpdate(futuresPositions FuturesPositionMap) {
+	for _, cb := range stream.FuturesPositionUpdateCallbacks {
+		cb(futuresPositions)
 	}
 }
 
-func (stream *StandardStream) OnPositionSnapshot(cb func(position PositionMap)) {
-	stream.PositionSnapshotCallbacks = append(stream.PositionSnapshotCallbacks, cb)
+func (stream *StandardStream) OnFuturesPositionSnapshot(cb func(futuresPositions FuturesPositionMap)) {
+	stream.FuturesPositionSnapshotCallbacks = append(stream.FuturesPositionSnapshotCallbacks, cb)
 }
 
-func (stream *StandardStream) EmitPositionSnapshot(position PositionMap) {
-	for _, cb := range stream.PositionSnapshotCallbacks {
-		cb(position)
+func (stream *StandardStream) EmitFuturesPositionSnapshot(futuresPositions FuturesPositionMap) {
+	for _, cb := range stream.FuturesPositionSnapshotCallbacks {
+		cb(futuresPositions)
 	}
 }
 
@@ -169,7 +169,7 @@ type StandardStreamEventHub interface {
 
 	OnBookSnapshot(cb func(book SliceOrderBook))
 
-	OnPositionUpdate(cb func(position PositionMap))
+	OnFuturesPositionUpdate(cb func(futuresPositions FuturesPositionMap))
 
-	OnPositionSnapshot(cb func(position PositionMap))
+	OnFuturesPositionSnapshot(cb func(futuresPositions FuturesPositionMap))
 }

--- a/pkg/types/stream.go
+++ b/pkg/types/stream.go
@@ -62,9 +62,9 @@ type StandardStream struct {
 	bookSnapshotCallbacks []func(book SliceOrderBook)
 
 	// Futures
-	PositionUpdateCallbacks []func(position PositionMap)
+	FuturesPositionUpdateCallbacks []func(futuresPositions FuturesPositionMap)
 
-	PositionSnapshotCallbacks []func(position PositionMap)
+	FuturesPositionSnapshotCallbacks []func(futuresPositions FuturesPositionMap)
 }
 
 func (stream *StandardStream) Subscribe(channel Channel, symbol string, options SubscribeOptions) {


### PR DESCRIPTION
not implement yet:

1. OrderTradeUpdateEvent `case "TRADE"`
2. OrderTradeUpdateEvent `case "CALCULATED - Liquidation Execution"`