### PR TITLE
ftx: Support LIMIT_MAKER and IOC_LIMIT order type

### DIFF
--- a/pkg/exchange/ftx/convert.go
+++ b/pkg/exchange/ftx/convert.go
@@ -152,3 +152,29 @@ func toGlobalKLine(symbol string, interval types.Interval, h Candle) (types.KLin
 		Closed:    true,
 	}, nil
 }
+
+type OrderType string
+
+const (
+	OrderTypeLimit  OrderType = "limit"
+	OrderTypeMarket OrderType = "market"
+)
+
+func toLocalOrderType(orderType types.OrderType) (OrderType, bool, bool, error) {
+	switch orderType {
+
+	case types.OrderTypeLimitMaker:
+		return OrderTypeLimit, true, false, nil
+
+	case types.OrderTypeLimit:
+		return OrderTypeLimit, false, false, nil
+
+	case types.OrderTypeMarket:
+		return OrderTypeMarket, false, false, nil
+
+	case types.OrderTypeIOCLimit:
+		return OrderTypeLimit, false, true, nil
+	}
+
+	return "", false, false, fmt.Errorf("order type %s not supported", orderType)
+}

--- a/pkg/exchange/ftx/convert_test.go
+++ b/pkg/exchange/ftx/convert_test.go
@@ -100,3 +100,43 @@ func TestTrimLowerString(t *testing.T) {
 func Test_toGlobalSymbol(t *testing.T) {
 	assert.Equal(t, "BTCUSDT", toGlobalSymbol("BTC/USDT"))
 }
+
+func Test_toLocalOrderTypeWithLimitMaker(t *testing.T) {
+
+	orderType, postOnly, IOC, err := toLocalOrderType(types.OrderTypeLimitMaker)
+
+	assert.NoError(t, err)
+	assert.Equal(t, orderType, OrderTypeLimit)
+	assert.Equal(t, postOnly, true)
+	assert.Equal(t, IOC, false)
+}
+
+func Test_toLocalOrderTypeWithLimit(t *testing.T) {
+
+	orderType, postOnly, IOC, err := toLocalOrderType(types.OrderTypeLimit)
+
+	assert.NoError(t, err)
+	assert.Equal(t, orderType, OrderTypeLimit)
+	assert.Equal(t, postOnly, false)
+	assert.Equal(t, IOC, false)
+}
+
+func Test_toLocalOrderTypeWithMarket(t *testing.T) {
+
+	orderType, postOnly, IOC, err := toLocalOrderType(types.OrderTypeMarket)
+
+	assert.NoError(t, err)
+	assert.Equal(t, orderType, OrderTypeMarket)
+	assert.Equal(t, postOnly, false)
+	assert.Equal(t, IOC, false)
+}
+
+func Test_toLocalOrderTypeWithIOCLimit(t *testing.T) {
+
+	orderType, postOnly, IOC, err := toLocalOrderType(types.OrderTypeIOCLimit)
+
+	assert.NoError(t, err)
+	assert.Equal(t, orderType, OrderTypeLimit)
+	assert.Equal(t, postOnly, false)
+	assert.Equal(t, IOC, true)
+}


### PR DESCRIPTION
According [FTX document](https://docs.ftx.com/#place-order), it should use `postOnly` and `ioc` to support `LIMIT_MAKER` and 
 `IOC_LIMIT `

I create the `toLocalOrderType` method for mapping ftx order.

PS. Still not support `STOP_LIMIT` and `STOP_MARKET`