### PR TITLE
fix: #431 for not updating lastPrice if no tade happened

### DIFF
--- a/pkg/backtest/matching.go
+++ b/pkg/backtest/matching.go
@@ -405,7 +405,7 @@ func (m *SimplePriceMatching) processKLine(kline types.KLine) {
 
 	switch kline.Direction() {
 	case types.DirectionDown:
-		if kline.High > kline.Open {
+		if kline.High >= kline.Open {
 			m.BuyToPrice(fixedpoint.NewFromFloat(kline.High))
 		}
 
@@ -417,7 +417,7 @@ func (m *SimplePriceMatching) processKLine(kline types.KLine) {
 		}
 
 	case types.DirectionUp:
-		if kline.Low < kline.Open {
+		if kline.Low <= kline.Open {
 			m.SellToPrice(fixedpoint.NewFromFloat(kline.Low))
 		}
 
@@ -425,6 +425,10 @@ func (m *SimplePriceMatching) processKLine(kline types.KLine) {
 			m.BuyToPrice(fixedpoint.NewFromFloat(kline.High))
 			m.SellToPrice(fixedpoint.NewFromFloat(kline.Close))
 		} else {
+			m.BuyToPrice(fixedpoint.NewFromFloat(kline.Close))
+		}
+    default: // no trade up or down
+		if (m.LastPrice == 0) {
 			m.BuyToPrice(fixedpoint.NewFromFloat(kline.Close))
 		}
 


### PR DESCRIPTION
resolve #431   
cc. @arthurwolf 

if the order is sent as market order, it will fetch lastprice as price of the order
however, there's rarely having trade happening inside btc pairs, so lastprice might not been updated for the first tick