### PR TITLE
Fix: precision of futures trade data is incorrect.

### DIFF
--- a/pkg/exchange/binance/parse.go
+++ b/pkg/exchange/binance/parse.go
@@ -731,13 +731,13 @@ func (e *OrderTradeUpdateEvent) TradeFutures() (*types.Trade, error) {
 		Symbol:        e.OrderTrade.Symbol,
 		OrderID:       uint64(e.OrderTrade.OrderId),
 		Side:          toGlobalSideType(binance.SideType(e.OrderTrade.Side)),
-		Price:         float64(e.OrderTrade.LastFilledPrice),
-		Quantity:      float64(e.OrderTrade.OrderLastFilledQuantity),
-		QuoteQuantity: float64(e.OrderTrade.OrderFilledAccumulatedQuantity),
+		Price:         e.OrderTrade.LastFilledPrice.Float64(),
+		Quantity:      e.OrderTrade.OrderLastFilledQuantity.Float64(),
+		QuoteQuantity: e.OrderTrade.OrderFilledAccumulatedQuantity.Float64(),
 		IsBuyer:       e.OrderTrade.Side == "BUY",
 		IsMaker:       e.OrderTrade.IsMaker,
 		Time:          types.Time(tt),
-		Fee:           float64(e.OrderTrade.CommissionAmount),
+		Fee:           e.OrderTrade.CommissionAmount.Float64(),
 		FeeCurrency:   e.OrderTrade.CommissionAsset,
 	}, nil
 }


### PR DESCRIPTION
Issue:
[0002]  INFO submitting order: SubmitOrder ETHUSDT LIMIT SELL 0.005000 @ 3002.700000
[0105]  INFO TRADE binance ETHUSDT SELL 500000 @ 300270000000 amount 500000 fee 300270 USDT orderID 8389765515765757063 Feb 12 03:33:32.628 session=binance