### PR TITLE
feature: add market trade subscription in binance

### DIFF
--- a/pkg/bbgo/session.go
+++ b/pkg/bbgo/session.go
@@ -358,6 +358,10 @@ func (session *ExchangeSession) Init(ctx context.Context, environ *Environment) 
 		session.lastPrices[kline.Symbol] = kline.Close
 	})
 
+	session.MarketDataStream.OnMarketTrade(func(trade types.Trade) {
+		session.lastPrices[trade.Symbol] = trade.Price
+	})
+
 	session.IsInitialized = true
 	return nil
 }

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -471,10 +471,10 @@ func (e *Exchange) QuerySpotAccount(ctx context.Context) (*types.Account, error)
 	}
 
 	a := &types.Account{
-		AccountType:     types.AccountTypeSpot,
-		CanDeposit:      account.CanDeposit,  // if can transfer in asset
-		CanTrade:        account.CanTrade,    // if can trade
-		CanWithdraw:     account.CanWithdraw, // if can transfer out asset
+		AccountType: types.AccountTypeSpot,
+		CanDeposit:  account.CanDeposit,  // if can transfer in asset
+		CanTrade:    account.CanTrade,    // if can trade
+		CanWithdraw: account.CanWithdraw, // if can transfer out asset
 	}
 	a.UpdateBalances(balances)
 	return a, nil

--- a/pkg/exchange/binance/exchange_test.go
+++ b/pkg/exchange/binance/exchange_test.go
@@ -10,8 +10,8 @@ import (
 func Test_newClientOrderID(t *testing.T) {
 	cID := newSpotClientOrderID("")
 	assert.Len(t, cID, 32)
-	strings.HasPrefix(cID, "x-" + spotBrokerID)
+	strings.HasPrefix(cID, "x-"+spotBrokerID)
 
 	cID = newSpotClientOrderID("myid1")
-	assert.Equal(t, cID, "x-" + spotBrokerID + "myid1")
+	assert.Equal(t, cID, "x-"+spotBrokerID+"myid1")
 }

--- a/pkg/exchange/binance/parse.go
+++ b/pkg/exchange/binance/parse.go
@@ -480,6 +480,7 @@ type MarketTradeEvent struct {
 	TradeId        int64 `json:"t"`
 
 	IsMaker bool `json:"m"`
+	Dummy   bool `json:"M"`
 }
 
 /*
@@ -504,16 +505,28 @@ market trade
 
 func (e *MarketTradeEvent) Trade() types.Trade {
 	tt := time.Unix(0, e.OrderTradeTime*int64(time.Millisecond))
+	var orderId int64
+	var side types.SideType
+	var isBuyer bool
+	if e.IsMaker {
+		orderId = e.SellerOrderId // seller is taker
+		side = types.SideTypeSell
+		isBuyer = false
+	} else {
+		orderId = e.BuyerOrderId // buyer is taker
+		side = types.SideTypeBuy
+		isBuyer = true
+	}
 	return types.Trade{
 		ID:            uint64(e.TradeId),
 		Exchange:      types.ExchangeBinance,
 		Symbol:        e.Symbol,
-		OrderID:       uint64(e.BuyerOrderId),
-		Side:          types.SideTypeBoth,
+		OrderID:       uint64(orderId),
+		Side:          side,
 		Price:         e.Price,
 		Quantity:      e.Quantity,
 		QuoteQuantity: e.Quantity,
-		IsBuyer:       true,
+		IsBuyer:       isBuyer,
 		IsMaker:       e.IsMaker,
 		Time:          types.Time(tt),
 		Fee:           fixedpoint.Zero,

--- a/pkg/exchange/binance/stream.go
+++ b/pkg/exchange/binance/stream.go
@@ -47,6 +47,7 @@ type Stream struct {
 	kLineClosedEventCallbacks []func(e *KLineEvent)
 
 	markPriceUpdateEventCallbacks []func(e *MarkPriceUpdateEvent)
+	marketTradeEventCallbacks     []func(e *MarketTradeEvent)
 
 	continuousKLineEventCallbacks       []func(e *ContinuousKLineEvent)
 	continuousKLineClosedEventCallbacks []func(e *ContinuousKLineEvent)
@@ -116,6 +117,7 @@ func NewStream(ex *Exchange, client *binance.Client, futuresClient *futures.Clie
 	stream.OnBookTickerEvent(stream.handleBookTickerEvent)
 	stream.OnExecutionReportEvent(stream.handleExecutionReportEvent)
 	stream.OnContinuousKLineEvent(stream.handleContinuousKLineEvent)
+	stream.OnMarketTradeEvent(stream.handleMarketTradeEvent)
 
 	// Event type ACCOUNT_UPDATE from user data stream updates Balance and FuturesPosition.
 	stream.OnAccountUpdateEvent(stream.handleAccountUpdateEvent)
@@ -205,6 +207,10 @@ func (s *Stream) handleExecutionReportEvent(e *ExecutionReportEvent) {
 
 func (s *Stream) handleBookTickerEvent(e *BookTickerEvent) {
 	s.EmitBookTickerUpdate(e.BookTicker())
+}
+
+func (s *Stream) handleMarketTradeEvent(e *MarketTradeEvent) {
+	s.EmitMarketTrade(e.Trade())
 }
 
 func (s *Stream) handleKLineEvent(e *KLineEvent) {
@@ -316,6 +322,9 @@ func (s *Stream) dispatchEvent(e interface{}) {
 
 	case *BalanceUpdateEvent:
 		s.EmitBalanceUpdateEvent(e)
+
+	case *MarketTradeEvent:
+		s.EmitMarketTradeEvent(e)
 
 	case *KLineEvent:
 		s.EmitKLineEvent(e)

--- a/pkg/exchange/binance/stream_callbacks.go
+++ b/pkg/exchange/binance/stream_callbacks.go
@@ -44,6 +44,16 @@ func (s *Stream) EmitMarkPriceUpdateEvent(e *MarkPriceUpdateEvent) {
 	}
 }
 
+func (s *Stream) OnMarketTradeEvent(cb func(e *MarketTradeEvent)) {
+	s.marketTradeEventCallbacks = append(s.marketTradeEventCallbacks, cb)
+}
+
+func (s *Stream) EmitMarketTradeEvent(e *MarketTradeEvent) {
+	for _, cb := range s.marketTradeEventCallbacks {
+		cb(e)
+	}
+}
+
 func (s *Stream) OnContinuousKLineEvent(cb func(e *ContinuousKLineEvent)) {
 	s.continuousKLineEventCallbacks = append(s.continuousKLineEventCallbacks, cb)
 }
@@ -152,6 +162,8 @@ type StreamEventHub interface {
 	OnKLineClosedEvent(cb func(e *KLineEvent))
 
 	OnMarkPriceUpdateEvent(cb func(e *MarkPriceUpdateEvent))
+
+	OnMarketTradeEvent(cb func(e *MarketTradeEvent))
 
 	OnContinuousKLineEvent(cb func(e *ContinuousKLineEvent))
 

--- a/pkg/types/channel.go
+++ b/pkg/types/channel.go
@@ -5,3 +5,4 @@ type Channel string
 var BookChannel = Channel("book")
 var KLineChannel = Channel("kline")
 var BookTickerChannel = Channel("bookticker")
+var MarketTradeChannel = Channel("trade")

--- a/pkg/types/exchange.go
+++ b/pkg/types/exchange.go
@@ -60,6 +60,8 @@ func ValidExchangeName(a string) (ExchangeName, error) {
 		return ExchangeFTX, nil
 	case "okex":
 		return ExchangeOKEx, nil
+	case "kucoin":
+		return ExchangeKucoin, nil
 	}
 
 	return "", fmt.Errorf("invalid exchange name: %s", a)

--- a/pkg/types/standardstream_callbacks.go
+++ b/pkg/types/standardstream_callbacks.go
@@ -124,6 +124,16 @@ func (s *StandardStream) EmitBookSnapshot(book SliceOrderBook) {
 	}
 }
 
+func (s *StandardStream) OnMarketTrade(cb func(trade Trade)) {
+	s.marketTradeCallbacks = append(s.marketTradeCallbacks, cb)
+}
+
+func (s *StandardStream) EmitMarketTrade(trade Trade) {
+	for _, cb := range s.marketTradeCallbacks {
+		cb(trade)
+	}
+}
+
 func (s *StandardStream) OnFuturesPositionUpdate(cb func(futuresPositions FuturesPositionMap)) {
 	s.FuturesPositionUpdateCallbacks = append(s.FuturesPositionUpdateCallbacks, cb)
 }
@@ -168,6 +178,8 @@ type StandardStreamEventHub interface {
 	OnBookTickerUpdate(cb func(bookTicker BookTicker))
 
 	OnBookSnapshot(cb func(book SliceOrderBook))
+
+	OnMarketTrade(cb func(trade Trade))
 
 	OnFuturesPositionUpdate(cb func(futuresPositions FuturesPositionMap))
 

--- a/pkg/types/stream.go
+++ b/pkg/types/stream.go
@@ -96,6 +96,8 @@ type StandardStream struct {
 
 	bookSnapshotCallbacks []func(book SliceOrderBook)
 
+	marketTradeCallbacks []func(trade Trade)
+
 	// Futures
 	FuturesPositionUpdateCallbacks []func(futuresPositions FuturesPositionMap)
 


### PR DESCRIPTION
and update session.lastPrice accordingly.  

in backtest still doesn't work.  
also the field in market trade is very different from private trade. 
some fields in types.Trade is filled with dummy messages.

one missing part in types/exchange.go is added (the kucoin verification)