### PR TITLE
strategy: add bollmaker futures support

### DIFF
--- a/pkg/exchange/binance/convert.go
+++ b/pkg/exchange/binance/convert.go
@@ -273,7 +273,7 @@ func toLocalFuturesOrderType(orderType types.OrderType) (futures.OrderType, erro
 	// case types.OrderTypeLimitMaker:
 	// 	return futures.OrderTypeLimitMaker, nil //TODO
 
-	case types.OrderTypeLimit:
+	case types.OrderTypeLimit, types.OrderTypeLimitMaker:
 		return futures.OrderTypeLimit, nil
 
 	// case types.OrderTypeStopLimit:

--- a/pkg/strategy/bollmaker/strategy.go
+++ b/pkg/strategy/bollmaker/strategy.go
@@ -319,22 +319,24 @@ func (s *Strategy) placeOrders(ctx context.Context, orderExecutor bbgo.OrderExec
 	buyQuantity := s.QuantityOrAmount.CalculateQuantity(bidPrice)
 
 	sellOrder := types.SubmitOrder{
-		Symbol:   s.Symbol,
-		Side:     types.SideTypeSell,
-		Type:     types.OrderTypeLimitMaker,
-		Quantity: sellQuantity,
-		Price:    askPrice,
-		Market:   s.Market,
-		GroupID:  s.groupID,
+		Symbol:      s.Symbol,
+		Side:        types.SideTypeSell,
+		Type:        types.OrderTypeLimitMaker,
+		Quantity:    sellQuantity,
+		Price:       askPrice,
+		Market:      s.Market,
+		GroupID:     s.groupID,
+		TimeInForce: types.TimeInForceGTC,
 	}
 	buyOrder := types.SubmitOrder{
-		Symbol:   s.Symbol,
-		Side:     types.SideTypeBuy,
-		Type:     types.OrderTypeLimitMaker,
-		Quantity: buyQuantity,
-		Price:    bidPrice,
-		Market:   s.Market,
-		GroupID:  s.groupID,
+		Symbol:      s.Symbol,
+		Side:        types.SideTypeBuy,
+		Type:        types.OrderTypeLimitMaker,
+		Quantity:    buyQuantity,
+		Price:       bidPrice,
+		Market:      s.Market,
+		GroupID:     s.groupID,
+		TimeInForce: types.TimeInForceGTC,
 	}
 
 	var submitOrders []types.SubmitOrder


### PR DESCRIPTION
example config
```
persistence:
  redis:
    host: 127.0.0.1
    port: 6379
    db: 0


sessions:
  binance-futures:
    exchange: binance
    futures: true
#  binance:
#    exchange: binance

sync:
  # userDataStream is used to sync the trading data in real-time
  # it uses the websocket connection to insert the trades
  userDataStream:
    trades: true
    filledOrders: true

  # since is the start date of your trading data
  since: 2019-11-01

  # sessions is the list of session names you want to sync
  # by default, BBGO sync all your available sessions.
  sessions:
#  - binance
  - binance-futures

  # symbols is the list of symbols you want to sync
  # by default, BBGO try to guess your symbols by your existing account balances.
  symbols:
  - BTCUSDT

exchangeStrategies:
- on: binance-futures
  bollmaker:
    symbol: BTCUSDT
    interval: 1m
    # quantity: 0.8
    amount: 60
    askSpread: 0.1%
    bidSpread: 0.1%
    minProfitSpread: 0.1%
    useTickerPrice: true

    # maxExposurePosition: 50

    dynamicExposurePositionScale:
      byPercentage:
        # exp means we want to use exponential scale, you can replace "exp" with "linear" for linear scale
        exp:
          # from down to up
          domain: [ -1, 1 ]
          # when in down band, holds 1.0 by maximum
          # when in up band, holds 0.05 by maximum
          range: [ 0.1, 0.005 ]
    uptrendSkew: 0.2
    downtrendSkew: 1.5

    long: false
    buyBelowNeutralSMA: true
    tradeInBand: true

    defaultBollinger:
      interval: "1d"
      window: 21
      bandWidth: 2.0

    neutralBollinger:
      interval: "5m"
      window: 21
      bandWidth: 2.0

    persistence:
      type: redis
```