### PR TITLE
feature: add atr stoploss on ewoDgtrd strategy

### DIFF
--- a/config/ewo_dgtrd.yaml
+++ b/config/ewo_dgtrd.yaml
@@ -9,14 +9,14 @@ exchangeStrategies:
  
 - on: binance
   ewo_dgtrd:
-    symbol: NEARUSDT
-    interval: 15m
+    symbol: MATICUSDT
+    interval: 30m
     useEma: false
     useSma: false
     sigWin: 3
     stoploss: 2%
-    callback: 1%
     useHeikinAshi: true
+    disableShortStop: true
     #stops:
     #- trailingStop:
     #    callbackRate: 5.1%
@@ -33,16 +33,18 @@ sync:
     sessions:
       - binance
     symbols:
-      - NEARUSDT
+      - MATICUSDT
 
 backtest:
-  startTime: "2022-03-03"
-  endTime: "2022-04-14"
+  startTime: "2022-04-14"
+  endTime: "2022-04-28"
   symbols:
-    - NEARUSDT
+    - MATICUSDT
   sessions: [binance]
   account:
     binance:
+      makerFeeRate: 0
+      takerFeeRate: 0
       balances:
-        NEAR: 0
+        MATIC: 500
         USDT: 10000

--- a/pkg/indicator/atr_test.go
+++ b/pkg/indicator/atr_test.go
@@ -41,9 +41,9 @@ func Test_calculateATR(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			atr := ATR{IntervalWindow: types.IntervalWindow{Window: tt.window}}
+			atr := &ATR{IntervalWindow: types.IntervalWindow{Window: tt.window}}
 			atr.calculateAndUpdate(tt.kLines)
-			got := atr.Values.Last()
+			got := atr.Last()
 			diff := math.Trunc((got-tt.want)*100) / 100
 			if diff != 0 {
 				t.Errorf("calculateATR() = %v, want %v", got, tt.want)


### PR DESCRIPTION
add atr stoploss for ewo strategy.
fix some filter condition
result: 
```log
BINANCE MATICUSDT PROFIT AND LOSS REPORT
===============================================
[0017]  INFO TRADES SINCE: 2022-04-14 23:30:59.999 +0900 JST
[0017]  INFO NUMBER OF TRADES: 3
[0017]  INFO AVERAGE COST: $ 1.41
[0017]  INFO TOTAL BUY VOLUME: 7783.49108117
[0017]  INFO TOTAL SELL VOLUME: 8283.49108117
[0017]  INFO STOCK: -500
[0017]  INFO CURRENT PRICE: $ 1.25
[0017]  INFO CURRENCY FEES:
[0017]  INFO  - USDT: 0
[0017]  INFO  - MATIC: 0
[0017]  INFO PROFIT: $ 266.83
[0017]  INFO UNREALIZED PROFIT: $ 76.50
[0017]  INFO INITIAL BALANCES:
[0017]  INFO  MATIC: 500
[0017]  INFO  USDT: 10000
[0017]  INFO FINAL BALANCES:
[0017]  INFO  USDT: 10959.1554423 (locked 11.67523662)
[0017]  INFO INITIAL ASSET IN USDT ~= 10705.0 USDT (1 MATIC = 1.41)
[0017]  INFO FINAL ASSET IN USDT ~= 10970.8 USDT (1 MATIC = 1.25499999)
REALIZED PROFIT: +266.83067892 USDT
UNREALIZED PROFIT: +76.500005 USDT
ASSET INCREASED: +265.83067892 USDT (+2.48%)
MATIC BASE ASSET PERFORMANCE: -10.99% (= (1.25 - 1.41) / 1.41)
```