### PR TITLE
Fix error: Data too long for profits column 'symbol'

### DIFF
--- a/migrations/mysql/20220512170322_fix_profit_symbol_length.sql
+++ b/migrations/mysql/20220512170322_fix_profit_symbol_length.sql
@@ -1,0 +1,11 @@
+-- +up
+-- +begin
+ALTER TABLE profits
+    CHANGE symbol symbol VARCHAR(20) NOT NULL;
+-- +end
+
+-- +down
+
+-- +begin
+SELECT 1;
+-- +end

--- a/migrations/sqlite3/20220512170330_fix_profit_symbol_length.sql
+++ b/migrations/sqlite3/20220512170330_fix_profit_symbol_length.sql
@@ -1,0 +1,11 @@
+-- +up
+-- +begin
+ALTER TABLE profits
+    CHANGE symbol symbol VARCHAR(20) NOT NULL;
+-- +end
+
+-- +down
+
+-- +begin
+SELECT 1;
+-- +end

--- a/migrations/sqlite3/20220512170330_fix_profit_symbol_length.sql
+++ b/migrations/sqlite3/20220512170330_fix_profit_symbol_length.sql
@@ -1,7 +1,8 @@
 -- +up
 -- +begin
-ALTER TABLE profits
-    CHANGE symbol symbol VARCHAR(20) NOT NULL;
+-- We can not change column type in sqlite
+-- However, SQLite does not enforce the length of a VARCHAR, i.e VARCHAR(8) == VARCHAR(20) == TEXT
+SELECT 1;
 -- +end
 
 -- +down

--- a/pkg/migrations/mysql/20220512170322_fix_profit_symbol_length.go
+++ b/pkg/migrations/mysql/20220512170322_fix_profit_symbol_length.go
@@ -1,0 +1,34 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/c9s/rockhopper"
+)
+
+func init() {
+	AddMigration(upFixProfitSymbolLength, downFixProfitSymbolLength)
+
+}
+
+func upFixProfitSymbolLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is applied.
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE profits\n    CHANGE symbol symbol VARCHAR(20) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func downFixProfitSymbolLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is rolled back.
+
+	_, err = tx.ExecContext(ctx, "SELECT 1;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/pkg/migrations/sqlite3/20220512170330_fix_profit_symbol_length.go
+++ b/pkg/migrations/sqlite3/20220512170330_fix_profit_symbol_length.go
@@ -14,7 +14,7 @@ func init() {
 func upFixProfitSymbolLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
 	// This code is executed when the migration is applied.
 
-	_, err = tx.ExecContext(ctx, "ALTER TABLE profits\n    CHANGE symbol symbol VARCHAR(20) NOT NULL;")
+	_, err = tx.ExecContext(ctx, "SELECT 1;")
 	if err != nil {
 		return err
 	}

--- a/pkg/migrations/sqlite3/20220512170330_fix_profit_symbol_length.go
+++ b/pkg/migrations/sqlite3/20220512170330_fix_profit_symbol_length.go
@@ -1,0 +1,34 @@
+package sqlite3
+
+import (
+	"context"
+
+	"github.com/c9s/rockhopper"
+)
+
+func init() {
+	AddMigration(upFixProfitSymbolLength, downFixProfitSymbolLength)
+
+}
+
+func upFixProfitSymbolLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is applied.
+
+	_, err = tx.ExecContext(ctx, "ALTER TABLE profits\n    CHANGE symbol symbol VARCHAR(20) NOT NULL;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func downFixProfitSymbolLength(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is rolled back.
+
+	_, err = tx.ExecContext(ctx, "SELECT 1;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}


### PR DESCRIPTION
This change fixes "Error 1406: Data too long for column 'symbol' at row 1" for pair symbol longer than 8 chars.

Fixes #608