### PR TITLE
fix: change from go get to go install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV GOPATH_ORIG=$GOPATH
 ENV GOPATH=${GO_MOD_CACHE:+$WORKDIR/$GO_MOD_CACHE}
 ENV GOPATH=${GOPATH:-$GOPATH_ORIG}
 ENV CGO_ENABLED=1
-RUN go get github.com/mattn/go-sqlite3
+RUN go install github.com/mattn/go-sqlite3
 ADD . .
 RUN go build -o $GOPATH_ORIG/bin/bbgo ./cmd/bbgo
 


### PR DESCRIPTION
go get in 1.18 without go.mod is deprecated