### PR TITLE
WIP: add MEXC 

### DIFF
--- a/pkg/cmd/cmdutil/exchange.go
+++ b/pkg/cmd/cmdutil/exchange.go
@@ -10,6 +10,7 @@ import (
 	"github.com/c9s/bbgo/pkg/exchange/kucoin"
 	"github.com/c9s/bbgo/pkg/exchange/max"
 	"github.com/c9s/bbgo/pkg/exchange/okex"
+	"github.com/c9s/bbgo/pkg/exchange/mexc"
 	"github.com/c9s/bbgo/pkg/types"
 )
 
@@ -34,6 +35,9 @@ func NewExchangeStandard(n types.ExchangeName, key, secret, passphrase, subAccou
 
 	case types.ExchangeKucoin:
 		return kucoin.New(key, secret, passphrase), nil
+
+	case types.ExchangeMEXC:
+		return mexc.New(key, secret), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported exchange: %v", n)

--- a/pkg/exchange/mexc/exchange.go
+++ b/pkg/exchange/mexc/exchange.go
@@ -1,6 +1,8 @@
 package mexc
 
 import (
+	"golang.org/x/time/rate"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
@@ -20,6 +22,8 @@ import (
 )
 
 const MX = "MX"
+
+var queryLimiter = rate.NewLimiter(rate.Every(time.Second), 20)
 
 var urlTemplate url.URL = url.URL{
 	Scheme:  "https",
@@ -79,8 +83,13 @@ func (e *Exchange) publicRequest(ctx context.Context, method string, path string
 }
 
 func (e *Exchange) signRequest(ctx context.Context, method string, path string, params url.Values) ([]byte, error) {
-	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
-	params.Add("timestamp", timestamp)
+	timestamp, err := e.time(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// user time might not be synchronized with the server
+	// timestamp := time.Now().UnixMilli()
+	params.Add("timestamp", strconv.FormatInt(timestamp, 10))
 	queryString := params.Encode()
 	sign := hmac.New(sha256.New, []byte(e.secret))
 	sign.Write([]byte(queryString))
@@ -90,11 +99,12 @@ func (e *Exchange) signRequest(ctx context.Context, method string, path string, 
 	u.Path += path
 	u.RawPath += path
 	u.RawQuery = params.Encode()
+	log.Infof("%s %s, %s", u.String(), method, queryString)
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Context-Type", "application/json")
+	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-MEXC-APIKEY", e.key)
 	if e.client == nil {
 		e.client = &http.Client{
@@ -269,7 +279,7 @@ type depth struct {
 
 // MEXC doesn't have a way to query open orders' snapshot
 // Only has different depths of aggregated orders
-func (e *Exchange) QueryOpenOrders(ctx context.Context, symbol string) (orders []types.Order, err error) {
+func (e *Exchange) QueryMarketOrders(ctx context.Context, symbol string) (orders []types.Order, err error) {
 	v := url.Values{}
 	v.Set("symbol", symbol)
 	//v.Set("limit", 100)  // default: 100, max: 5000
@@ -361,32 +371,300 @@ func (e *Exchange) QueryKLines(ctx context.Context, symbol string, interval type
 	return result, nil
 }
 
-/*
-func (e *Exchange) NewStream() types.Stream {
+// private
+
+type cancelOrderResp struct {
+	Symbol              string            `json:"symbol"`
+	OrigClientOrderId   string            `json:"origClientOrderId"`
+	OrderId             string            `json:"orderId"`
+	ClientOrderId       string            `json:"clientOrderId"`
+	Price               fixedpoint.Value  `json:"price"`
+	OrigQty             fixedpoint.Value  `json:"origQty"`
+	ExecutedQty         fixedpoint.Value  `json:"executedQty"`
+	CummulativeQuoteQty fixedpoint.Value  `json:"cummulativeQuoteQty"`
+	Status              types.OrderStatus `json:"status"`
+	TimeInForce         types.TimeInForce `json:"timeInForce"`
+	Type                types.OrderType   `json:"type"`
+	Side                types.SideType    `json:"side"`
 }
+
+func (c *cancelOrderResp) ToOrder() types.Order {
+	return types.Order{
+		SubmitOrder: types.SubmitOrder{
+			ClientOrderID: c.ClientOrderId,
+			Symbol:        c.Symbol,
+			Side:          c.Side,
+			Type:          c.Type,
+			Quantity:      c.OrigQty,
+			Price:         c.Price,
+			TimeInForce:   c.TimeInForce,
+			IsFutures:     false,
+		},
+		Status:           c.Status,
+		ExecutedQuantity: c.ExecutedQty,
+	}
+}
+func (e *Exchange) CancelOrders(ctx context.Context, orders ...types.Order) (err error) {
+	var resp []byte
+	for _, o := range orders {
+		v := url.Values{}
+		v.Set("symbol", o.Symbol)
+		v.Set("orderId", strconv.FormatUint(o.OrderID, 10))
+		if len(o.UUID) > 0 {
+			v.Set("origClientOrderId", o.UUID)
+			v.Set("newClientOrderId", o.UUID)
+		}
+		resp, err = e.signRequest(ctx, "DELETE", "/order", v)
+		if err != nil {
+			log.WithError(err).Errorf("cancel failed")
+			continue
+		}
+		var result cancelOrderResp
+		json.Unmarshal(resp, &result)
+		if result.Status != types.OrderStatusCanceled &&
+			result.Status != types.OrderStatusPartiallyCanceled {
+			log.Debugf("cancel failed: OrderId: %s, Symbol: %s, Status: %s",
+				result.OrderId, result.Symbol, result.Status)
+		} else {
+			log.Debugf("cancel succeed: OrderId: %s, Symbol: %s, Status: %s",
+				result.OrderId, result.Symbol, result.Status)
+		}
+	}
+	return err
+}
+
+func (e *Exchange) CancelOrdersBySymbol(ctx context.Context, symbol string) (orders []types.Order, err error) {
+	var resp []byte
+	v := url.Values{}
+	v.Set("symbol", symbol)
+	resp, err = e.signRequest(ctx, "DELETE", "/openOrders", v)
+	if err != nil {
+		log.WithError(err).Errorf("cancel by symbol failed")
+		return orders, err
+	}
+	var results []cancelOrderResp
+	json.Unmarshal(resp, &results)
+	for _, result := range results {
+		if result.Status != types.OrderStatusCanceled &&
+			result.Status != types.OrderStatusPartiallyCanceled {
+			log.Debugf("cancel failed: OrderId: %s, Symbol: %s, Status: %s",
+				result.OrderId, result.Symbol, result.Status)
+		} else {
+			log.Debugf("cancel succeed: OrderId: %s, Symbol: %s, Status: %s",
+				result.OrderId, result.Symbol, result.Status)
+		}
+		orders = append(orders, result.ToOrder())
+	}
+	return orders, err
+}
+
+type queryOrderResp struct {
+	cancelOrderResp
+	StopPrice  fixedpoint.Value `json:"stopPrice"`
+	Time       types.Time       `json:"time"`
+	UpdateTime types.Time       `json:"updateTime"`
+	IsWorking  bool             `json:"isWorking"`
+
+	// open order query
+	IcebergQty        fixedpoint.Value `json:"icebergQty"`
+	OrigQuoteOrderQty fixedpoint.Value `json:origQuoteOrderQty`
+	OrderListId       int64            `json:"orderListId"`
+}
+
+func (q *queryOrderResp) ToOrder() types.Order {
+	order := q.cancelOrderResp.ToOrder()
+	order.StopPrice = q.StopPrice
+	order.CreationTime = q.Time
+	order.UpdateTime = q.UpdateTime
+	order.IsWorking = q.IsWorking
+	return order
+}
+
+/*{"symbol":"USTUSDT","orderId":"156198093501521920","orderListId":-1,"clientOrderId":null,"price":"0.01","origQty":"2799.81","executedQty":"0","cummulativeQuoteQty":"0","status":"NEW","timeInForce":null,"type":"LIMIT","side":"BUY","stopPrice":null,"icebergQty":null,"time":1653022763000,"updateTime":1653022763000,"isWorking":true,"origQuoteOrderQty":"27.9981"}*/
 
 func (e *Exchange) QueryOrder(ctx context.Context, q types.OrderQuery) (*types.Order, error) {
+	v := url.Values{}
+	v.Set("symbol", q.Symbol)
+	if len(q.OrderID) > 0 {
+		v.Set("orderId", q.OrderID)
+	}
+	if len(q.ClientOrderID) > 0 {
+		v.Set("origClientId", q.ClientOrderID)
+	}
+	resp, err := e.signRequest(ctx, "GET", "/order", v)
+	if err != nil {
+		log.WithError(err).Errorf("query order failed")
+		return nil, err
+	}
+	var result queryOrderResp
+	json.Unmarshal(resp, &result)
+	order := result.ToOrder()
+	return &order, nil
 }
 
-func (e *Exchange) QueryClosedOrders(ctx context.Context, symbol string, since, util time.Time, lastOrderID uint64) ([]types.Order, error) {
+/*[{"symbol":"USTUSDT","orderId":"156198093501521920","orderListId":-1,"clientOrderId":"","price":"0.01","origQty":"2799.81","executedQty":"0","cummulativeQuoteQty":"0","status":"NEW","timeInForce":null,"type":"LIMIT","side":"BUY","stopPrice":null,"icebergQty":null,"time":1653022763377,"updateTime":null,"isWorking":true,"origQuoteOrderQty":"27.9981"}]*/
+
+func (e *Exchange) QueryOpenOrders(ctx context.Context, symbol string) (orders []types.Order, err error) {
+	v := url.Values{}
+	v.Set("symbol", symbol)
+	var resp []byte
+	resp, err = e.signRequest(ctx, "GET", "/openOrders", v)
+	if err != nil {
+		log.WithError(err).Errorf("open orders query failed")
+		return orders, err
+	}
+	var results []queryOrderResp
+	json.Unmarshal(resp, &results)
+	for _, result := range results {
+		orders = append(orders, result.ToOrder())
+	}
+	return orders, err
+}
+
+func (e *Exchange) QueryClosedOrders(ctx context.Context, symbol string, since, until time.Time, lastOrderID uint64) (orders []types.Order, err error) {
+	v := url.Values{}
+	v.Set("symbol", symbol)
+	v.Set("startTime", strconv.FormatInt(since.UnixMilli(), 10))
+	v.Set("endTime", strconv.FormatInt(until.UnixMilli(), 10))
+	if lastOrderID > 0 {
+		v.Set("orderId", strconv.FormatUint(lastOrderID, 10))
+	}
+	var resp []byte
+	resp, err = e.signRequest(ctx, "GET", "/allOrders", v)
+	var results []queryOrderResp
+	json.Unmarshal(resp, &results)
+	for _, result := range results {
+		if result.Status != types.OrderStatusNew { // filled or cancelled
+			orders = append(orders, result.ToOrder())
+		}
+	}
+	return orders, err
+}
+
+// TODO: test endpoint integration
+
+func (e *Exchange) SubmitOrders(ctx context.Context, orders ...types.SubmitOrder) (createdOrders types.OrderSlice, err error) {
+	for _, o := range orders {
+		v := url.Values{}
+		v.Set("symbol", o.Symbol)
+		// BUY, SELL
+		v.Set("side", string(o.Side))
+		// LIMIT, MARKET, LIMIT_MAKER
+		v.Set("type", string(o.Type))
+		if o.Type == types.OrderTypeLimit || o.Type == types.OrderTypeLimitMaker {
+			if o.Quantity.IsZero() {
+				return createdOrders, errors.New("order quantity error: limit order should have quantity set")
+			}
+			if o.Market.Symbol != "" {
+				v.Set("quantity", o.Market.FormatQuantity(o.Quantity))
+			} else {
+				v.Set("quantity", o.Quantity.FormatString(8))
+			}
+		} else { // Market
+			if o.Side == types.SideTypeBuy {
+				if o.QuoteOrderQty.IsZero() {
+					return createdOrders, errors.New("order quoteqty error: market buy order should have quoteOrderQty set")
+				}
+				if o.Market.Symbol != "" {
+					v.Set("quoteOrderQty", o.Market.FormatVolume(o.QuoteOrderQty))
+				} else {
+					v.Set("quoteOrderQty", o.QuoteOrderQty.FormatString(8))
+				}
+			} else {
+				if o.Quantity.IsZero() {
+					return createdOrders, errors.New("order quantity error: market sell order should have quantity set")
+				}
+				if o.Market.Symbol != "" {
+					v.Set("quantity", o.Market.FormatQuantity(o.Quantity))
+				} else {
+					v.Set("quantity", o.Quantity.FormatString(8))
+				}
+			}
+		}
+		switch o.Type {
+		case types.OrderTypeLimit, types.OrderTypeLimitMaker:
+			if o.Market.Symbol != "" {
+				v.Set("price", o.Market.FormatPrice(o.Price))
+			} else {
+				v.Set("price", o.Price.FormatString(8))
+			}
+		case types.OrderTypeStopLimit:
+			return createdOrders, errors.New("stop limit order not supported")
+		}
+		// TODO: broker ID for newClientOrderId
+		var resp []byte
+		resp, err = e.signRequest(ctx, "POST", "/order", v)
+		if err != nil {
+			log.WithError(err).Errorf("submit orders failed")
+			return createdOrders, err
+		}
+		var result queryOrderResp
+		json.Unmarshal(resp, &result)
+		order := result.ToOrder()
+		order.SubmitOrder = o
+		createdOrders = append(createdOrders, order)
+	}
+	return createdOrders, err
+}
+
+type queryTradeResp struct {
+	Symbol      string           `json:"symbol"`
+	Id          uint64           `json:"id"`
+	OrderId     uint64           `json:"orderId"`
+	OrderListId int64            `json:"orderListId"`
+	Price       fixedpoint.Value `json:"price"`
+	Qty         fixedpoint.Value `json:"qty"`
+	QuoteQty    fixedpoint.Value `json:"quoteQty"`
+	Time        int64            `json:"time"`
+	//commission
+	//commissionAsset
+	IsBuyer     bool `json:"isBuyer"`
+	IsMaker     bool `json:"isMaker"`
+	IsBestMatch bool `json:"isBestMatch"`
+}
+
+func (e *Exchange) QueryTrades(ctx context.Context, symbol string, options *types.TradeQueryOptions) (trades []types.Trade, err error) {
+	v := url.Values{}
+	v.Set("symbol", symbol)
+	if options != nil {
+		if options.StartTime != nil {
+			v.Set("startTime", strconv.FormatInt(options.StartTime.UnixMilli(), 10))
+		}
+		if options.EndTime != nil {
+			v.Set("endTime", strconv.FormatInt(options.EndTime.UnixMilli(), 10))
+		}
+		if options.Limit != 0 {
+			v.Set("limit", strconv.FormatInt(options.Limit, 10))
+		}
+		// TODO: Not documented, need check
+		// there's only orderId search option
+		if options.LastTradeID != 0 {
+			v.Set("id", strconv.FormatUint(options.LastTradeID, 10))
+		}
+	}
+	var resp []byte
+	resp, err = e.signRequest(ctx, "GET", "/myTrades", v)
+	if err != nil {
+		log.WithError(err).Errorf("submit orders failed")
+		return trades, err
+	}
+	var results []queryTradeResp
+	json.Unmarshal(resp, &results)
+	return trades, err
+
+}
+
+/*
+func (e *Exchange) NewStream() types.Stream {
 }
 
 func (e *Exchange) CancelAllOrders(ctx context.Context) ([]types.Order, error) {
 }
 
-func (e *Exchange) CancelOrdersBySymbol(ctx context.Context, symbol string) ([]types.Order, error) {
-}
-
 func (e *Exchange) CancelOrdersByGroupID(ctx context.Context, groupID uint32) ([]types.Order, error) {
 }
 
-func (e *Exchange) CancelOrders(ctx context.Context, ordrs ...types.Order) (err error) {
-}
-
 func (e *Exchange) Withdrawal(ctx context.Context, asset string, amount fixedpoint.Value, address string, options *types.WithdrawalOptions) error {
-}
-
-func (e *Exchange) SubmitOrders(ctx context.Context, orders ...types.SubmitOrder) (createdOrders types.OrderSlice, err error) {
 }
 
 func (e *Exchange) QueryAccount(ctx context.Context) (*types.Account, error) {
@@ -401,10 +679,7 @@ func (e *Exchange) QueryDepositHistory(ctx context.Context, asset string, since,
 func (e *Exchange) QueryAccountBalance(ctx contexxt.Context) (types.BalanceMap, error) {
 }
 
-func (e *Exchange) QueryTrades(ctx context.Context, symbol string, options *types.TradeQueryOptions) (trades []types.Trade, err error) {
-}
-
 func (e *Exchange) QueryRewards(ctx context.Context, startTime time.Time) ([]types.Reward, error) {
 }
-
-var _ types.Exchange = &Exchange{}*/
+*/
+//var _ types.Exchange = &Exchange{}

--- a/pkg/exchange/mexc/exchange.go
+++ b/pkg/exchange/mexc/exchange.go
@@ -1,0 +1,155 @@
+package mexc
+
+import (
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+
+	"time"
+	"crypto/tls"
+	"crypto/hmac"
+	"net/http"
+	"net/url"
+)
+
+const MX = "MX"
+const apiURL = "https://api.mexc.com/api/v3"
+const urlTemplate = net.URL{
+	Scheme: "https",
+	Host: apiURL,
+}
+
+var log = logrus.WithFields("exchange", "mexc")
+
+type Exchange struct {
+	key, secret string
+	client *http.Client
+}
+
+func (e *Exchange) Name() types.ExchangeName {
+	return types.ExchangeMEXC
+}
+
+func (e *Exchange) PlatformFeeCurrency() string {
+	return MX
+}
+
+func (e *Exchange) publicRequest(ctx context.Context, method string, path string, params url.Values) (*http.Response, error) {
+	u := urlTemplate
+	u.Path = path
+	u.RawQuery = params.Encode()
+	req, err := http.NewRequestWithContext(ctx, method, u.String())
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("X-MEXC-APIKEY", e.key)
+	if e.client == nil {
+		e.client = &http.Client {
+			Transport: &http.Transport{
+				MaxIdleConns: 10,
+				IdleConnTimeout: 30 * time.Second,
+			}
+		}
+	}
+	return e.client.Do(req)
+}
+
+func (e *Exchange) signRequest(ctx context.Context, method string, path string, params url.Values) (*http.Response, error) {
+	timestamp := strconv.Itoa(time.Now().Unix())
+	params.Add("timestamp", timestamp)
+	queryString := params.Encode()
+	sign := hmac.New(sha256.New, []byte(e.secret))
+	sign.Write(queryString)
+	signature := fmt.Sprintf("%x", sign.Sum64())
+	params.Add("signature", signature)
+	u := urlTemplate
+	u.Path = path
+	u.RawQuery = params.Encode()
+	req, err := http.NewRequestWithContext(ctx, method, u.String())
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Context-Type", "application/json")
+	req.Header.Add("X-MEXC-APIKEY", e.key)
+	if e.client == nil {
+		e.client = &http.Client {
+			Transport: &http.Transport {
+				MaxIdleConns: 10,
+				IdleConnTimeout: 30 * time.Second,
+			}
+		}
+	}
+	return e.client.Do(req)
+}
+
+func (e *Exchange) ping() {
+}
+
+func (e *Exchange) time() {
+
+}
+
+func (e *Exchange) QueryTicker(ctx context.Context, symbol string) (*types.Ticker, error) {
+}
+
+func (e *Exchange) QueryTickers(ctx context.Context, symbol ...string) (map[string]types.Ticker, error) {
+}
+
+func (e *Exchange) QueryMarkets(ctx context.Context) (types.MarketMap, error) {
+}
+
+func (e *Exchange) NewStream() types.Stream {
+}
+
+func (e *Exchange) QueryOrder(ctx context.Context, q types.OrderQuery) (*types.Order, error) {
+}
+
+func (e *Exchange) QueryOpenOrders(ctx context.Context, symbol string) (orders []types.Order, error) {
+}
+
+func (e *Exchange) QueryClosedOrders(ctx context.Context, symbol string, since, util time.Time, lastOrderID uint64) ([]types.Order, error) {
+}
+
+func (e *Exchange) CancelAllOrders(ctx context.Context) ([]types.Order, error) {
+}
+
+func (e *Exchange) CancelOrdersBySymbol(ctx context.Context, symbol string) ([]types.Order, error) {
+}
+
+func (e *Exchange) CancelOrdersByGroupID(ctx context.Context, groupID uint32) ([]types.Order, error) {
+}
+
+func (e *Exchange) CancelOrders(ctx context.Context, ordrs ...types.Order) (err error) {
+}
+
+func (e *Exchange) Withdrawal(ctx context.Context, asset string, amount fixedpoint.Value, address string, options *types.WithdrawalOptions) error {
+}
+
+func (e *Exchange) SubmitOrders(ctx context.Context, orders ...types.SubmitOrder) (createdOrders types.OrderSlice, err error) {
+}
+
+func (e *Exchange) QueryAccount(ctx context.Context) (*types.Account, error) {
+}
+
+func (e *Exchange) QueryWithdrawHistory(ctx context.Context, asset string, since, until time.Time) (allWithdraws []types.Withdraw, err error) {
+}
+
+func (e *Exchange) QueryDepositHistory(ctx context.Context, asset string, since, until time.Time) (allDeposits []types.Deposit, err error) {
+}
+
+func (e *Exchange) QueryAccountBalance(ctx contexxt.Context) (types.BalanceMap, error) {
+}
+
+func (e *Exchange) QueryTrades(ctx context.Context, symbol string, options *types.TradeQueryOptions) (trades []types.Trade, err error) {
+}
+
+func (e *Exchange) QueryRewards(ctx context.Context, startTime time.Time) ([]types.Reward, error) {
+}
+
+func (e *Exchange) QueryKLines(ctx context.Context, symbol string, interval types.Interval, options types.KLineQueryOptions) ([]types.KLine, error) {
+}
+
+var _ types.Exchange = &Exchange{}

--- a/pkg/exchange/mexc/exchange_test.go
+++ b/pkg/exchange/mexc/exchange_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
 )
 
@@ -90,4 +91,11 @@ func Test_QueryOpenOrders(t *testing.T) {
 	t.Skip("private api skip")
 	assert.Equal(t, err, nil)
 	assert.Greater(t, len(orders), 0)
+}
+
+func Test_QueryAccount(t *testing.T) {
+	ex := getExchange(t)
+	account, err := ex.QueryAccount(context.Background())
+	assert.Equal(t, err, nil)
+	assert.Greater(t, account.TakerFeeRate, fixedpoint.Zero)
 }

--- a/pkg/exchange/mexc/exchange_test.go
+++ b/pkg/exchange/mexc/exchange_test.go
@@ -1,14 +1,16 @@
 package mexc
 
 import (
-	"time"
 	"context"
-	"testing"
-	"os"
 	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/c9s/bbgo/pkg/types"
 )
 
-func getExchange(t *testing.T) (*Exchange) {
+func getExchange(t *testing.T) *Exchange {
 	key := os.Getenv("MEXC_API_KEY")
 	secret := os.Getenv("MEXC_API_SECRET")
 	if len(key) == 0 || len(secret) == 0 {
@@ -35,4 +37,41 @@ func Test_Ticker(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.True(t, ticker.High.Compare(ticker.Low) > 0)
 	assert.InDelta(t, ticker.Time.UnixMilli(), time.Now().UnixMilli(), 86400_000)
+}
+
+func Test_Tickers(t *testing.T) {
+	ex := getExchange(t)
+	tickers, err := ex.QueryTickers(context.Background(), "APEUSDT", "ETHUSDT")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(tickers), 2)
+	assert.InDelta(t, tickers["APEUSDT"].Time.UnixMilli(), time.Now().UnixMilli(), 86400_000)
+	assert.InDelta(t, tickers["ETHUSDT"].Time.UnixMilli(), time.Now().UnixMilli(), 86400_000)
+
+	tickers, err = ex.QueryTickers(context.Background())
+	assert.Equal(t, err, nil)
+	assert.Greater(t, len(tickers), 100) // 1980 symbols @ 19/5/2022
+}
+
+func Test_Markets(t *testing.T) {
+	ex := getExchange(t)
+	markets, err := ex.QueryMarkets(context.Background())
+	assert.Equal(t, err, nil)
+	assert.Greater(t, len(markets), 0)
+	assert.Equal(t, markets["MXUSDT"].PricePrecision, 4)
+	assert.Equal(t, markets["MXUSDT"].VolumePrecision, 2)
+}
+
+func Test_OpenOrders(t *testing.T) {
+	ex := getExchange(t)
+	orders, err := ex.QueryOpenOrders(context.Background(), "MXUSDT")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(orders), 200)
+}
+
+func Test_KLines(t *testing.T) {
+	ex := getExchange(t)
+	klines, err := ex.QueryKLines(context.Background(), "MXUSDT", types.Interval5m,
+		types.KLineQueryOptions{})
+	assert.Equal(t, err, nil)
+	assert.Equal(t, len(klines), 500)
 }

--- a/pkg/exchange/mexc/exchange_test.go
+++ b/pkg/exchange/mexc/exchange_test.go
@@ -1,0 +1,38 @@
+package mexc
+
+import (
+	"time"
+	"context"
+	"testing"
+	"os"
+	"github.com/stretchr/testify/assert"
+)
+
+func getExchange(t *testing.T) (*Exchange) {
+	key := os.Getenv("MEXC_API_KEY")
+	secret := os.Getenv("MEXC_API_SECRET")
+	if len(key) == 0 || len(secret) == 0 {
+		t.Skip("api key/secret not configured")
+	}
+	return &Exchange{key, secret, nil}
+}
+
+func Test_Ping(t *testing.T) {
+	ex := getExchange(t)
+	assert.True(t, ex.ping(context.Background()))
+}
+
+func Test_Time(t *testing.T) {
+	ex := getExchange(t)
+	timestamp, err := ex.time(context.Background())
+	assert.Equal(t, err, nil)
+	assert.InDelta(t, timestamp, time.Now().UnixMilli(), 60000)
+}
+
+func Test_Ticker(t *testing.T) {
+	ex := getExchange(t)
+	ticker, err := ex.QueryTicker(context.Background(), "APEUSDT")
+	assert.Equal(t, err, nil)
+	assert.True(t, ticker.High.Compare(ticker.Low) > 0)
+	assert.InDelta(t, ticker.Time.UnixMilli(), time.Now().UnixMilli(), 86400_000)
+}

--- a/pkg/exchange/mexc/exchange_test.go
+++ b/pkg/exchange/mexc/exchange_test.go
@@ -61,9 +61,9 @@ func Test_Markets(t *testing.T) {
 	assert.Equal(t, markets["MXUSDT"].VolumePrecision, 2)
 }
 
-func Test_OpenOrders(t *testing.T) {
+func Test_MarketOrders(t *testing.T) {
 	ex := getExchange(t)
-	orders, err := ex.QueryOpenOrders(context.Background(), "MXUSDT")
+	orders, err := ex.QueryMarketOrders(context.Background(), "MXUSDT")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(orders), 200)
 }
@@ -74,4 +74,20 @@ func Test_KLines(t *testing.T) {
 		types.KLineQueryOptions{})
 	assert.Equal(t, err, nil)
 	assert.Equal(t, len(klines), 500)
+}
+
+func Test_QueryOrder(t *testing.T) {
+	ex := getExchange(t)
+	order, err := ex.QueryOrder(context.Background(), types.OrderQuery{Symbol: "USTUSDT", OrderID: "156198093501521920"})
+	t.Skip("private api skip")
+	assert.Equal(t, err, nil)
+	assert.NotEqual(t, order, nil)
+}
+
+func Test_QueryOpenOrders(t *testing.T) {
+	ex := getExchange(t)
+	orders, err := ex.QueryOpenOrders(context.Background(), "USTUSDT")
+	t.Skip("private api skip")
+	assert.Equal(t, err, nil)
+	assert.Greater(t, len(orders), 0)
 }

--- a/pkg/exchange/mexc/stream.go
+++ b/pkg/exchange/mexc/stream.go
@@ -1,0 +1,40 @@
+package mexc
+
+import (
+	"context"
+
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+//go:generate callbackgen -types Stream -interface
+type Stream struct {
+	types.StandardStream
+}
+
+func NewStream(ex *Exchange) *Stream {
+	stream := &Stream {
+		StandardStream: types.NewStandardStream(),
+	}
+	return stream
+}
+
+func (s *Stream) handleDisconnect() {
+}
+
+func (s *Stream) handleConnect() {
+}
+
+func (s *Stream) Subscribe(channel types.Channel, symbol string, options types.SubscribeOptions) {
+}
+
+func (s *Stream) SetPublicOnly() {
+}
+
+func (s *Stream) Connect(ctx context.Context) error {
+	return nil
+}
+
+func (s *Stream) Close() error {
+	return nil
+}
+var _ types.Stream = &Stream{}

--- a/pkg/types/exchange.go
+++ b/pkg/types/exchange.go
@@ -26,7 +26,7 @@ func (n *ExchangeName) UnmarshalJSON(data []byte) error {
 	}
 
 	switch s {
-	case "max", "binance", "ftx", "okex":
+	case "max", "binance", "ftx", "okex", "mexc":
 		*n = ExchangeName(s)
 		return nil
 
@@ -45,10 +45,11 @@ const (
 	ExchangeFTX      = ExchangeName("ftx")
 	ExchangeOKEx     = ExchangeName("okex")
 	ExchangeKucoin   = ExchangeName("kucoin")
+	ExchangeMEXC     = ExchangeName("mexc")
 	ExchangeBacktest = ExchangeName("backtest")
 )
 
-var SupportedExchanges = []ExchangeName{"binance", "max", "ftx", "okex", "kucoin"}
+var SupportedExchanges = []ExchangeName{"binance", "max", "ftx", "okex", "kucoin", "mexc"}
 
 func ValidExchangeName(a string) (ExchangeName, error) {
 	switch strings.ToLower(a) {
@@ -62,6 +63,8 @@ func ValidExchangeName(a string) (ExchangeName, error) {
 		return ExchangeOKEx, nil
 	case "kucoin":
 		return ExchangeKucoin, nil
+	case "mexc":
+		return ExchangeMEXC, nil
 	}
 
 	return "", fmt.Errorf("invalid exchange name: %s", a)

--- a/pkg/types/interval.go
+++ b/pkg/types/interval.go
@@ -41,6 +41,7 @@ func (s IntervalSlice) StringSlice() (slice []string) {
 }
 
 var Interval1m = Interval("1m")
+var Interval3m = Interval("3m")
 var Interval5m = Interval("5m")
 var Interval15m = Interval("15m")
 var Interval30m = Interval("30m")
@@ -48,12 +49,16 @@ var Interval1h = Interval("1h")
 var Interval2h = Interval("2h")
 var Interval4h = Interval("4h")
 var Interval6h = Interval("6h")
+var Interval8h = Interval("8h")
 var Interval12h = Interval("12h")
 var Interval1d = Interval("1d")
 var Interval3d = Interval("3d")
+var Interval1w = Interval("1w")
+var Interval1M = Interval("1M")
 
 var SupportedIntervals = map[Interval]int{
 	Interval1m:  1,
+	Interval3m:  3,
 	Interval5m:  5,
 	Interval15m: 15,
 	Interval30m: 30,
@@ -61,9 +66,12 @@ var SupportedIntervals = map[Interval]int{
 	Interval2h:  60 * 2,
 	Interval4h:  60 * 4,
 	Interval6h:  60 * 6,
+	Interval8h:  60 * 8,
 	Interval12h: 60 * 12,
 	Interval1d:  60 * 24,
 	Interval3d:  60 * 24 * 3,
+	Interval1w:  60 * 24 * 7,
+	Interval1M:  60 * 24 * 30, // FIXME: by month
 }
 
 // IntervalWindow is used by the indicators

--- a/pkg/types/order.go
+++ b/pkg/types/order.go
@@ -105,6 +105,9 @@ const (
 	// OrderStatusCanceled means the order is canceled without partially filled or filled.
 	OrderStatusCanceled OrderStatus = "CANCELED"
 
+	// OrderStatusPartiallyCanceled means the order is partially-filled, and been canceled in the end.
+	OrderStatusPartiallyCanceled OrderStatus = "PARTIALLY_CANCELED"
+
 	// OrderStatusRejected means the order is not placed successfully, it's rejected by the api
 	OrderStatusRejected OrderStatus = "REJECTED"
 )
@@ -116,9 +119,10 @@ type SubmitOrder struct {
 	Side   SideType  `json:"side" db:"side"`
 	Type   OrderType `json:"orderType" db:"order_type"`
 
-	Quantity  fixedpoint.Value `json:"quantity" db:"quantity"`
-	Price     fixedpoint.Value `json:"price" db:"price"`
-	StopPrice fixedpoint.Value `json:"stopPrice,omitempty" db:"stop_price"`
+	Quantity      fixedpoint.Value `json:"quantity" db:"quantity"`
+	QuoteOrderQty fixedpoint.Value `json:"quoteOrderQuantity" db:"quoteOrderQuantity"`
+	Price         fixedpoint.Value `json:"price" db:"price"`
+	StopPrice     fixedpoint.Value `json:"stopPrice,omitempty" db:"stop_price"`
 
 	Market Market `json:"-" db:"-"`
 


### PR DESCRIPTION
Add support for MEXC exchange.
https://m.mexc.com/auth/signup?inviteCode=18RW6
resolves #616   

 ## Checklist

Exchange Interface - the minimum requirement for spot trading

- [x] QueryMarkets
- [x] QueryTickers
- [x] QueryOpenOrders
- [x] SubmitOrders
- [x] CancelOrders
- [x] NewStream

Trading History Service Interface - (optional) used for syncing user trading data

- [ ] QueryClosedOrders
- [ ] QueryTrades

Order Query Service Interface - (optional) used for querying order status

- [ ] QueryOrder

Back-testing service - kline data is used for back-testing

- [x] QueryKLines

Convert functions:

- [ ] MarketData convert functions
  - [ ] toGlobalMarket
  - [ ] toGlobalTicker
  - [ ] toGlobalKLine
- [ ] UserData convert functions
  - [ ] toGlobalOrder
  - [ ] toGlobalTrade
  - [ ] toGlobalAccount
  - [ ] toGlobalBalance

Stream

- [ ] UserDataStream
  - [ ] Trade message parser
  - [ ] Order message parser
  - [ ] Account message parser
  - [ ] Balance message parser
- [ ] MarketDataStream
  - [ ] OrderBook message parser (or depth)
  - [ ] KLine message parser (required for backtesting)
  - [ ] Public trade message parser (optional)
  - [ ] Ticker message parser (optional)
- [ ] ping/pong handling.
- [ ] heart-beat hanlding or keep-alive handling.
- [ ] handling reconnect

Database

- [ ] Add a new kline table for the exchange (this is required for back-testing)
  - [ ] Add MySQL migration SQL
  - [ ] Add SQLite migration SQL

Exchange Factory

- [ ] Add the exchange constructor to the exchange instance factory function.
- [ ] Add extended fields to the ExchangeSession struct. (optional)