### PR TITLE
strategy: add supertrend strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,9 @@ Check out the strategy directory [strategy](pkg/strategy) for all built-in strat
   indicator [bollgrid](pkg/strategy/bollgrid)
 - `grid` strategy implements the fixed price band grid strategy [grid](pkg/strategy/grid). See
   [document](./doc/strategy/grid.md).
-- `support` strategy implements the fixed price band grid strategy [support](pkg/strategy/support). See
+- `supertrend` strategy uses Supertrend indicator as trend, and DEMA indicator as noise filter [supertrend](pkg/strategy/supertrend). See
+  [document](./doc/strategy/supertrend.md).
+- `support` strategy uses K-lines with high volume as support [support](pkg/strategy/support). See
   [document](./doc/strategy/support.md).
 - `flashcrash` strategy implements a strategy that catches the flashcrash [flashcrash](pkg/strategy/flashcrash)
 

--- a/config/supertrend.yaml
+++ b/config/supertrend.yaml
@@ -46,3 +46,12 @@ exchangeStrategies:
       averageTrueRangeWindow: 39
       # ATR Multiplier for calculating super trend prices, the higher, the stronger the trends are
       averageTrueRangeMultiplier: 3
+
+    # TP according to ATR multiple, 0 to disable this
+    takeProfitMultiplier: 3
+
+    # Set SL price to the low of the triggering Kline
+    stopLossByTriggeringK: true
+
+    # TP/SL by reversed signals
+    tpslBySignal: true

--- a/config/supertrend.yaml
+++ b/config/supertrend.yaml
@@ -1,0 +1,48 @@
+---
+persistence:
+  redis:
+    host: 127.0.0.1
+    port: 6379
+    db: 0
+
+sessions:
+  binance:
+    exchange: binance
+    envVarPrefix: binance
+
+backtest:
+  sessions: [binance]
+  # for testing max draw down (MDD) at 03-12
+  # see here for more details
+  # https://www.investopedia.com/terms/m/maximum-drawdown-mdd.asp
+  startTime: "2022-04-01"
+  endTime: "2022-04-30"
+  symbols:
+  - BTCUSDT
+  accounts:
+    binance:
+      makerCommission: 10  # 0.15%
+      takerCommission: 15  # 0.15%
+      balances:
+        BTC: 1.0
+        USDT: 10000.0
+
+exchangeStrategies:
+- on: binance
+  supertrend:
+    symbol: BTCUSDT
+
+    # interval is how long do you want to update your order price and quantity
+    interval: 1h
+
+    # leverage is the leverage of the orders
+    leverage: 1
+
+    # fastDEMAWindow and slowDEMAWindow are for filtering super trend noise
+    fastDEMAWindow: 144
+    slowDEMAWindow: 169
+
+    superTrend:
+      averageTrueRangeWindow: 39
+      # ATR Multiplier for calculating super trend prices, the higher, the stronger the trends are
+      averageTrueRangeMultiplier: 3

--- a/config/supertrend.yaml
+++ b/config/supertrend.yaml
@@ -36,7 +36,7 @@ exchangeStrategies:
     interval: 1h
 
     # leverage is the leverage of the orders
-    leverage: 1
+    leverage: 1.0
 
     # fastDEMAWindow and slowDEMAWindow are for filtering super trend noise
     fastDEMAWindow: 144

--- a/config/supertrend.yaml
+++ b/config/supertrend.yaml
@@ -45,7 +45,9 @@ exchangeStrategies:
     fastDEMAWindow: 144
     slowDEMAWindow: 169
 
+    # Supertrend indicator parameters
     superTrend:
+      # ATR window used by Supertrend
       averageTrueRangeWindow: 39
       # ATR Multiplier for calculating super trend prices, the higher, the stronger the trends are
       averageTrueRangeMultiplier: 3

--- a/config/supertrend.yaml
+++ b/config/supertrend.yaml
@@ -9,6 +9,9 @@ sessions:
   binance:
     exchange: binance
     envVarPrefix: binance
+    margin: true
+    isolatedMargin: true
+    isolatedMarginSymbol: BTCUSDT
 
 backtest:
   sessions: [binance]

--- a/doc/README.md
+++ b/doc/README.md
@@ -22,6 +22,7 @@
 * [Grid](strategy/grid.md) - Grid Strategy Explanation
 * [Interaction](strategy/interaction.md) - Interaction registration for strategies
 * [Price Alert](strategy/pricealert.md) - Send price alert notification on price changes
+* [Supertrend](strategy/supertrend.md) - Supertrend strategy uses Supertrend indicator as trend, and DEMA indicator as noise filter
 * [Support](strategy/support.md) - Support strategy that buys on high volume support
 
 ### Development

--- a/doc/strategy/supertrend.md
+++ b/doc/strategy/supertrend.md
@@ -1,0 +1,29 @@
+### Supertrend Strategy
+
+This strategy uses Supertrend indicator as trend, and DEMA indicator as noise filter.
+This strategy needs margin enabled in order to submit short orders, but you can use `leverage` parameter to limit your risk.
+
+
+#### Parameters
+
+- `symbol`
+    - The trading pair symbol, e.g., `BTCUSDT`, `ETHUSDT`
+- `interval`
+    - The K-line interval, e.g., `5m`, `1h`
+- `leverage`
+    - The leverage of the orders.  
+- `fastDEMAWindow`
+    - The MA window of the fast DEMA.
+- `slowDEMAWindow`
+    - The MA window of the slow DEMA.
+- `superTrend`
+    - Supertrend indicator for deciding current trend.
+    - `averageTrueRangeWindow`
+        - The MA window of the ATR indicator used by Supertrend. 
+    - `averageTrueRangeMultiplier`
+        - Multiplier for calculating upper and lower bond prices, the higher, the stronger the trends are, but also makes it less sensitive.
+
+
+#### Examples
+
+See [supertrend.yaml](../../config/supertrend.yaml)

--- a/doc/strategy/supertrend.md
+++ b/doc/strategy/supertrend.md
@@ -22,6 +22,12 @@ This strategy needs margin enabled in order to submit short orders, but you can 
         - The MA window of the ATR indicator used by Supertrend. 
     - `averageTrueRangeMultiplier`
         - Multiplier for calculating upper and lower bond prices, the higher, the stronger the trends are, but also makes it less sensitive.
+- `takeProfitMultiplier`
+    - TP according to ATR multiple, 0 to disable this.
+- `stopLossByTriggeringK`
+    - Set SL price to the low of the triggering Kline.
+- `tpslBySignal`
+    - TP/SL by reversed signals.
 
 
 #### Examples

--- a/doc/strategy/supertrend.md
+++ b/doc/strategy/supertrend.md
@@ -1,7 +1,8 @@
 ### Supertrend Strategy
 
 This strategy uses Supertrend indicator as trend, and DEMA indicator as noise filter.
-This strategy needs margin enabled in order to submit short orders, but you can use `leverage` parameter to limit your risk.
+Supertrend strategy needs margin enabled in order to submit short orders, and you can use `leverage` parameter to limit your risk.
+**Please note, using leverage higher than 1 is highly risky.**
 
 
 #### Parameters

--- a/pkg/cmd/builtin.go
+++ b/pkg/cmd/builtin.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/c9s/bbgo/pkg/strategy/rebalance"
 	_ "github.com/c9s/bbgo/pkg/strategy/schedule"
 	_ "github.com/c9s/bbgo/pkg/strategy/skeleton"
+	_ "github.com/c9s/bbgo/pkg/strategy/supertrend"
 	_ "github.com/c9s/bbgo/pkg/strategy/support"
 	_ "github.com/c9s/bbgo/pkg/strategy/swing"
 	_ "github.com/c9s/bbgo/pkg/strategy/techsignal"

--- a/pkg/strategy/supertrend/strategy.go
+++ b/pkg/strategy/supertrend/strategy.go
@@ -289,13 +289,6 @@ func (s *Strategy) calculateQuantity(currentPrice fixedpoint.Value) fixedpoint.V
 	return quantity
 }
 
-func (s *Strategy) HasTradableBase(currentPrice fixedpoint.Value) bool {
-	if s.Market.IsDustQuantity(s.Position.GetBase().Abs(), currentPrice) {
-		return false
-	}
-	return true
-}
-
 func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, session *bbgo.ExchangeSession) error {
 	s.session = session
 	s.Market, _ = session.Market(s.Symbol)

--- a/pkg/strategy/supertrend/strategy.go
+++ b/pkg/strategy/supertrend/strategy.go
@@ -1,0 +1,310 @@
+package supertrend
+
+import (
+	"context"
+	"fmt"
+	"github.com/c9s/bbgo/pkg/bbgo"
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/indicator"
+	"github.com/c9s/bbgo/pkg/types"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"math"
+)
+
+// TODO:
+// 1. Position control
+// 2. Strategy control
+
+const ID = "supertrend"
+
+const stateKey = "state-v1"
+
+var NotionalModifier = fixedpoint.NewFromFloat(1.0001)
+
+var zeroiw = types.IntervalWindow{}
+
+var log = logrus.WithField("strategy", ID)
+
+func init() {
+	// Register the pointer of the strategy struct,
+	// so that bbgo knows what struct to be used to unmarshal the configs (YAML or JSON)
+	// Note: built-in strategies need to imported manually in the bbgo cmd package.
+	bbgo.RegisterStrategy(ID, &Strategy{})
+}
+
+type SuperTrend struct {
+	// AverageTrueRangeWindow ATR window for calculation of supertrend
+	AverageTrueRangeWindow types.IntervalWindow `json:"averageTrueRangeWindow"`
+	// AverageTrueRangeMultiplier ATR multiplier for calculation of supertrend
+	AverageTrueRangeMultiplier float64 `json:"averageTrueRangeMultiplier"`
+
+	AverageTrueRange *indicator.ATR
+
+	closePrice         float64
+	lastClosePrice     float64
+	uptrendPrice       float64
+	lastUptrendPrice   float64
+	downtrendPrice     float64
+	lastDowntrendPrice float64
+
+	trend       types.Direction
+	lastTrend   types.Direction
+	tradeSignal types.Direction
+}
+
+// Update SuperTrend indicator
+func (st *SuperTrend) Update(kline types.KLine) {
+	highPrice := kline.GetHigh().Float64()
+	lowPrice := kline.GetLow().Float64()
+	closePrice := kline.GetClose().Float64()
+
+	// Update ATR
+	st.AverageTrueRange.Update(highPrice, lowPrice, closePrice)
+
+	// Update last prices
+	st.lastUptrendPrice = st.uptrendPrice
+	st.lastDowntrendPrice = st.downtrendPrice
+	st.lastClosePrice = st.closePrice
+	st.lastTrend = st.trend
+
+	st.closePrice = closePrice
+
+	src := (highPrice + lowPrice) / 2
+
+	// Update uptrend
+	st.uptrendPrice = src - st.AverageTrueRange.Last()*st.AverageTrueRangeMultiplier
+	if st.lastClosePrice > st.lastUptrendPrice {
+		st.uptrendPrice = math.Max(st.uptrendPrice, st.lastUptrendPrice)
+	}
+
+	// Update downtrend
+	st.downtrendPrice = src + st.AverageTrueRange.Last()*st.AverageTrueRangeMultiplier
+	if st.lastClosePrice < st.lastDowntrendPrice {
+		st.downtrendPrice = math.Min(st.downtrendPrice, st.lastDowntrendPrice)
+	}
+
+	// Update trend
+	if st.lastTrend == types.DirectionUp && st.closePrice < st.lastUptrendPrice {
+		st.trend = types.DirectionDown
+	} else if st.lastTrend == types.DirectionDown && st.closePrice > st.lastDowntrendPrice {
+		st.trend = types.DirectionUp
+	} else {
+		st.trend = st.lastTrend
+	}
+
+	// Update signal
+	if st.trend == types.DirectionUp && st.lastTrend == types.DirectionDown {
+		st.tradeSignal = types.DirectionUp
+	} else if st.trend == types.DirectionDown && st.lastTrend == types.DirectionUp {
+		st.tradeSignal = types.DirectionDown
+	} else {
+		st.tradeSignal = types.DirectionNone
+	}
+}
+
+// GetSignal returns SuperTrend signal
+func (st *SuperTrend) GetSignal() types.Direction {
+	return st.tradeSignal
+}
+
+type Strategy struct {
+	*bbgo.Graceful
+	*bbgo.Notifiability
+	*bbgo.Persistence
+
+	Environment          *bbgo.Environment
+	StandardIndicatorSet *bbgo.StandardIndicatorSet
+	session              *bbgo.ExchangeSession
+	Market               types.Market
+
+	// persistence fields
+	Position    *types.Position    `json:"position,omitempty" persistence:"position"`
+	ProfitStats *types.ProfitStats `json:"profitStats,omitempty" persistence:"profit_stats"`
+
+	// Order and trade
+	orderStore     *bbgo.OrderStore
+	tradeCollector *bbgo.TradeCollector
+	// groupID is the group ID used for the strategy instance for canceling orders
+	groupID uint32
+
+	// Symbol is the market symbol you want to trade
+	Symbol string `json:"symbol"`
+
+	// Interval is how long do you want to update your order price and quantity
+	Interval types.Interval `json:"interval"`
+
+	// FastDEMA DEMA window for checking breakout
+	FastDEMAWindow types.IntervalWindow `json:"fastDEMAWindow"`
+	// SlowDEMA DEMA window for checking breakout
+	SlowDEMAWindow types.IntervalWindow `json:"slowDEMAWindow"`
+	FastDEMA       *indicator.DEMA
+	SlowDEMA       *indicator.DEMA
+
+	// SuperTrend indicator
+	SuperTrend SuperTrend `json:"superTrend"`
+
+	bbgo.QuantityOrAmount
+
+	// StrategyController
+	bbgo.StrategyController
+}
+
+func (s *Strategy) ID() string {
+	return ID
+}
+
+func (s *Strategy) InstanceID() string {
+	return fmt.Sprintf("%s:%s", ID, s.Symbol)
+}
+
+func (s *Strategy) Validate() error {
+	if len(s.Symbol) == 0 {
+		return errors.New("symbol is required")
+	}
+
+	// TODO: Validate DEMA window and ATR window
+	return nil
+}
+
+func (s *Strategy) Subscribe(session *bbgo.ExchangeSession) {
+	session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.Interval})
+
+	if s.FastDEMAWindow != zeroiw {
+		session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.FastDEMAWindow.Interval})
+	}
+
+	if s.SlowDEMAWindow != zeroiw {
+		session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.SlowDEMAWindow.Interval})
+	}
+
+	session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.SuperTrend.AverageTrueRangeWindow.Interval})
+}
+
+func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, session *bbgo.ExchangeSession) error {
+	s.session = session
+	s.Market, _ = session.Market(s.Symbol)
+
+	// If position is nil, we need to allocate a new position for calculation
+	if s.Position == nil {
+		s.Position = types.NewPositionFromMarket(s.Market)
+	}
+	// Always update the position fields
+	s.Position.Strategy = ID
+	s.Position.StrategyInstanceID = s.InstanceID()
+
+	if s.ProfitStats == nil {
+		s.ProfitStats = types.NewProfitStats(s.Market)
+	}
+
+	s.orderStore = bbgo.NewOrderStore(s.Symbol)
+	s.orderStore.BindStream(session.UserDataStream)
+
+	// StrategyController
+	s.Status = types.StrategyStatusRunning
+
+	// Setup indicators
+	if s.FastDEMAWindow != zeroiw {
+		s.FastDEMA = &indicator.DEMA{IntervalWindow: s.FastDEMAWindow}
+	}
+	if s.SlowDEMAWindow != zeroiw {
+		s.SlowDEMA = &indicator.DEMA{IntervalWindow: s.SlowDEMAWindow}
+	}
+	s.SuperTrend.AverageTrueRange = &indicator.ATR{IntervalWindow: s.SuperTrend.AverageTrueRangeWindow}
+	s.SuperTrend.trend = types.DirectionUp
+	// TODO: Use initializer
+
+	session.MarketDataStream.OnKLineClosed(func(kline types.KLine) {
+		// skip k-lines from other symbols
+		if kline.Symbol != s.Symbol {
+			return
+		}
+
+		closePrice := kline.GetClose().Float64()
+		openPrice := kline.GetOpen().Float64()
+
+		// Update indicators
+		if kline.Interval == s.FastDEMA.Interval {
+			s.FastDEMA.Update(closePrice)
+		}
+		if kline.Interval == s.SlowDEMA.Interval {
+			s.SlowDEMA.Update(closePrice)
+		}
+		if kline.Interval == s.SuperTrend.AverageTrueRange.Interval {
+			s.SuperTrend.Update(kline)
+		}
+
+		if kline.Symbol != s.Symbol || kline.Interval != s.Interval {
+			return
+		}
+
+		// Get signals
+		stSignal := s.SuperTrend.GetSignal()
+		var demaSignal types.Direction
+		if closePrice > s.FastDEMA.Last() && closePrice > s.SlowDEMA.Last() && !(openPrice > s.FastDEMA.Last() && openPrice > s.SlowDEMA.Last()) {
+			demaSignal = types.DirectionUp
+		} else if closePrice < s.FastDEMA.Last() && closePrice < s.SlowDEMA.Last() && !(openPrice < s.FastDEMA.Last() && openPrice < s.SlowDEMA.Last()) {
+			demaSignal = types.DirectionDown
+		} else {
+			demaSignal = types.DirectionNone
+		}
+
+		// TODO: TP/SL
+
+		// Place order
+		var side types.SideType
+		if stSignal == types.DirectionUp && demaSignal == types.DirectionUp {
+			side = types.SideTypeBuy
+		} else if stSignal == types.DirectionDown && demaSignal == types.DirectionDown {
+			side = types.SideTypeSell
+		}
+		quantity := s.CalculateQuantity(fixedpoint.NewFromFloat(closePrice))
+
+		if side == types.SideTypeSell || side == types.SideTypeBuy {
+			orderForm := types.SubmitOrder{
+				Symbol:   s.Symbol,
+				Market:   s.Market,
+				Side:     side,
+				Type:     types.OrderTypeMarket,
+				Quantity: quantity,
+			}
+			log.Infof("%v", orderForm)
+
+			createdOrder, err := s.session.Exchange.SubmitOrders(ctx, orderForm)
+			if err != nil {
+				log.WithError(err).Errorf("can not place order")
+			}
+			s.orderStore.Add(createdOrder...)
+		}
+
+		// check if there is a canceled order had partially filled.
+		s.tradeCollector.Process()
+	})
+
+	s.tradeCollector = bbgo.NewTradeCollector(s.Symbol, s.Position, s.orderStore)
+
+	s.tradeCollector.OnTrade(func(trade types.Trade, profit, netProfit fixedpoint.Value) {
+		s.Notifiability.Notify(trade)
+		s.ProfitStats.AddTrade(trade)
+
+		if profit.Compare(fixedpoint.Zero) == 0 {
+			s.Environment.RecordPosition(s.Position, trade, nil)
+		} else {
+			log.Infof("%s generated profit: %v", s.Symbol, profit)
+			p := s.Position.NewProfit(trade, profit, netProfit)
+			p.Strategy = ID
+			p.StrategyInstanceID = s.InstanceID()
+			s.Notify(&p)
+
+			s.ProfitStats.AddProfit(p)
+			s.Notify(&s.ProfitStats)
+
+			s.Environment.RecordPosition(s.Position, trade, &p)
+		}
+		log.Infof("%v", s.Position)
+	})
+
+	s.tradeCollector.BindStream(session.UserDataStream)
+
+	return nil
+}

--- a/pkg/strategy/supertrend/strategy.go
+++ b/pkg/strategy/supertrend/strategy.go
@@ -14,7 +14,6 @@ import (
 )
 
 // TODO: Margin side effect
-// TODO: Update balance
 
 const ID = "supertrend"
 
@@ -425,6 +424,12 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 				if err := s.ClosePosition(ctx, fixedpoint.One); err != nil {
 					s.Notify("can not place position close order")
 				}
+			}
+
+			// Update balance for exchanges like FTX, which doesn't update balances automatically
+			balances, err := s.session.Exchange.QueryAccountBalances(ctx)
+			if err != nil {
+				s.session.GetAccount().UpdateBalances(balances)
 			}
 
 			orderForm := s.GenerateOrderForm(side, s.CalculateQuantity(kline.GetClose()))


### PR DESCRIPTION

```
BACK-TEST REPORT
===============================================
START TIME: Fri, 01 Apr 2022 00:00:00 UTC
END TIME: Sat, 30 Apr 2022 00:00:00 UTC
INITIAL TOTAL BALANCE: BalanceMap[BTC: 100, USDT: 10000]
FINAL TOTAL BALANCE: BalanceMap[BTC: 100.00108121, USDT: 10221.17915601]
binance BTCUSDT PROFIT AND LOSS REPORT
===============================================
TRADES SINCE: 2022-04-01 01:58:59.999 +0000 UTC
NUMBER OF TRADES: 12
AVERAGE COST: $ 39,324.93
TOTAL BUY VOLUME: 1.44164431
TOTAL SELL VOLUME: 1.4405631
CURRENT PRICE: $ 38,596.11
CURRENCY FEES:
 - USDT: 45.55325269
 - BTC: 0.00108121
PROFIT: $ 274.20
UNREALIZED PROFIT: $ 0.00
INITIAL ASSET IN USDT ~= 4561035.00000 USDT (1 BTC = 45510.35)
FINAL ASSET IN USDT ~= 3869873.90965 USDT (1 BTC = 38596.11)
REALIZED PROFIT: +274.19909983 USDT
UNREALIZED PROFIT: 0 USDT
ASSET DECREASED: -691161.0903439 USDT (-15.15%)
BTC BASE ASSET PERFORMANCE: -15.19% (= (38596.11 - 45510.35) / 45510.35)
```