### PR TITLE
fix: change from local timezone to UTC when do syncing

### DIFF
--- a/pkg/bbgo/environment.go
+++ b/pkg/bbgo/environment.go
@@ -106,7 +106,7 @@ func NewEnvironment() *Environment {
 		// default trade scan time
 		syncStartTime: time.Now().AddDate(-1, 0, 0), // defaults to sync from 1 year ago
 		sessions:      make(map[string]*ExchangeSession),
-		startTime:     time.Now(),
+		startTime:     time.Now().UTC(),
 
 		syncStatus: SyncNotStarted,
 		PersistenceServiceFacade: &service.PersistenceServiceFacade{

--- a/pkg/exchange/batch/kline.go
+++ b/pkg/exchange/batch/kline.go
@@ -24,7 +24,7 @@ func (e *KLineBatchQuery) Query(ctx context.Context, symbol string, interval typ
 			})
 		},
 		T: func(obj interface{}) time.Time {
-			return time.Time(obj.(types.KLine).StartTime)
+			return time.Time(obj.(types.KLine).StartTime).UTC()
 		},
 		ID: func(obj interface{}) string {
 			kline := obj.(types.KLine)


### PR DESCRIPTION
old one:
```log
[0000]  INFO synchronizing lastKLine for interval 15m from exchange binance
[0000]  INFO querying kline MATICUSDT 15m {0 2022-04-01 00:00:00 +0000 UTC 2022-06-02 07:50:30.2778472 +0000 UTC} exchange=binance
[0024]  INFO querying kline MATICUSDT 15m {0 2022-04-11 18:45:00 +0900 JST 2022-06-02 07:50:30.2778472 +0000 UTC} exchange=binance
[0049]  INFO querying kline MATICUSDT 15m {0 2022-04-22 04:30:00 +0900 JST 2022-06-02 07:50:30.2778472 +0000 UTC} exchange=binance
[0075]  INFO querying kline MATICUSDT 15m {0 2022-05-02 14:15:00 +0900 JST 2022-06-02 07:50:30.2778472 +0000 UTC} exchange=binance
[0118]  INFO querying kline MATICUSDT 15m {0 2022-05-13 00:00:00 +0900 JST 2022-06-02 07:50:30.2778472 +0000 UTC} exchange=binance
[0161]  INFO querying kline MATICUSDT 15m {0 2022-05-23 09:45:00 +0900 JST 2022-06-02 07:50:30.2778472 +0000 UTC} exchange=binance
```

new one:
```log
[0281]  INFO querying last kline exchange = binance AND symbol = MATICUSDT AND interval = 1m
[0281]  INFO synchronizing lastKLine for interval 1m from exchange binance
[0281]  INFO querying kline MATICUSDT 1m {0 2022-04-01 00:00:00 +0000 UTC 2022-06-02 08:00:55.5333626 +0000 UTC} exchange=binance
[0324]  INFO querying kline MATICUSDT 1m {0 2022-04-01 16:39:00 +0000 UTC 2022-06-02 08:00:55.5333626 +0000 UTC} exchange=binance
[0365]  INFO querying kline MATICUSDT 1m {0 2022-04-02 09:18:00 +0000 UTC 2022-06-02 08:00:55.5333626 +0000 UTC} exchange=binance
[0408]  INFO querying kline MATICUSDT 1m {0 2022-04-03 01:57:00 +0000 UTC 2022-06-02 08:00:55.5333626 +0000 UTC} exchange=binance
```