### PR TITLE
fix: drift window in factorzoo, order_execution print order, refactor…

### DIFF
--- a/pkg/bbgo/order_execution.go
+++ b/pkg/bbgo/order_execution.go
@@ -85,9 +85,9 @@ func (e *ExchangeOrderExecutor) notifySubmitOrders(orders ...types.SubmitOrder) 
 		// pass submit order as an interface object.
 		channel, ok := e.RouteObject(&order)
 		if ok {
-			e.NotifyTo(channel, ":memo: Submitting %s %s %s order with quantity: %f @ %f", order.Symbol, order.Type, order.Side, order.Quantity.Float64(), order.Price.Float64(), &order)
+			e.NotifyTo(channel, ":memo: Submitting %s %s %s order with quantity: %f @ %f, order: %v", order.Symbol, order.Type, order.Side, order.Quantity.Float64(), order.Price.Float64(), &order)
 		} else {
-			e.Notify(":memo: Submitting %s %s %s order with quantity: %f @ %f", order.Symbol, order.Type, order.Side, order.Quantity.Float64(), order.Price.Float64(), &order)
+			e.Notify(":memo: Submitting %s %s %s order with quantity: %f @ %f, order: %v", order.Symbol, order.Type, order.Side, order.Quantity.Float64(), order.Price.Float64(), &order)
 		}
 	}
 }
@@ -102,9 +102,9 @@ func (e *ExchangeOrderExecutor) SubmitOrders(ctx context.Context, orders ...type
 		// pass submit order as an interface object.
 		channel, ok := e.RouteObject(&order)
 		if ok {
-			e.NotifyTo(channel, ":memo: Submitting %s %s %s order with quantity: %f", order.Symbol, order.Type, order.Side, order.Quantity.Float64(), order)
+			e.NotifyTo(channel, ":memo: Submitting %s %s %s order with quantity: %f, order: %v", order.Symbol, order.Type, order.Side, order.Quantity.Float64(), &order)
 		} else {
-			e.Notify(":memo: Submitting %s %s %s order with quantity: %f", order.Symbol, order.Type, order.Side, order.Quantity.Float64(), order)
+			e.Notify(":memo: Submitting %s %s %s order with quantity: %f: %v", order.Symbol, order.Type, order.Side, order.Quantity.Float64(), &order)
 		}
 
 		log.Infof("submitting order: %s", order.String())

--- a/pkg/strategy/factorzoo/strategy.go
+++ b/pkg/strategy/factorzoo/strategy.go
@@ -154,7 +154,11 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 	// s.pvDivergence.OnUpdate(func(corr float64) {
 	//	//fmt.Printf("now we've got corr: %f\n", corr)
 	// })
-	drift := &indicator.Drift{IntervalWindow: types.IntervalWindow{Window: 14, Interval: s.Interval}}
+	windowSize := 360/s.Interval.Minutes()
+	if windowSize == 0 {
+		windowSize = 3
+	}
+	drift := &indicator.Drift{IntervalWindow: types.IntervalWindow{Window: windowSize, Interval: s.Interval}}
 	drift.Bind(st)
 
 	s.Alpha = [][]float64{{}, {}, {}, {}, {}, {}}


### PR DESCRIPTION
- fix: drift window in factorzoo
- fix: order_execution print order
- refactor: use defer to mu.Unlock in depth/buffer.go