### PR TITLE
strategy pivotshort: refactor and add stop EMA

### DIFF
--- a/config/pivotshort-ETHUSDT.yaml
+++ b/config/pivotshort-ETHUSDT.yaml
@@ -12,19 +12,32 @@ exchangeStrategies:
   pivotshort:
     symbol: ETHUSDT
     interval: 5m
+    pivotLength: 200
 
-    pivotLength: 120
-
-    entry:
+    # breakLow settings are used for shorting when the current price break the previous low
+    breakLow:
+      ratio: 0.1%
       quantity: 10.0
-      marginOrderSideEffect: borrow
+      # stopLossPercentage: 1%
+
+    bounceShort:
+      quantity: 10.0
+      # stopLossPercentage: 1%
+      numOfLayers: 10
+      layerSpread: 0.1%
+      pivotRatio: 0.1%
 
     exit:
-      takeProfitPercentage: 25%
-      stopLossPercentage: 1%
-      lowerShadowRatio: 0.95
-      marginOrderSideEffect: repay
+      # roiStopLossPercentage is the stop loss percentage of the position ROI (currently the price change)
+      roiStopLossPercentage: 1%
 
+      # roiTakeProfitPercentage is the take profit percentage of the position ROI (currently the price change)
+      roiTakeProfitPercentage: 25%
+
+      # lowerShadowRatio is used to force taking profit when the (lower shadow height / low price) > lowerShadowRatio
+      lowerShadowRatio: 3%
+
+      marginOrderSideEffect: repay
 
 backtest:
   sessions:

--- a/config/pivotshort-ETHUSDT.yaml
+++ b/config/pivotshort-ETHUSDT.yaml
@@ -13,7 +13,7 @@ exchangeStrategies:
     symbol: ETHUSDT
     interval: 5m
 
-    pivotLength:  120
+    pivotLength: 120
 
     entry:
       quantity: 10.0
@@ -28,12 +28,12 @@ exchangeStrategies:
 
 backtest:
   sessions:
-    - binance
+  - binance
   startTime: "2022-04-01"
-  endTime: "2022-06-03"
+  endTime: "2022-06-08"
   symbols:
-    - ETHUSDT
-  account:
+  - ETHUSDT
+  accounts:
     binance:
       balances:
         ETH: 10.0

--- a/config/pivotshort-ETHUSDT.yaml
+++ b/config/pivotshort-ETHUSDT.yaml
@@ -18,7 +18,10 @@ exchangeStrategies:
     breakLow:
       ratio: 0.1%
       quantity: 10.0
-      # stopLossPercentage: 1%
+      stopEMARange: 5%
+      stopEMA:
+        interval: 1h
+        window: 99
 
     bounceShort:
       quantity: 10.0

--- a/config/pivotshort-ETHUSDT.yaml
+++ b/config/pivotshort-ETHUSDT.yaml
@@ -35,10 +35,17 @@ exchangeStrategies:
       roiStopLossPercentage: 1%
 
       # roiTakeProfitPercentage is the take profit percentage of the position ROI (currently the price change)
+      # force to take the profit ROI exceeded the percentage.
       roiTakeProfitPercentage: 25%
 
       # lowerShadowRatio is used to force taking profit when the (lower shadow height / low price) > lowerShadowRatio
+      # you can grab a simple stats by the following SQL:
+      # SELECT ((close - low) / close) AS shadow_ratio FROM binance_klines WHERE symbol = 'ETHUSDT' AND `interval` = '5m' AND start_time > '2022-01-01' ORDER BY shadow_ratio DESC LIMIT 20;
       lowerShadowRatio: 3%
+
+      cumulatedVolume:
+        minVolume: 50_000
+        window: 5
 
       marginOrderSideEffect: repay
 

--- a/config/pivotshort-GMTBUSD.yaml
+++ b/config/pivotshort-GMTBUSD.yaml
@@ -37,7 +37,7 @@ backtest:
   endTime: "2022-06-03"
   symbols:
     - GMTBUSD
-  account:
+  accounts:
     binance:
       balances:
         GMT: 3_000.0

--- a/config/pivotshort.yaml
+++ b/config/pivotshort.yaml
@@ -16,15 +16,33 @@ exchangeStrategies:
 
     pivotLength: 120
 
-    entry:
-      quantity: 3000.0
-    #      marginOrderSideEffect: borrow
+    # breakLow settings are used for shorting when the current price break the previous low
+    breakLow:
+      ratio: 0.1%
+      quantity: 10.0
+      stopEMARange: 5%
+      stopEMA:
+        interval: 1h
+        window: 99
 
     exit:
-      takeProfitPercentage: 25%
-      stopLossPercentage: 1%
-      lowerShadowRatio: 0.95
-#      marginOrderSideEffect: repay
+      # roiStopLossPercentage is the stop loss percentage of the position ROI (currently the price change)
+      roiStopLossPercentage: 1%
+
+      # roiTakeProfitPercentage is the take profit percentage of the position ROI (currently the price change)
+      # force to take the profit ROI exceeded the percentage.
+      roiTakeProfitPercentage: 25%
+
+      # lowerShadowRatio is used to force taking profit when the (lower shadow height / low price) > lowerShadowRatio
+      # you can grab a simple stats by the following SQL:
+      # SELECT ((close - low) / close) AS shadow_ratio FROM binance_klines WHERE symbol = 'ETHUSDT' AND `interval` = '5m' AND start_time > '2022-01-01' ORDER BY shadow_ratio DESC LIMIT 20;
+      lowerShadowRatio: 3%
+
+      cumulatedVolume:
+        minVolume: 50_000
+        window: 5
+
+      marginOrderSideEffect: repay
 
 
 backtest:

--- a/config/pivotshort.yaml
+++ b/config/pivotshort.yaml
@@ -14,11 +14,11 @@ exchangeStrategies:
     symbol: GMTUSDT
     interval: 5m
 
-    pivotLength:  120
+    pivotLength: 120
 
     entry:
       quantity: 3000.0
-#      marginOrderSideEffect: borrow
+    #      marginOrderSideEffect: borrow
 
     exit:
       takeProfitPercentage: 25%
@@ -29,12 +29,12 @@ exchangeStrategies:
 
 backtest:
   sessions:
-    - binance
+  - binance
   startTime: "2022-05-01"
   endTime: "2022-06-03"
   symbols:
-    - GMTUSDT
-  account:
+  - GMTUSDT
+  accounts:
     binance:
       balances:
         GMT: 3010.0

--- a/config/pivotshort_optimizer.yaml
+++ b/config/pivotshort_optimizer.yaml
@@ -1,0 +1,18 @@
+# usage:
+#
+#   go run ./cmd/bbgo optimize --config bollmaker_ethusdt.yaml  --optimizer-config optimizer.yaml --debug
+#
+---
+matrix:
+- type: iterate
+  label: interval
+  path: '/exchangeStrategies/0/pivotshort/interval'
+  values: [ "5m", "30m", "1h" ]
+
+- type: range
+  path: '/exchangeStrategies/0/pivotshort/pivotLength'
+  label: pivotLength
+  min: 100.0
+  max: 200.0
+  step: 10.0
+

--- a/config/pivotshort_optimizer.yaml
+++ b/config/pivotshort_optimizer.yaml
@@ -12,7 +12,15 @@ matrix:
 - type: range
   path: '/exchangeStrategies/0/pivotshort/pivotLength'
   label: pivotLength
-  min: 100.0
+  min: 20.0
   max: 200.0
   step: 10.0
+
+- type: range
+  path: '/exchangeStrategies/0/pivotshort/breakLow/stopEMARange'
+  label: pivotLength
+  min: 0%
+  max: 10%
+  step: 0.5%
+
 

--- a/pkg/backtest/exchange.go
+++ b/pkg/backtest/exchange.go
@@ -323,12 +323,13 @@ func (e *Exchange) SubscribeMarketData(extraIntervals ...types.Interval) (chan t
 		loadedIntervals[it] = struct{}{}
 	}
 
+	// collect subscriptions
 	for _, sub := range e.marketDataStream.Subscriptions {
 		loadedSymbols[sub.Symbol] = struct{}{}
 
 		switch sub.Channel {
 		case types.KLineChannel:
-			loadedIntervals[types.Interval(sub.Options.Interval)] = struct{}{}
+			loadedIntervals[sub.Options.Interval] = struct{}{}
 
 		default:
 			// Since Environment is not yet been injected at this point, no hard error

--- a/pkg/bbgo/activeorderbook.go
+++ b/pkg/bbgo/activeorderbook.go
@@ -10,7 +10,7 @@ import (
 	"github.com/c9s/bbgo/pkg/types"
 )
 
-const CancelOrderWaitTime = 20 * time.Millisecond
+const CancelOrderWaitTime = 10 * time.Millisecond
 
 // ActiveOrderBook manages the local active order books.
 //go:generate callbackgen -type ActiveOrderBook

--- a/pkg/bbgo/activeorderbook.go
+++ b/pkg/bbgo/activeorderbook.go
@@ -69,6 +69,8 @@ func (b *ActiveOrderBook) waitAllClear(ctx context.Context, waitTime, timeout ti
 
 // GracefulCancel cancels the active orders gracefully
 func (b *ActiveOrderBook) GracefulCancel(ctx context.Context, ex types.Exchange) error {
+	waitTime := CancelOrderWaitTime
+
 	log.Debugf("[ActiveOrderBook] gracefully cancelling %s orders...", b.Symbol)
 
 	startTime := time.Now()
@@ -86,9 +88,9 @@ func (b *ActiveOrderBook) GracefulCancel(ctx context.Context, ex types.Exchange)
 			log.WithError(err).Errorf("[ActiveOrderBook] can not cancel %s orders", b.Symbol)
 		}
 
-		log.Debugf("[ActiveOrderBook] waiting %s for %s orders to be cancelled...", CancelOrderWaitTime, b.Symbol)
+		log.Debugf("[ActiveOrderBook] waiting %s for %s orders to be cancelled...", waitTime, b.Symbol)
 
-		clear, err := b.waitAllClear(ctx, CancelOrderWaitTime, 5*time.Second)
+		clear, err := b.waitAllClear(ctx, waitTime, 5*time.Second)
 		if clear || err != nil {
 			break
 		}

--- a/pkg/bbgo/notifier.go
+++ b/pkg/bbgo/notifier.go
@@ -1,6 +1,10 @@
 package bbgo
 
-import "github.com/sirupsen/logrus"
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+)
 
 type Notifier interface {
 	NotifyTo(channel string, obj interface{}, args ...interface{})
@@ -69,7 +73,7 @@ func (m *Notifiability) NotifyTo(channel string, obj interface{}, args ...interf
 func filterSimpleArgs(args []interface{}) (simpleArgs []interface{}) {
 	for _, arg := range args {
 		switch arg.(type) {
-		case int, int64, int32, uint64, uint32, string, []byte, float64, float32:
+		case int, int64, int32, uint64, uint32, string, []byte, float64, float32, fixedpoint.Value:
 			simpleArgs = append(simpleArgs, arg)
 		}
 	}

--- a/pkg/bbgo/smart_stops.go
+++ b/pkg/bbgo/smart_stops.go
@@ -128,7 +128,7 @@ func (c *TrailingStopController) Run(ctx context.Context, session *ExchangeSessi
 
 			log.Infof("current %s position: %s", c.Symbol, c.position.String())
 
-			marketOrder := c.position.NewClosePositionOrder(c.ClosePosition)
+			marketOrder := c.position.NewMarketCloseOrder(c.ClosePosition)
 			if marketOrder != nil {
 				log.Infof("submitting %s market order to stop: %+v", c.Symbol, marketOrder)
 

--- a/pkg/cmd/backtest.go
+++ b/pkg/cmd/backtest.go
@@ -127,7 +127,6 @@ var BacktestCmd = &cobra.Command{
 			return err
 		}
 
-
 		if userConfig.Backtest == nil {
 			return errors.New("backtest config is not defined")
 		}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -34,7 +34,6 @@ func init() {
 	RunCmd.Flags().Bool("enable-grpc", false, "enable grpc server")
 	RunCmd.Flags().String("grpc-bind", ":50051", "grpc server binding")
 
-	RunCmd.Flags().String("cpu-profile", "", "cpu profile")
 	RunCmd.Flags().Bool("setup", false, "use setup mode")
 	RootCmd.AddCommand(RunCmd)
 }

--- a/pkg/fixedpoint/convert.go
+++ b/pkg/fixedpoint/convert.go
@@ -98,7 +98,7 @@ func (v Value) String() string {
 func (v Value) FormatString(prec int) string {
 	pow := math.Pow10(prec)
 	return strconv.FormatFloat(
-		math.Trunc(float64(v)/DefaultPow * pow) / pow, 'f', prec, 64)
+		math.Trunc(float64(v)/DefaultPow*pow)/pow, 'f', prec, 64)
 }
 
 func (v Value) Percentage() string {
@@ -114,7 +114,7 @@ func (v Value) FormatPercentage(prec int) string {
 	}
 	pow := math.Pow10(prec)
 	result := strconv.FormatFloat(
-		math.Trunc(float64(v)/DefaultPow * pow * 100.) / pow, 'f', prec, 64)
+		math.Trunc(float64(v)/DefaultPow*pow*100.)/pow, 'f', prec, 64)
 	return result + "%"
 }
 
@@ -222,6 +222,10 @@ func (v *Value) UnmarshalYAML(unmarshal func(a interface{}) error) (err error) {
 	return err
 }
 
+func (v Value) MarshalYAML() (interface{}, error) {
+	return v.FormatString(DefaultPrecision), nil
+}
+
 func (v Value) MarshalJSON() ([]byte, error) {
 	return []byte(v.FormatString(DefaultPrecision)), nil
 }
@@ -326,7 +330,7 @@ func NewFromString(input string) (Value, error) {
 	// if is decimal, we don't need this
 	hasScientificNotion := false
 	scIndex := -1
-	for i, c := range(input) {
+	for i, c := range input {
 		if hasDecimal {
 			if c <= '9' && c >= '0' {
 				decimalCount++
@@ -345,7 +349,7 @@ func NewFromString(input string) (Value, error) {
 		}
 	}
 	if hasDecimal {
-		after := input[dotIndex+1:len(input)]
+		after := input[dotIndex+1 : len(input)]
 		if decimalCount >= 8 {
 			after = after[0:8] + "." + after[8:len(after)]
 		} else {
@@ -368,7 +372,7 @@ func NewFromString(input string) (Value, error) {
 		if err != nil {
 			return 0, err
 		}
-		v, err := strconv.ParseFloat(input[0:scIndex+1] + strconv.FormatInt(exp + 8, 10), 64)
+		v, err := strconv.ParseFloat(input[0:scIndex+1]+strconv.FormatInt(exp+8, 10), 64)
 		if err != nil {
 			return 0, err
 		}
@@ -385,7 +389,6 @@ func NewFromString(input string) (Value, error) {
 		}
 		return Value(v), nil
 	}
-
 }
 
 func MustNewFromString(input string) Value {

--- a/pkg/strategy/ewoDgtrd/strategy.go
+++ b/pkg/strategy/ewoDgtrd/strategy.go
@@ -613,13 +613,13 @@ func (s *Strategy) PlaceSellOrder(ctx context.Context, price fixedpoint.Value) (
 }
 
 // ClosePosition(context.Context) -> (closeOrder *types.Order, ok bool)
-// this will decorate the generated order from NewClosePositionOrder
+// this will decorate the generated order from NewMarketCloseOrder
 // add do necessary checks
 // if available quantity is zero, will return (nil, true)
 // if any of the checks failed, will return (nil, false)
 // otherwise, return the created close order and true
 func (s *Strategy) ClosePosition(ctx context.Context) (*types.Order, bool) {
-	order := s.Position.NewClosePositionOrder(fixedpoint.One)
+	order := s.Position.NewMarketCloseOrder(fixedpoint.One)
 	// no position exists
 	if order == nil {
 		// no base

--- a/pkg/strategy/pivotshort/strategy.go
+++ b/pkg/strategy/pivotshort/strategy.go
@@ -298,7 +298,7 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 				}
 
 				return
-			} else if roi.Compare(s.Exit.RoiTakeProfitPercentage) > 0 {
+			} else if roi.Compare(s.Exit.RoiTakeProfitPercentage) > 0 { // disable this condition temporarily
 				s.Notify("%s TakeProfit triggered at price %f, ROI take profit percentage by %s", s.Symbol, kline.Close.Float64(), roi.Percentage(), kline)
 				if err := s.activeMakerOrders.GracefulCancel(ctx, s.session.Exchange); err != nil {
 					log.WithError(err).Errorf("graceful cancel order error")
@@ -307,8 +307,7 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 				if err := s.ClosePosition(ctx, fixedpoint.One); err != nil {
 					log.WithError(err).Errorf("close position error")
 				}
-				return
-			} else if !s.Exit.LowerShadowRatio.IsZero() && kline.GetLowerShadowHeight().Div(kline.Low).Compare(s.Exit.LowerShadowRatio) > 0 {
+			} else if !s.Exit.LowerShadowRatio.IsZero() && kline.GetLowerShadowHeight().Div(kline.Close).Compare(s.Exit.LowerShadowRatio) > 0 {
 				s.Notify("%s TakeProfit triggered at price %f: shadow ratio %f", s.Symbol, kline.Close.Float64(), kline.GetLowerShadowRatio().Float64(), kline)
 				if err := s.activeMakerOrders.GracefulCancel(ctx, s.session.Exchange); err != nil {
 					log.WithError(err).Errorf("graceful cancel order error")

--- a/pkg/strategy/pivotshort/strategy.go
+++ b/pkg/strategy/pivotshort/strategy.go
@@ -257,12 +257,12 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 		if len(s.pivotLowPrices) > 0 {
 			lastLow := s.pivotLowPrices[len(s.pivotLowPrices)-1]
 			if kline.Close.Compare(lastLow) < 0 {
-				s.Notify("%s price %f breaks the previous low %f, submitting market sell to open a short position", s.Symbol, kline.Close.Float64(), lastLow.Float64())
-
 				if !s.Position.IsClosed() && !s.Position.IsDust(kline.Close) {
-					s.Notify("skip opening %s position, which is not closed", s.Symbol, s.Position)
+					// s.Notify("skip opening %s position, which is not closed", s.Symbol, s.Position)
 					return
 				}
+
+				s.Notify("%s price %f breaks the previous low %f, submitting market sell to open a short position", s.Symbol, kline.Close.Float64(), lastLow.Float64())
 
 				if err := s.activeMakerOrders.GracefulCancel(ctx, s.session.Exchange); err != nil {
 					log.WithError(err).Errorf("graceful cancel order error")

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -807,8 +807,7 @@ func (s *Strategy) CrossRun(ctx context.Context, orderExecutionRouter bbgo.Order
 		defer tradeScanTicker.Stop()
 
 		defer func() {
-			if err := s.activeMakerOrders.GracefulCancel(context.Background(),
-				s.makerSession.Exchange); err != nil {
+			if err := s.activeMakerOrders.GracefulCancel(context.Background(), s.makerSession.Exchange); err != nil {
 				log.WithError(err).Errorf("can not cancel %s orders", s.Symbol)
 			}
 		}()

--- a/pkg/types/position.go
+++ b/pkg/types/position.go
@@ -120,7 +120,7 @@ func (p *Position) NewProfit(trade Trade, profit, netProfit fixedpoint.Value) Pr
 	}
 }
 
-func (p *Position) NewClosePositionOrder(percentage fixedpoint.Value) *SubmitOrder {
+func (p *Position) NewMarketCloseOrder(percentage fixedpoint.Value) *SubmitOrder {
 	base := p.GetBase()
 
 	quantity := base.Abs()


### PR DESCRIPTION
```
BACK-TEST REPORT
===============================================
START TIME: Fri, 01 Apr 2022 00:00:00 UTC
END TIME: Wed, 08 Jun 2022 00:00:00 UTC
INITIAL TOTAL BALANCE: BalanceMap[ETH: 10, USDT: 3000]
FINAL TOTAL BALANCE: BalanceMap[ETH: 0.05250783, USDT: 35872.95613945]
binance ETHUSDT PROFIT AND LOSS REPORT
===============================================
TRADES SINCE: 2022-04-05 23:51:59.999 +0000 UTC
NUMBER OF TRADES: 22
AVERAGE COST: $ 1,907.45
BASE ASSET POSITION: -10.00000562
TOTAL BUY VOLUME: 70.05253372
TOTAL SELL VOLUME: 80
CURRENT PRICE: $ 1,814.21
CURRENCY FEES:
 - USDT: 132.10289997
 - ETH: 0.05253934
PROFIT: $ 13,905.81
UNREALIZED PROFIT: $ 932.38
INITIAL ASSET IN USDT ~= 35815.1000 USDT (1 ETH = 3281.51)
FINAL ASSET IN USDT ~= 35968.2163 USDT (1 ETH = 1814.21)
REALIZED PROFIT: +13905.81092495 USDT
UNREALIZED PROFIT: +932.38400289 USDT
ASSET INCREASED: +153.11636971 USDT (+0.42%)
```