### PR TITLE
pivotshort: add roiMinTakeProfitPercentage option and cumulatedVolume…

### DIFF
--- a/config/pivotshort-ETHUSDT.yaml
+++ b/config/pivotshort-ETHUSDT.yaml
@@ -34,17 +34,22 @@ exchangeStrategies:
       # roiStopLossPercentage is the stop loss percentage of the position ROI (currently the price change)
       roiStopLossPercentage: 1%
 
-      # roiTakeProfitPercentage is the take profit percentage of the position ROI (currently the price change)
+      # roiTakeProfitPercentage is used to force taking profit percentage of the position ROI (currently the price change)
       # force to take the profit ROI exceeded the percentage.
       roiTakeProfitPercentage: 25%
 
-      # lowerShadowRatio is used to force taking profit when the (lower shadow height / low price) > lowerShadowRatio
+      # roiMinTakeProfitPercentage applies to lowerShadowRatio and cumulatedVolume exit options
+      roiMinTakeProfitPercentage: 10%
+
+      # lowerShadowRatio is used to taking profit when the (lower shadow height / low price) > lowerShadowRatio
       # you can grab a simple stats by the following SQL:
       # SELECT ((close - low) / close) AS shadow_ratio FROM binance_klines WHERE symbol = 'ETHUSDT' AND `interval` = '5m' AND start_time > '2022-01-01' ORDER BY shadow_ratio DESC LIMIT 20;
       lowerShadowRatio: 3%
 
+      # cumulatedVolume is used to take profit when the cumulated quote volume from the klines exceeded a threshold
       cumulatedVolume:
-        minVolume: 50_000
+        enabled: true
+        minQuoteVolume: 90_000_000
         window: 5
 
       marginOrderSideEffect: repay
@@ -52,7 +57,7 @@ exchangeStrategies:
 backtest:
   sessions:
   - binance
-  startTime: "2022-04-01"
+  startTime: "2022-01-01"
   endTime: "2022-06-08"
   symbols:
   - ETHUSDT

--- a/config/pivotshort-ETHUSDT.yaml
+++ b/config/pivotshort-ETHUSDT.yaml
@@ -34,7 +34,7 @@ exchangeStrategies:
       # roiStopLossPercentage is the stop loss percentage of the position ROI (currently the price change)
       roiStopLossPercentage: 1%
 
-      # roiTakeProfitPercentage is used to force taking profit percentage of the position ROI (currently the price change)
+      # roiTakeProfitPercentage is used to force taking profit by percentage of the position ROI (currently the price change)
       # force to take the profit ROI exceeded the percentage.
       roiTakeProfitPercentage: 25%
 

--- a/config/pivotshort_optimizer.yaml
+++ b/config/pivotshort_optimizer.yaml
@@ -1,26 +1,41 @@
 # usage:
 #
-#   go run ./cmd/bbgo optimize --config bollmaker_ethusdt.yaml  --optimizer-config optimizer.yaml --debug
+#   go run ./cmd/bbgo optimize --config config/pivotshort-ETHUSDT.yaml  --optimizer-config config/pivotshort_optimizer.yaml --debug
 #
 ---
 matrix:
-- type: iterate
-  label: interval
-  path: '/exchangeStrategies/0/pivotshort/interval'
-  values: [ "5m", "30m", "1h" ]
 
-- type: range
-  path: '/exchangeStrategies/0/pivotshort/pivotLength'
-  label: pivotLength
-  min: 20.0
-  max: 200.0
-  step: 10.0
+#- type: iterate
+#  label: interval
+#  path: '/exchangeStrategies/0/pivotshort/interval'
+#  values: [ "5m", "30m" ]
+
+#- type: range
+#  path: '/exchangeStrategies/0/pivotshort/pivotLength'
+#  label: pivotLength
+#  min: 100.0
+#  max: 200.0
+#  step: 20.0
 
 - type: range
   path: '/exchangeStrategies/0/pivotshort/breakLow/stopEMARange'
-  label: pivotLength
+  label: stopEMARange
   min: 0%
   max: 10%
+  step: 1%
+
+- type: range
+  path: '/exchangeStrategies/0/pivotshort/exit/roiStopLossPercentage'
+  label: roiStopLossPercentage
+  min: 0.5%
+  max: 3%
   step: 0.5%
+
+- type: range
+  path: '/exchangeStrategies/0/pivotshort/exit/roiTakeProfitPercentage'
+  label: roiTakeProfitPercentage
+  min: 10%
+  max: 50%
+  step: 5%
 
 

--- a/config/pivotshort_optimizer.yaml
+++ b/config/pivotshort_optimizer.yaml
@@ -28,7 +28,7 @@ matrix:
   path: '/exchangeStrategies/0/pivotshort/exit/roiStopLossPercentage'
   label: roiStopLossPercentage
   min: 0.5%
-  max: 3%
+  max: 2%
   step: 0.5%
 
 - type: range
@@ -38,4 +38,10 @@ matrix:
   max: 50%
   step: 5%
 
+- type: range
+  path: '/exchangeStrategies/0/pivotshort/exit/roiMinTakeProfitPercentage'
+  label: roiMinTakeProfitPercentage
+  min: 3%
+  max: 10%
+  step: 1%
 


### PR DESCRIPTION
adjusted backtest start time to: Sat, 01 Jan 2022 00:00:00 UTC


```
BACK-TEST REPORT
===============================================
START TIME: Sat, 01 Jan 2022 00:00:00 UTC
END TIME: Wed, 08 Jun 2022 00:00:00 UTC
INITIAL TOTAL BALANCE: BalanceMap[ETH: 10, USDT: 3000]
FINAL TOTAL BALANCE: BalanceMap[ETH: 0.38263972, USDT: 31484.48162887]
binance ETHUSDT PROFIT AND LOSS REPORT
===============================================
TRADES SINCE: 2022-01-05 18:03:59.999 +0000 UTC
NUMBER OF TRADES: 154
AVERAGE COST: $ 1,907.45
BASE ASSET POSITION: -10.00000562
TOTAL BUY VOLUME: 510.382781
TOTAL SELL VOLUME: 520
CURRENT PRICE: $ 1,814.21
CURRENCY FEES:
 - USDT: 1078.69087487
 - ETH: 0.38278662
PROFIT: $ 10,466.50
UNREALIZED PROFIT: $ 932.38
INITIAL ASSET IN USDT ~= 39762.1999 USDT (1 ETH = 3676.22)
FINAL ASSET IN USDT ~= 32178.6704 USDT (1 ETH = 1814.21)
REALIZED PROFIT: +10466.50463953 USDT
UNREALIZED PROFIT: +932.38400289 USDT
ASSET DECREASED: -7583.5295647 USDT (-19.07%)
```