### PR TITLE
feature: add prettier to format the typescript code

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,3 @@
+.next/
+out/
+node_modules/

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "yarn run next dev",
     "build": "yarn run next build",
     "start": "yarn run next start",
-    "export": "yarn run next build && yarn run next export"
+    "export": "yarn run next build && yarn run next export",
+    "prettier": "prettier --write ."
   },
   "dependencies": {
     "@material-ui/core": "^4.11.2",
@@ -33,6 +34,7 @@
     "next-transpile-modules": "^6.1.0",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-preset-env": "^6.7.0",
+    "prettier": "^2.6.2",
     "typescript": "^4.1.3"
   }
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -82,42 +82,38 @@ export default function MyApp(props) {
                 <CssBaseline/>
                 {
                     loading ? (syncing ? (
-                        <React.Fragment>
-                            <Dialog
-                                open={syncing}
-                                aria-labelledby="alert-dialog-title"
-                                aria-describedby="alert-dialog-description"
-                            >
-                                <DialogTitle id="alert-dialog-title">{"Syncing Trades"}</DialogTitle>
-                                <DialogContent>
-                                    <DialogContentText id="alert-dialog-description">
-                                        The environment is syncing trades from the exchange sessions.
-                                        Please wait a moment...
-                                    </DialogContentText>
-                                    <Box m={2}>
-                                        <LinearProgress/>
-                                    </Box>
-                                </DialogContent>
-                            </Dialog>
-                        </React.Fragment>
+                       <Dialog
+                           open={syncing}
+                           aria-labelledby="alert-dialog-title"
+                           aria-describedby="alert-dialog-description"
+                       >
+                           <DialogTitle id="alert-dialog-title">{"Syncing Trades"}</DialogTitle>
+                           <DialogContent>
+                               <DialogContentText id="alert-dialog-description">
+                                   The environment is syncing trades from the exchange sessions.
+                                   Please wait a moment...
+                               </DialogContentText>
+                               <Box m={2}>
+                                   <LinearProgress/>
+                               </Box>
+                           </DialogContent>
+                       </Dialog>
                     ) : (
-                        <React.Fragment>
-                            <Dialog
-                                open={loading}
-                                aria-labelledby="alert-dialog-title"
-                                aria-describedby="alert-dialog-description"
-                            >
-                                <DialogTitle id="alert-dialog-title">{"Loading"}</DialogTitle>
-                                <DialogContent>
-                                    <DialogContentText id="alert-dialog-description">
-                                        Loading...
-                                    </DialogContentText>
-                                    <Box m={2}>
-                                        <LinearProgress/>
-                                    </Box>
-                                </DialogContent>
-                            </Dialog>
-                        </React.Fragment>
+                         <Dialog
+                             open={loading}
+                             aria-labelledby="alert-dialog-title"
+                             aria-describedby="alert-dialog-description"
+                         >
+                             <DialogTitle id="alert-dialog-title">{"Loading"}</DialogTitle>
+                             <DialogContent>
+                                 <DialogContentText id="alert-dialog-description">
+                                     Loading...
+                                 </DialogContentText>
+                                 <Box m={2}>
+                                     <LinearProgress/>
+                                 </Box>
+                             </DialogContent>
+                         </Dialog>
                     )) : (
                         <Component {...pageProps}/>
                     )

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -15,7 +15,6 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import theme from '../src/theme';
 import '../styles/globals.css'
 import {querySessions, querySyncStatus} from "../api/bbgo";
-import {Sync} from "@material-ui/icons";
 
 const SyncNotStarted = 0
 const Syncing = 1

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3201,6 +3201,11 @@ postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.32, postcss@^7.0.
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
+prettier@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
It's important to have consistent coding styles in our repo. We don't have default formatter for typescript, so I install `prettier` to format our code. I only apply the single quote rule. We can configure the rule in the future.

We can execute `yarn prettier` to format them.