### PR TITLE
Do not block whole page while syncing

### DIFF
--- a/frontend/api/bbgo.ts
+++ b/frontend/api/bbgo.ts
@@ -15,18 +15,19 @@ export function queryOutboundIP(cb) {
   });
 }
 
-const triggerSync = async () => {
+export async function triggerSync() {
   return axios.post<any>(baseURL + '/api/environment/sync');
 };
 
-export { triggerSync };
+export enum SyncStatus {
+  SyncNotStarted = 0,
+  Syncing = 1,
+  SyncDone = 2
+}
 
-export function querySyncStatus(cb) {
-  return axios
-    .get<any>(baseURL + '/api/environment/syncing')
-    .then((response) => {
-      cb(response.data.syncing);
-    });
+export async function querySyncStatus(): Promise<SyncStatus> {
+  const resp = await axios.get<any>(baseURL + '/api/environment/syncing')
+  return resp.data.syncing
 }
 
 export function testDatabaseConnection(params, cb) {

--- a/frontend/components/SyncButton.tsx
+++ b/frontend/components/SyncButton.tsx
@@ -1,0 +1,43 @@
+import {styled} from "@mui/styles";
+import React, {useEffect, useState} from "react";
+import {querySyncStatus, SyncStatus, triggerSync} from "../api/bbgo";
+import useInterval from "../hooks/useInterval";
+
+const ToolbarButton = styled('button')(({ theme }) => ({
+  padding: theme.spacing(1),
+}));
+
+export default function SyncButton() {
+  const [syncing, setSyncing] = useState(false);
+  
+  const sync = async () => {
+    try {
+      setSyncing(true);
+      await triggerSync();
+    } catch {
+      setSyncing(false);
+    }
+  };
+  
+  useEffect(() => {
+    sync();
+  }, [])
+  
+  useInterval(() => {
+    querySyncStatus().then(s => {
+      if (s !== SyncStatus.Syncing) {
+        setSyncing(false);
+      }
+    })
+  }, 2000)
+  
+  return (
+    <ToolbarButton
+      disabled={syncing}
+      onClick={sync}
+    >
+      {syncing ? 'Syncing...' : 'Sync'}
+    </ToolbarButton>
+  );
+}
+

--- a/frontend/hooks/useInterval.ts
+++ b/frontend/hooks/useInterval.ts
@@ -1,0 +1,20 @@
+import {useEffect, useRef} from "react";
+
+export default function useInterval(cb: Function, delayMs: number | null) {
+  const savedCallback = useRef<Function>();
+  
+  useEffect(() => {
+    savedCallback.current = cb
+  }, [cb])
+  
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    
+    if (delayMs !== null) {
+      let timerId = setInterval(tick, delayMs)
+      return () => clearInterval(timerId)
+    }
+  }, [delayMs])
+}

--- a/frontend/layouts/DashboardLayout.js
+++ b/frontend/layouts/DashboardLayout.js
@@ -1,17 +1,16 @@
 import React from 'react';
 
-import { makeStyles, styled } from '@mui/styles';
+import { makeStyles } from '@mui/styles';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 
 import SideBar from '../components/SideBar';
+import SyncButton from '../components/SyncButton';
 
 import ConnectWallet from '../components/ConnectWallet';
 import { Box } from '@mui/material';
-import { throttle } from '../src/utils';
-import { triggerSync } from '../api/bbgo';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -32,18 +31,6 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-between',
   },
 }));
-
-const ToolbarButton = styled('button')(({ theme }) => ({
-  padding: theme.spacing(1),
-}));
-
-function SyncButton() {
-  const handleClick = throttle(async () => {
-    await triggerSync();
-  }, 2000);
-
-  return <ToolbarButton onClick={handleClick}>Sync</ToolbarButton>;
-}
 
 export default function DashboardLayout({ children }) {
   const classes = useStyles();

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -7,7 +7,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../src/theme';
 import '../styles/globals.css';
-import {triggerSync} from "../api/bbgo";
+import { triggerSync } from '../api/bbgo';
 
 export default function MyApp(props) {
   const { Component, pageProps } = props;
@@ -21,9 +21,9 @@ export default function MyApp(props) {
   }, []);
 
   useEffect(() => {
-    triggerSync()
-  }, [])
-  
+    triggerSync();
+  }, []);
+
   return (
     <React.Fragment>
       <Head>

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../src/theme';
 import '../styles/globals.css';
+import {triggerSync} from "../api/bbgo";
 
 export default function MyApp(props) {
   const { Component, pageProps } = props;
@@ -19,6 +20,10 @@ export default function MyApp(props) {
     }
   }, []);
 
+  useEffect(() => {
+    triggerSync()
+  }, [])
+  
   return (
     <React.Fragment>
       <Head>

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -7,7 +7,6 @@ import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../src/theme';
 import '../styles/globals.css';
-import { triggerSync } from '../api/bbgo';
 
 export default function MyApp(props) {
   const { Component, pageProps } = props;
@@ -18,10 +17,6 @@ export default function MyApp(props) {
     if (jssStyles) {
       jssStyles.parentElement.removeChild(jssStyles);
     }
-  }, []);
-
-  useEffect(() => {
-    triggerSync();
   }, []);
 
   return (

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,73 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Head from 'next/head';
 
 import { ThemeProvider } from '@mui/material/styles';
 
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
-import LinearProgress from '@mui/material/LinearProgress';
-import Box from '@mui/material/Box';
-
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '../src/theme';
 import '../styles/globals.css';
-import { querySessions, querySyncStatus } from '../api/bbgo';
-
-const SyncNotStarted = 0;
-const Syncing = 1;
-const SyncDone = 2;
-
-// session is configured, check if we're syncing data
-let syncStatusPoller = null;
 
 export default function MyApp(props) {
   const { Component, pageProps } = props;
 
-  const [loading, setLoading] = React.useState(true);
-  const [syncing, setSyncing] = React.useState(false);
-
-  React.useEffect(() => {
+  useEffect(() => {
     // Remove the server-side injected CSS.
     const jssStyles = document.querySelector('#jss-server-side');
     if (jssStyles) {
       jssStyles.parentElement.removeChild(jssStyles);
     }
-
-    querySessions((sessions) => {
-      if (sessions.length > 0) {
-        setSyncing(true);
-
-        const pollSyncStatus = () => {
-          querySyncStatus((status) => {
-            switch (status) {
-              case SyncNotStarted:
-                break;
-              case Syncing:
-                setSyncing(true);
-                break;
-              case SyncDone:
-                clearInterval(syncStatusPoller);
-                setLoading(false);
-                setSyncing(false);
-                break;
-            }
-          }).catch((err) => {
-            console.error(err);
-          });
-        };
-
-        syncStatusPoller = setInterval(pollSyncStatus, 1000);
-      } else {
-        // no session found, so we can not sync any data
-        setLoading(false);
-        setSyncing(false);
-      }
-    }).catch((err) => {
-      console.error(err);
-    });
   }, []);
 
   return (
@@ -82,46 +31,7 @@ export default function MyApp(props) {
       <ThemeProvider theme={theme}>
         {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
         <CssBaseline />
-        {loading ? (
-          syncing ? (
-            <Dialog
-              open={syncing}
-              aria-labelledby="alert-dialog-title"
-              aria-describedby="alert-dialog-description"
-            >
-              <DialogTitle id="alert-dialog-title">
-                {'Syncing Trades'}
-              </DialogTitle>
-              <DialogContent>
-                <DialogContentText id="alert-dialog-description">
-                  The environment is syncing trades from the exchange sessions.
-                  Please wait a moment...
-                </DialogContentText>
-                <Box m={2}>
-                  <LinearProgress />
-                </Box>
-              </DialogContent>
-            </Dialog>
-          ) : (
-            <Dialog
-              open={loading}
-              aria-labelledby="alert-dialog-title"
-              aria-describedby="alert-dialog-description"
-            >
-              <DialogTitle id="alert-dialog-title">{'Loading'}</DialogTitle>
-              <DialogContent>
-                <DialogContentText id="alert-dialog-description">
-                  Loading...
-                </DialogContentText>
-                <Box m={2}>
-                  <LinearProgress />
-                </Box>
-              </DialogContent>
-            </Dialog>
-          )
-        ) : (
-          <Component {...pageProps} />
-        )}
+        <Component {...pageProps} />
       </ThemeProvider>
     </React.Fragment>
   );


### PR DESCRIPTION
Currently we block the whole page when the server is syncing. But actually we don't have to invoke sync API for some tabs, like strategy. Therefore, I remove the blocking dialog. We should be able to open the strategy page even if the syncing operation is not done yet.

The first time we enter the bbgo frontend page, it invokes the asynchronous sync API first. When we click the order or trade tab, it will query the orders/trades from bbgo API. It's reasonable not to receive whole data since the orders and trades are inserted anytime. it's not possible to always have latest data if bbgo only provides REST API.

So the logic is the same as previous implementation. 

Also, you can trigger the syncing anytime by click the sync button #715 