### PR TITLE
fix: sync api guard condition

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -77,7 +77,7 @@ func (s *Server) newEngine(ctx context.Context) *gin.Engine {
 	})
 
 	r.POST("/api/environment/sync", func(c *gin.Context) {
-		if s.Environ.IsSyncing() == bbgo.SyncDone {
+		if s.Environ.IsSyncing() != bbgo.Syncing {
 			go func() {
 				// We use the root context here because the syncing operation is a background goroutine.
 				// It should not be terminated if the request is disconnected.


### PR DESCRIPTION
I haven't noticed the syncing status is defined as 0 in constructor, so the sync goroutine is never initialized. I fix the guard.