### PR TITLE
totp-user: add default user 'bbgo'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # First stage container
-FROM golang:1.17.6-alpine3.15 AS builder
+FROM golang:1.17.11-alpine3.16 AS builder
 RUN apk add --no-cache git ca-certificates gcc libc-dev pkgconfig
 # gcc is for github.com/mattn/go-sqlite3
 # ADD . $GOPATH/src/github.com/c9s/bbgo
@@ -16,14 +16,16 @@ ADD . .
 RUN go build -o $GOPATH_ORIG/bin/bbgo ./cmd/bbgo
 
 # Second stage container
-FROM alpine:3.15
+FROM alpine:3.16
 
-# RUN apk add --no-cache ca-certificates
-RUN mkdir /app
+# Create the default user 'bbgo' and assign to env 'USER'
+ENV USER=bbgo
+RUN adduser -D -G wheel "$USER"
+USER ${USER}
 
-WORKDIR /app
 COPY --from=builder /go/bin/bbgo /usr/local/bin
 
+WORKDIR /home/${USER}
 ENTRYPOINT ["/usr/local/bin/bbgo"]
 CMD ["run", "--config", "/config/bbgo.yaml", "--no-compile"]
 # vim:filetype=dockerfile:

--- a/pkg/service/totp.go
+++ b/pkg/service/totp.go
@@ -1,12 +1,12 @@
 package service
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -39,7 +39,8 @@ func NewDefaultTotpKey() (*otp.Key, error) {
 		}
 
 		if !ok {
-			return nil, fmt.Errorf("can not get USER or USERNAME env var for totp account name")
+			log.Warnf("can not get USER or USERNAME env var, use default name 'bbgo' for totp account name")
+			user = "bbgo"
 		}
 
 		totpAccountName = user


### PR DESCRIPTION
There's no `USER` env var in alpine image, causes the program throws error 'No USER or USERNAME' in containers.

* Create and assign `USER` env var in bbgo image
* Fallback to use the default user 'bbgo' when env `USER` or `USERNAME` was unassigned