### PR TITLE
optimizer/fix: prevent from crashing if missing SummaryReport

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,6 @@ github.com/lestrrat-go/strftime v1.0.0/go.mod h1:E1nN3pCbtMSu1yjSVeyuRFVm/U0xoR7
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/lib/pq v1.10.5 h1:J+gdV2cUmX7ZqL2B0lFcW0m+egaHC2V3lpO8nWxyYiQ=
-github.com/lib/pq v1.10.5/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.6 h1:jbk+ZieJ0D7EVGJYpL9QTz7/YW6UHbmdnZWYyK5cdBs=
 github.com/lib/pq v1.10.6/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=

--- a/pkg/optimizer/grid.go
+++ b/pkg/optimizer/grid.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/cheggaaa/pb/v3"
 	"sort"
 
-	"github.com/evanphx/json-patch/v5"
+	"github.com/cheggaaa/pb/v3"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
 
 	"github.com/c9s/bbgo/pkg/backtest"
 	"github.com/c9s/bbgo/pkg/fixedpoint"
@@ -16,6 +17,9 @@ import (
 type MetricValueFunc func(summaryReport *backtest.SummaryReport) fixedpoint.Value
 
 var TotalProfitMetricValueFunc = func(summaryReport *backtest.SummaryReport) fixedpoint.Value {
+	if summaryReport == nil {
+		return fixedpoint.Zero
+	}
 	return summaryReport.TotalProfit
 }
 
@@ -217,6 +221,9 @@ func (o *GridOptimizer) Run(executor Executor, configJson []byte) (map[string][]
 
 	for result := range resultsC {
 		for metricName, metricFunc := range valueFunctions {
+			if result.Report == nil {
+				log.Errorf("no summaryReport found for params: %+v", result.Params)
+			}
 			var metricValue = metricFunc(result.Report)
 			bar.Set("log", fmt.Sprintf("params: %+v => %s %+v", result.Params, metricName, metricValue))
 			bar.Increment()


### PR DESCRIPTION
If TotalProfitMetricValueFunc is given summaryReport as nil, the optimizer used to crash. This prevent the optimizer from crashing, and returns 0 (fixedpoint.Zero). In addition, the parameters used while the would crash can be seen in the log.