### PR TITLE
strategy/supertrend: use types.IntervalWindow instead of types.Interval

### DIFF
--- a/config/supertrend.yaml
+++ b/config/supertrend.yaml
@@ -38,19 +38,17 @@ exchangeStrategies:
     # interval is how long do you want to update your order price and quantity
     interval: 5m
 
+    # ATR window used by Supertrend
+    window: 49
+    # ATR Multiplier for calculating super trend prices, the higher, the stronger the trends are
+    supertrendMultiplier: 4
+
     # leverage is the leverage of the orders
     leverage: 1.0
 
     # fastDEMAWindow and slowDEMAWindow are for filtering super trend noise
     fastDEMAWindow: 144
     slowDEMAWindow: 169
-
-    # Supertrend indicator parameters
-    superTrend:
-      # ATR window used by Supertrend
-      averageTrueRangeWindow: 49
-      # ATR Multiplier for calculating super trend prices, the higher, the stronger the trends are
-      averageTrueRangeMultiplier: 4
 
     # Use linear regression as trend confirmation
     linearRegression:

--- a/pkg/strategy/supertrend/double_dema.go
+++ b/pkg/strategy/supertrend/double_dema.go
@@ -7,7 +7,7 @@ import (
 )
 
 type DoubleDema struct {
-	Interval types.Interval `json:"interval"`
+	DemaInterval types.Interval `json:"demaInterval"`
 
 	// FastDEMAWindow DEMA window for checking breakout
 	FastDEMAWindow int `json:"fastDEMAWindow"`
@@ -46,19 +46,19 @@ func (dd *DoubleDema) preloadDema(kLineStore *bbgo.MarketDataStore) {
 
 // setupDoubleDema initializes double DEMA indicators
 func (dd *DoubleDema) setupDoubleDema(kLineStore *bbgo.MarketDataStore, interval types.Interval) {
-	dd.Interval = interval
+	dd.DemaInterval = interval
 
 	// DEMA
 	if dd.FastDEMAWindow == 0 {
 		dd.FastDEMAWindow = 144
 	}
-	dd.fastDEMA = &indicator.DEMA{IntervalWindow: types.IntervalWindow{Interval: dd.Interval, Window: dd.FastDEMAWindow}}
+	dd.fastDEMA = &indicator.DEMA{IntervalWindow: types.IntervalWindow{Interval: dd.DemaInterval, Window: dd.FastDEMAWindow}}
 	dd.fastDEMA.Bind(kLineStore)
 
 	if dd.SlowDEMAWindow == 0 {
 		dd.SlowDEMAWindow = 169
 	}
-	dd.slowDEMA = &indicator.DEMA{IntervalWindow: types.IntervalWindow{Interval: dd.Interval, Window: dd.SlowDEMAWindow}}
+	dd.slowDEMA = &indicator.DEMA{IntervalWindow: types.IntervalWindow{Interval: dd.DemaInterval, Window: dd.SlowDEMAWindow}}
 	dd.slowDEMA.Bind(kLineStore)
 
 	dd.preloadDema(kLineStore)

--- a/pkg/strategy/supertrend/strategy.go
+++ b/pkg/strategy/supertrend/strategy.go
@@ -39,17 +39,13 @@ type Strategy struct {
 	// Symbol is the market symbol you want to trade
 	Symbol string `json:"symbol"`
 
+	types.IntervalWindow
+
 	// Double DEMA
 	DoubleDema
 
-	// Interval is how long do you want to update your order price and quantity
-	Interval types.Interval `json:"interval"`
-
 	// SuperTrend indicator
-	// SuperTrend SuperTrend `json:"superTrend"`
 	Supertrend *indicator.Supertrend
-	// SupertrendWindow ATR window for calculation of supertrend
-	SupertrendWindow int `json:"supertrendWindow"`
 	// SupertrendMultiplier ATR multiplier for calculation of supertrend
 	SupertrendMultiplier float64 `json:"supertrendMultiplier"`
 
@@ -112,6 +108,7 @@ func (s *Strategy) Validate() error {
 
 func (s *Strategy) Subscribe(session *bbgo.ExchangeSession) {
 	session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.Interval})
+	session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.LinearRegression.Interval})
 }
 
 // Position control
@@ -168,14 +165,14 @@ func (s *Strategy) setupIndicators() {
 	s.setupDoubleDema(kLineStore, s.Interval)
 
 	// Supertrend
-	if s.SupertrendWindow == 0 {
-		s.SupertrendWindow = 39
+	if s.Window == 0 {
+		s.Window = 39
 	}
 	if s.SupertrendMultiplier == 0 {
 		s.SupertrendMultiplier = 3
 	}
-	s.Supertrend = &indicator.Supertrend{IntervalWindow: types.IntervalWindow{Window: s.SupertrendWindow, Interval: s.Interval}, ATRMultiplier: s.SupertrendMultiplier}
-	s.Supertrend.AverageTrueRange = &indicator.ATR{IntervalWindow: types.IntervalWindow{Window: s.SupertrendWindow, Interval: s.Interval}}
+	s.Supertrend = &indicator.Supertrend{IntervalWindow: types.IntervalWindow{Window: s.Window, Interval: s.Interval}, ATRMultiplier: s.SupertrendMultiplier}
+	s.Supertrend.AverageTrueRange = &indicator.ATR{IntervalWindow: types.IntervalWindow{Window: s.Window, Interval: s.Interval}}
 	s.Supertrend.Bind(kLineStore)
 	preloadSupertrend(s.Supertrend, kLineStore)
 


### PR DESCRIPTION
use types.IntervalWindow instead of types.Interval and resolve var name conflict