### PR TITLE
optimizer: prepare database before executing backtests

### DIFF
--- a/pkg/cmd/optimize.go
+++ b/pkg/cmd/optimize.go
@@ -101,6 +101,10 @@ var optimizeCmd = &cobra.Command{
 			Config: optConfig,
 		}
 
+		if err := executor.Prepare(configJson); err != nil {
+			return err
+		}
+
 		metrics, err := optz.Run(executor, configJson)
 		if err != nil {
 			return err

--- a/pkg/optimizer/local.go
+++ b/pkg/optimizer/local.go
@@ -76,6 +76,20 @@ func (e *LocalProcessExecutor) readReport(output []byte) (*backtest.SummaryRepor
 	return summaryReport, nil
 }
 
+// Prepare prepares the environment for the following back tests
+// this is a blocking operation
+func (e *LocalProcessExecutor) Prepare(configJson []byte) error {
+	log.Debugln("Sync database before launching backtests...")
+	tf, err := jsonToYamlConfig(e.ConfigDir, configJson)
+	if err != nil {
+		return err
+	}
+
+	c := exec.Command(e.Bin, "backtest", "--sync", "--sync-only", "--config", tf.Name())
+	_, err = c.Output()
+	return err
+}
+
 func (e *LocalProcessExecutor) Run(ctx context.Context, taskC chan BacktestTask, bar *pb.ProgressBar) (chan BacktestTask, error) {
 	var maxNumOfProcess = e.Config.MaxNumberOfProcesses
 	var resultsC = make(chan BacktestTask, maxNumOfProcess*2)


### PR DESCRIPTION
In current design, optimizer launches `bbgo backtest` as subprocesses, and these processes will apply DB migration during `DatabaseService` initialization. However, if the optimizer is launched with an empty database, the migrations in these subprocesses would apply their own migration and conflict. There are some ways to prevent such situation:

1. Check the DB before launching backtests, and tip user to execute `bbgo backtest --sync --sync-only` before grid searching logic.
2. Trigger DB sync before backtests. Implemented by this PR.

In addition, to the second approach, maybe it would be more convenient to provide `--sync-from` option to user?