### PR TITLE
backtest: correct final asset calculation

### DIFF
--- a/pkg/backtest/report.go
+++ b/pkg/backtest/report.go
@@ -86,7 +86,7 @@ func (r *SessionSymbolReport) InitialEquityValue() fixedpoint.Value {
 }
 
 func (r *SessionSymbolReport) FinalEquityValue() fixedpoint.Value {
-	return InQuoteAsset(r.FinalBalances, r.Market, r.StartPrice)
+	return InQuoteAsset(r.FinalBalances, r.Market, r.LastPrice)
 }
 
 func (r *SessionSymbolReport) Print(wantBaseAssetBaseline bool) {


### PR DESCRIPTION
The final asset should be

> quote + balance * _last_price_

Instead of

> quote + balance * _start_price_