### PR TITLE
strategy/pivotshort: refactor breaklow + add fake break stop

### DIFF
--- a/config/pivotshort.yaml
+++ b/config/pivotshort.yaml
@@ -42,13 +42,13 @@ exchangeStrategies:
       # Notice: When marketOrder is set, bounceRatio will not be used.
       # bounceRatio: 0.1%
 
-      # stopEMARange is the price range we allow short.
+      # stopEMA is the price range we allow short.
       # Short-allowed price range = [current price] > [EMA] * (1 - [stopEMARange])
       # Higher the stopEMARange than higher the chance to open a short
-      stopEMARange: 2%
       stopEMA:
         interval: 1h
         window: 99
+        range: 2%
 
       trendEMA:
         interval: 1d

--- a/pkg/bbgo/exit_cumulated_volume_take_profit.go
+++ b/pkg/bbgo/exit_cumulated_volume_take_profit.go
@@ -72,7 +72,9 @@ func (s *CumulatedVolumeTakeProfit) Bind(session *ExchangeSession, orderExecutor
 				cqv.Float64(),
 				s.MinQuoteVolume.Float64(), kline.Close.Float64())
 
-			_ = orderExecutor.ClosePosition(context.Background(), fixedpoint.One, "cumulatedVolumeTakeProfit")
+			if err := orderExecutor.ClosePosition(context.Background(), fixedpoint.One, "cumulatedVolumeTakeProfit") ; err != nil {
+				log.WithError(err).Errorf("close position error")
+			}
 			return
 		}
 	}))

--- a/pkg/bbgo/standard_indicator_set.go
+++ b/pkg/bbgo/standard_indicator_set.go
@@ -25,7 +25,7 @@ type StandardIndicatorSet struct {
 	// interval -> window
 	boll    map[types.IntervalWindowBandWidth]*indicator.BOLL
 	stoch   map[types.IntervalWindow]*indicator.STOCH
-	simples map[types.IntervalWindow]indicator.Simple
+	simples map[types.IntervalWindow]indicator.KLinePusher
 
 	stream types.Stream
 	store  *MarketDataStore
@@ -36,7 +36,7 @@ func NewStandardIndicatorSet(symbol string, stream types.Stream, store *MarketDa
 		Symbol:  symbol,
 		store:   store,
 		stream:  stream,
-		simples: make(map[types.IntervalWindow]indicator.Simple),
+		simples: make(map[types.IntervalWindow]indicator.KLinePusher),
 
 		boll:  make(map[types.IntervalWindowBandWidth]*indicator.BOLL),
 		stoch: make(map[types.IntervalWindow]*indicator.STOCH),
@@ -53,7 +53,7 @@ func (s *StandardIndicatorSet) initAndBind(inc indicator.KLinePusher, iw types.I
 	s.stream.OnKLineClosed(types.KLineWith(s.Symbol, iw.Interval, inc.PushK))
 }
 
-func (s *StandardIndicatorSet) allocateSimpleIndicator(t indicator.Simple, iw types.IntervalWindow) indicator.Simple {
+func (s *StandardIndicatorSet) allocateSimpleIndicator(t indicator.KLinePusher, iw types.IntervalWindow) indicator.KLinePusher {
 	inc, ok := s.simples[iw]
 	if ok {
 		return inc

--- a/pkg/indicator/pivot_low.go
+++ b/pkg/indicator/pivot_low.go
@@ -72,7 +72,7 @@ func calculatePivotLow(lows types.Float64Slice, window int) (float64, error) {
 		return 0., fmt.Errorf("insufficient elements for calculating with window = %d", window)
 	}
 
-	min := lows[length-(window-1):].Min()
+	min := lows[length-1-(window-1):].Min()
 	if min == lows.Index(int(window/2.)-1) {
 		return min, nil
 	}

--- a/pkg/indicator/pivot_low.go
+++ b/pkg/indicator/pivot_low.go
@@ -72,7 +72,7 @@ func calculatePivotLow(lows types.Float64Slice, window int) (float64, error) {
 		return 0., fmt.Errorf("insufficient elements for calculating with window = %d", window)
 	}
 
-	end := length-1
+	end := length - 1
 	min := lows[end-(window-1):].Min()
 	if min == lows.Index(int(window/2.)-1) {
 		return min, nil

--- a/pkg/indicator/pivot_low.go
+++ b/pkg/indicator/pivot_low.go
@@ -11,8 +11,9 @@ import (
 
 //go:generate callbackgen -type PivotLow
 type PivotLow struct {
-	types.IntervalWindow
 	types.SeriesBase
+
+	types.IntervalWindow
 
 	Lows    types.Float64Slice
 	Values  types.Float64Slice
@@ -71,15 +72,10 @@ func calculatePivotLow(lows types.Float64Slice, window int) (float64, error) {
 		return 0., fmt.Errorf("insufficient elements for calculating with window = %d", window)
 	}
 
-	var pv types.Float64Slice
-	for _, low := range lows {
-		pv.Push(low)
+	min := lows[length-(window-1):].Min()
+	if min == lows.Index(int(window/2.)-1) {
+		return min, nil
 	}
 
-	pl := 0.
-	if lows.Min() == lows.Index(int(window/2.)-1) {
-		pl = lows.Min()
-	}
-
-	return pl, nil
+	return 0., nil
 }

--- a/pkg/indicator/pivot_low.go
+++ b/pkg/indicator/pivot_low.go
@@ -72,7 +72,8 @@ func calculatePivotLow(lows types.Float64Slice, window int) (float64, error) {
 		return 0., fmt.Errorf("insufficient elements for calculating with window = %d", window)
 	}
 
-	min := lows[length-1-(window-1):].Min()
+	end := length-1
+	min := lows[end-(window-1):].Min()
 	if min == lows.Index(int(window/2.)-1) {
 		return min, nil
 	}

--- a/pkg/risk/account_value.go
+++ b/pkg/risk/account_value.go
@@ -164,6 +164,7 @@ func CalculateBaseQuantity(session *bbgo.ExchangeSession, market types.Market, p
 		leverage = fixedpoint.NewFromInt(3)
 	}
 
+
 	baseBalance, _ := session.Account.Balance(market.BaseCurrency)
 	quoteBalance, _ := session.Account.Balance(market.QuoteCurrency)
 
@@ -185,11 +186,11 @@ func CalculateBaseQuantity(session *bbgo.ExchangeSession, market types.Market, p
 		return quantity, fmt.Errorf("quantity is zero, can not submit sell order, please check your quantity settings")
 	}
 
-	// using leverage -- starts from here
 	if !quantity.IsZero() {
 		return quantity, nil
 	}
 
+	// using leverage -- starts from here
 	logrus.Infof("calculating available leveraged base quantity: base balance = %+v, quote balance = %+v", baseBalance, quoteBalance)
 
 	// calculate the quantity automatically

--- a/pkg/strategy/pivotshort/breaklow.go
+++ b/pkg/strategy/pivotshort/breaklow.go
@@ -96,13 +96,13 @@ func (s *BreakLow) Bind(session *bbgo.ExchangeSession, orderExecutor *bbgo.Gener
 
 	// update pivot low data
 	session.MarketDataStream.OnStart(func() {
-		lastLow := fixedpoint.NewFromFloat(s.pivot.Lows.Last())
+		lastLow := fixedpoint.NewFromFloat(s.pivot.Last())
 		if lastLow.IsZero() {
 			return
 		}
 
 		if lastLow.Compare(s.lastLow) != 0 {
-			bbgo.Notify("%s found new pivot low: %f", s.Symbol, s.pivot.Lows.Last())
+			bbgo.Notify("%s found new pivot low: %f", s.Symbol, s.pivot.Last())
 		}
 
 		s.lastLow = lastLow
@@ -127,7 +127,7 @@ func (s *BreakLow) Bind(session *bbgo.ExchangeSession, orderExecutor *bbgo.Gener
 	})
 
 	session.MarketDataStream.OnKLineClosed(types.KLineWith(symbol, s.Interval, func(kline types.KLine) {
-		lastLow := fixedpoint.NewFromFloat(s.pivot.Lows.Last())
+		lastLow := fixedpoint.NewFromFloat(s.pivot.Last())
 		if lastLow.IsZero() {
 			return
 		}
@@ -144,7 +144,7 @@ func (s *BreakLow) Bind(session *bbgo.ExchangeSession, orderExecutor *bbgo.Gener
 			return
 		}
 
-		bbgo.Notify("%s new pivot low: %f", s.Symbol, s.pivot.Lows.Last())
+		bbgo.Notify("%s new pivot low: %f", s.Symbol, s.pivot.Last())
 	}))
 
 	session.MarketDataStream.OnKLineClosed(types.KLineWith(symbol, types.Interval1m, func(kline types.KLine) {

--- a/pkg/strategy/pivotshort/breaklow.go
+++ b/pkg/strategy/pivotshort/breaklow.go
@@ -10,6 +10,15 @@ import (
 	"github.com/c9s/bbgo/pkg/types"
 )
 
+type StopEMA struct {
+	types.IntervalWindow
+	Range fixedpoint.Value `json:"range"`
+}
+
+type TrendEMA struct {
+	types.IntervalWindow
+}
+
 // BreakLow -- when price breaks the previous pivot low, we set a trade entry
 type BreakLow struct {
 	Symbol string

--- a/pkg/strategy/pivotshort/breaklow.go
+++ b/pkg/strategy/pivotshort/breaklow.go
@@ -19,7 +19,7 @@ type TrendEMA struct {
 	types.IntervalWindow
 }
 
-type ClosedKLineStop struct {
+type FakeBreakStop struct {
 	types.IntervalWindow
 }
 
@@ -46,7 +46,7 @@ type BreakLow struct {
 
 	TrendEMA *TrendEMA `json:"trendEMA"`
 
-	ClosedKLineStop *ClosedKLineStop `json:"closedKLineStop"`
+	FakeBreakStop *FakeBreakStop `json:"fakeBreakStop"`
 
 	lastLow fixedpoint.Value
 
@@ -77,8 +77,8 @@ func (s *BreakLow) Subscribe(session *bbgo.ExchangeSession) {
 		session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.TrendEMA.Interval})
 	}
 
-	if s.ClosedKLineStop != nil {
-		session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.ClosedKLineStop.Interval})
+	if s.FakeBreakStop != nil {
+		session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.FakeBreakStop.Interval})
 	}
 }
 
@@ -127,10 +127,10 @@ func (s *BreakLow) Bind(session *bbgo.ExchangeSession, orderExecutor *bbgo.Gener
 		}
 	}))
 
-	if s.ClosedKLineStop != nil {
+	if s.FakeBreakStop != nil {
 		// if the position is already opened, and we just break the low, this checks if the kline closed above the low,
 		// so that we can close the position earlier
-		session.MarketDataStream.OnKLineClosed(types.KLineWith(s.Symbol, s.ClosedKLineStop.Interval, func(k types.KLine) {
+		session.MarketDataStream.OnKLineClosed(types.KLineWith(s.Symbol, s.FakeBreakStop.Interval, func(k types.KLine) {
 			// make sure the position is opened, and it's a short position
 			if !position.IsOpened(k.Close) || !position.IsShort() {
 				return

--- a/pkg/strategy/pivotshort/resistance.go
+++ b/pkg/strategy/pivotshort/resistance.go
@@ -50,7 +50,7 @@ func (s *ResistanceShort) Bind(session *bbgo.ExchangeSession, orderExecutor *bbg
 	s.resistancePivot = session.StandardIndicatorSet(s.Symbol).PivotLow(s.IntervalWindow)
 
 	// use the last kline from the history before we get the next closed kline
-	s.updateResistanceOrders(fixedpoint.NewFromFloat(s.resistancePivot.Lows.Last()))
+	s.updateResistanceOrders(fixedpoint.NewFromFloat(s.resistancePivot.Last()))
 
 	session.MarketDataStream.OnKLineClosed(types.KLineWith(s.Symbol, s.Interval, func(kline types.KLine) {
 		position := s.orderExecutor.Position()
@@ -77,7 +77,7 @@ func tail(arr []float64, length int) []float64 {
 func (s *ResistanceShort) updateCurrentResistancePrice(closePrice fixedpoint.Value) bool {
 	minDistance := s.MinDistance.Float64()
 	groupDistance := s.GroupDistance.Float64()
-	resistancePrices := findPossibleResistancePrices(closePrice.Float64()*(1.0+minDistance), groupDistance, tail(s.resistancePivot.Lows, 6))
+	resistancePrices := findPossibleResistancePrices(closePrice.Float64()*(1.0+minDistance), groupDistance, s.resistancePivot.Values.Tail(6))
 	if len(resistancePrices) == 0 {
 		return false
 	}


### PR DESCRIPTION
```
symbol: ETHUSDT
winningRatio: "0.96296296"
numOfLossTrade: 27
numOfProfitTrade: 26
grossProfit: "31685.53749875"
grossLoss: "-5011.38425128"
profits:
    - "23.90000000"
    - "1.59999990"
    - "6880.39999990"
    - "24.92150000"
    - "29.40000000"
    - "16.59999999"
    - "2015.00000000"
    - "8.29999980"
    - "20.60000000"
    - "12.00000000"
    - "30.70000000"
    - "276.80000000"
    - "6675.50000000"
    - "14.89999990"
    - "21.00000000"
    - "22.79999990"
    - "1747.30000000"
    - "2.55799979"
    - "26.29999999"
    - "24.60000000"
    - "29.90000000"
    - "10716.39999990"
    - "146.24999989"
    - "1490.34999989"
    - "175.20000000"
    - "1252.25799990"
losses:
    - "-18.10000000"
    - "-383.10000010"
    - "-19.09999999"
    - "-0.72650020"
    - "-202.20000000"
    - "-208.20000000"
    - "-203.90000000"
    - "-263.80000000"
    - "-270.10000010"
    - "-267.20000000"
    - "-248.70000000"
    - "-264.80000009"
    - "-234.47500000"
    - "-254.84475010"
    - "-236.50000000"
    - "-9.19999999"
    - "-268.89999999"
    - "-299.80000000"
    - "-214.03850010"
    - "-322.73350000"
    - "-4.83062500"
    - "-229.14700020"
    - "-159.00000000"
    - "-35.50000010"
    - "-5.38250000"
    - "-129.53000010"
    - "-257.57587520"
mostProfitableTrade: "10716.39999990"
mostLossTrade: "-383.10000010"
profitFactor: "6.32271163"
totalNetProfit: "26674.15324747"

[0003] DEBUG ActiveOrderBook: order status CANCELED, removing order ORDER backtest | Fri, 17 Jun 2022 02:49:59 CST | 165 | ETHUSDT | LIMIT_MAKER SELL | 0/10 @ 1173.29263332 | CANCELED
[0003] DEBUG ActiveOrderBook: order status CANCELED, removing order ORDER backtest | Fri, 17 Jun 2022 02:49:59 CST | 165 | ETHUSDT | LIMIT_MAKER SELL | 0/10 @ 1173.29263332 | CANCELED
BACK-TEST REPORT
===============================================
START TIME: Sat, 01 Jan 2022 00:00:00 UTC
END TIME: Sat, 18 Jun 2022 00:00:00 UTC
INITIAL TOTAL BALANCE: BalanceMap[ETH: 10, USDT: 5000]
FINAL TOTAL BALANCE: BalanceMap[ETH: 10, USDT: 31674.1532484]
binance ETHUSDT PROFIT AND LOSS REPORT
===============================================
TRADES SINCE: 2022-01-03 16:08:59.999 +0000 UTC
NUMBER OF TRADES: 106
AVERAGE COST: $ 1,175.70
BASE ASSET POSITION: 0
TOTAL BUY VOLUME: 530
TOTAL SELL VOLUME: 530
CURRENT PRICE: $ 1,086.94
CURRENCY FEES:
 - FEE: 2150.97146465
PROFIT: $ 26,674.15
UNREALIZED PROFIT: $ 0.00
INITIAL ASSET IN USDT ~= 41762.1999 USDT (1 ETH = 3676.22)
FINAL ASSET IN USDT ~= 42543.5532 USDT (1 ETH = 1086.94)
REALIZED PROFIT: +26674.15324747 USDT
UNREALIZED PROFIT: 0 USDT
ASSET INCREASED: +781.35324841 USDT (+1.87%)
```