### PR TITLE
exchange: order fee-amount protection

### DIFF
--- a/config/drift.yaml
+++ b/config/drift.yaml
@@ -12,6 +12,13 @@ sessions:
     envVarPrefix: binance
     heikinAshi: false
 
+    # Drift strategy intends to place buy/sell orders as much value mas it could be. To exchanges that requires to
+    # calculate fees before placing limit orders (e.g. FTX Pro), make sure the fee rate is configured correctly and
+    # enable modifyOrderAmountForFee to prevent order rejection.
+    makerFeeRate: 0.0002
+    takerFeeRate: 0.0007
+    modifyOrderAmountForFee: false
+
 exchangeStrategies:
  
 - on: binance

--- a/config/driftBTC.yaml
+++ b/config/driftBTC.yaml
@@ -12,6 +12,13 @@ sessions:
     envVarPrefix: binance
     heikinAshi: false
 
+    # Drift strategy intends to place buy/sell orders as much value mas it could be. To exchanges that requires to
+    # calculate fees before placing limit orders (e.g. FTX Pro), make sure the fee rate is configured correctly and
+    # enable modifyOrderAmountForFee to prevent order rejection.
+    makerFeeRate: 0.0002
+    takerFeeRate: 0.0007
+    modifyOrderAmountForFee: false
+
 exchangeStrategies:
  
 - on: binance

--- a/pkg/bbgo/config_test.go
+++ b/pkg/bbgo/config_test.go
@@ -82,16 +82,25 @@ func TestLoadConfig(t *testing.T) {
 				assert.Equal(t, map[string]interface{}{
 					"sessions": map[string]interface{}{
 						"max": map[string]interface{}{
-							"exchange":     "max",
-							"envVarPrefix": "MAX",
-							"takerFeeRate": 0.,
-							"makerFeeRate": 0.,
+							"exchange":                "max",
+							"envVarPrefix":            "MAX",
+							"takerFeeRate":            0.,
+							"makerFeeRate":            0.,
+							"modifyOrderAmountForFee": false,
 						},
 						"binance": map[string]interface{}{
-							"exchange":     "binance",
-							"envVarPrefix": "BINANCE",
-							"takerFeeRate": 0.,
-							"makerFeeRate": 0.,
+							"exchange":                "binance",
+							"envVarPrefix":            "BINANCE",
+							"takerFeeRate":            0.,
+							"makerFeeRate":            0.,
+							"modifyOrderAmountForFee": false,
+						},
+						"ftx": map[string]interface{}{
+							"exchange":                "ftx",
+							"envVarPrefix":            "FTX",
+							"takerFeeRate":            0.,
+							"makerFeeRate":            0.,
+							"modifyOrderAmountForFee": true,
 						},
 					},
 					"build": map[string]interface{}{

--- a/pkg/bbgo/testdata/strategy.yaml
+++ b/pkg/bbgo/testdata/strategy.yaml
@@ -5,11 +5,19 @@ sessions:
     envVarPrefix: MAX
     takerFeeRate: 0
     makerFeeRate: 0
+    modifyOrderAmountForFee: false
   binance:
     exchange: binance
     envVarPrefix: BINANCE
     takerFeeRate: 0
     makerFeeRate: 0
+    modifyOrderAmountForFee: false
+  ftx:
+    exchange: ftx
+    envVarPrefix: FTX
+    takerFeeRate: 0
+    makerFeeRate: 0
+    modifyOrderAmountForFee: true
 
 exchangeStrategies:
 - on: ["binance"]

--- a/pkg/types/exchange.go
+++ b/pkg/types/exchange.go
@@ -106,6 +106,10 @@ type ExchangeDefaultFeeRates interface {
 	DefaultFeeRates() ExchangeFee
 }
 
+type ExchangeAmountFeeProtect interface {
+	SetModifyOrderAmountForFee(ExchangeFee)
+}
+
 type ExchangeTradeHistoryService interface {
 	QueryTrades(ctx context.Context, symbol string, options *TradeQueryOptions) ([]Trade, error)
 	QueryClosedOrders(ctx context.Context, symbol string, since, until time.Time, lastOrderID uint64) (orders []Order, err error)


### PR DESCRIPTION
Reduce the order amount to prevent submit rejection because of balance exceeding.

  submit_amount = original_amount / (1 + fee_rate)

Currently supported only by FTX Pro.

This PR replaces #859 