### PR TITLE
[HOLD] backtest: risk evaluation

### DIFF
--- a/config/backtest.yaml
+++ b/config/backtest.yaml
@@ -10,6 +10,12 @@ backtest:
   - max
   - kucoin
   - okex
+  accounts:
+    binance:
+      balances:
+        # Only list assets to be traded to make risk evaluation correct.
+        BTC: 0.0
+        USDT: 100.0
 
 exchangeStrategies:
 - on: binance

--- a/config/optimizer-hyperparam-search.yaml
+++ b/config/optimizer-hyperparam-search.yaml
@@ -15,6 +15,8 @@ algorithm: tpe
 # - profit: by trading profit
 # - volume: by trading volume
 # - equity: by equity difference
+# - sharpe: by Sharpe ratio
+# - sortino: by Sortino ratio
 objectiveBy: equity
 
 # Maximum number of search evaluations.

--- a/pkg/backtest/report.go
+++ b/pkg/backtest/report.go
@@ -49,6 +49,9 @@ type SummaryReport struct {
 	TotalGrossProfit fixedpoint.Value `json:"totalGrossProfit,omitempty"`
 	TotalGrossLoss   fixedpoint.Value `json:"totalGrossLoss,omitempty"`
 
+	SharpeRatio  float64 `json:"sharpeRatio"`
+	SortinoRatio float64 `json:"sortinoRatio"`
+
 	SymbolReports []SessionSymbolReport `json:"symbolReports,omitempty"`
 
 	Manifests Manifests `json:"manifests,omitempty"`

--- a/pkg/bbgo/session.go
+++ b/pkg/bbgo/session.go
@@ -509,6 +509,10 @@ func (session *ExchangeSession) StartPrice(symbol string) (price fixedpoint.Valu
 	return price, ok
 }
 
+func (session *ExchangeSession) AllStartPrices() map[string]fixedpoint.Value {
+	return session.startPrices
+}
+
 func (session *ExchangeSession) LastPrice(symbol string) (price fixedpoint.Value, ok bool) {
 	price, ok = session.lastPrices[symbol]
 	return price, ok

--- a/pkg/optimizer/config.go
+++ b/pkg/optimizer/config.go
@@ -79,7 +79,7 @@ func LoadConfig(yamlConfigFileName string) (*Config, error) {
 	switch objective := strings.ToLower(optConfig.Objective); objective {
 	case "", "default":
 		optConfig.Objective = HpOptimizerObjectiveEquity
-	case HpOptimizerObjectiveEquity, HpOptimizerObjectiveProfit, HpOptimizerObjectiveVolume:
+	case HpOptimizerObjectiveEquity, HpOptimizerObjectiveProfit, HpOptimizerObjectiveVolume, HpOptimizerObjectiveSharpeRatio, HpOptimizerObjectiveSortinoRatio:
 		optConfig.Objective = objective
 	default:
 		return nil, fmt.Errorf(`unknown objective "%s"`, optConfig.Objective)

--- a/pkg/optimizer/grid.go
+++ b/pkg/optimizer/grid.go
@@ -40,6 +40,14 @@ var TotalEquityDiff = func(summaryReport *backtest.SummaryReport) fixedpoint.Val
 	return finalEquity.Sub(initEquity)
 }
 
+var FinalSharpeRatio = func(summaryReport *backtest.SummaryReport) fixedpoint.Value {
+	return fixedpoint.NewFromFloat(summaryReport.SharpeRatio)
+}
+
+var FinalSortinoRatio = func(summaryReport *backtest.SummaryReport) fixedpoint.Value {
+	return fixedpoint.NewFromFloat(summaryReport.SortinoRatio)
+}
+
 type Metric struct {
 	// Labels is the labels of the given parameters
 	Labels []string `json:"labels,omitempty"`
@@ -199,6 +207,8 @@ func (o *GridOptimizer) Run(executor Executor, configJson []byte) (map[string][]
 		"totalProfit":     TotalProfitMetricValueFunc,
 		"totalVolume":     TotalVolume,
 		"totalEquityDiff": TotalEquityDiff,
+		"sharpeRatio":     FinalSharpeRatio,
+		"sortinoRatio":    FinalSortinoRatio,
 	}
 	var metrics = map[string][]Metric{}
 

--- a/pkg/optimizer/hpoptimizer.go
+++ b/pkg/optimizer/hpoptimizer.go
@@ -22,6 +22,10 @@ const (
 	HpOptimizerObjectiveProfit = "profit"
 	// HpOptimizerObjectiveVolume optimize the parameters to maximize trading volume
 	HpOptimizerObjectiveVolume = "volume"
+	// HpOptimizerObjectiveSharpeRatio optimize the parameters to maximize the Sharpe Ratio
+	HpOptimizerObjectiveSharpeRatio = "sharpe"
+	// HpOptimizerObjectiveSortinoRatio optimize the parameters to maximize the Sortino Ratio
+	HpOptimizerObjectiveSortinoRatio = "sortino"
 )
 
 const (
@@ -198,6 +202,10 @@ func (o *HyperparameterOptimizer) buildObjective(executor Executor, configJson [
 		metricValueFunc = TotalVolume
 	case HpOptimizerObjectiveEquity:
 		metricValueFunc = TotalEquityDiff
+	case HpOptimizerObjectiveSharpeRatio:
+		metricValueFunc = FinalSharpeRatio
+	case HpOptimizerObjectiveSortinoRatio:
+		metricValueFunc = FinalSortinoRatio
 	}
 
 	return func(trial goptuna.Trial) (float64, error) {


### PR DESCRIPTION
*DO NOT MERGE*, need to be integrated into trade collector.

Add risk evaluation in back test, and export Sharpe ratio and Sortino ratio as objective functions to optimizer.

## How it works

The Sharpe ratio and Sortino ratio are defined as:

```
            ROI_excess    E[ROI] - ROI_risk_free      E[ROI] - ROI_risk_free
  sharpe = ----------- = ------------------------- = -------------------------
           variability   sqrt(E[(ROI - E[ROI])^2])   sqrt(E[ROI^2] - E[ROI]^2)

            ROI_excess   E[ROI] - ROI_risk_free
  sortino = ---------- = -----------------------
               risk      sqrt(E[ROI_drawdown^2])
```

- The `ROI` is calculated from current asset value compare to the initial value. Take average by hours.
- The `ROI_risk_free` is the ROI if we hold the stable coins in CeFi and earn the interests. The annual interest return rate is set to 8%.

## Limitation

It is user's responsibility to set initial balance correctly. We calculate the initial equity by stored K-line prices, and evaluate the risk-free returns from initial equity. Users are not expected to set unrelated assets in initial balance. The ratios in the final report would be NaN if there's any asset that unable to be evaluated the value from K-line prices.