### PR TITLE
strategy: bollmaker: fix nil pointer

### DIFF
--- a/pkg/strategy/bollmaker/strategy.go
+++ b/pkg/strategy/bollmaker/strategy.go
@@ -429,6 +429,9 @@ func (s *Strategy) hasShortSet() bool {
 }
 
 func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, session *bbgo.ExchangeSession) error {
+	// initial required information
+	s.session = session
+
 	// StrategyController
 	s.Status = types.StrategyStatusRunning
 
@@ -459,9 +462,6 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 	if s.ShadowProtectionRatio.IsZero() {
 		s.ShadowProtectionRatio = fixedpoint.NewFromFloat(0.01)
 	}
-
-	// initial required information
-	s.session = session
 
 	s.neutralBoll = s.StandardIndicatorSet.BOLL(s.NeutralBollinger.IntervalWindow, s.NeutralBollinger.BandWidth)
 	s.defaultBoll = s.StandardIndicatorSet.BOLL(s.DefaultBollinger.IntervalWindow, s.DefaultBollinger.BandWidth)


### PR DESCRIPTION
Fix the following nil pointer panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x158 pc=0x4bb8187]
goroutine 1 [running]:
github.com/c9s/bbgo/pkg/bbgo.(*ExchangeSession).MarketDataStore(0x0, {0xc0004cbc9a, 0x6})
 /Users/coldturnip/dev/rfns/bbgo/pkg/bbgo/session.go:492 +0x27
github.com/c9s/bbgo/pkg/strategy/bollmaker.(*DynamicSpreadSettings).Initialize(0xc000a43c78, {0xc0004cbc9a, 0x6}, 0x0?)
 /Users/coldturnip/dev/rfns/bbgo/pkg/strategy/bollmaker/dynamic_spread.go:52 +0x11a
github.com/c9s/bbgo/pkg/strategy/bollmaker.(*Strategy).Run(0xc000a43b80, {0x555c7f0?, 0xc000111f80}, {0x401619a?, 0x0?}, 0xc0002d7040)
 /Users/coldturnip/dev/rfns/bbgo/pkg/strategy/bollmaker/strategy.go:440 +0xfe
github.com/c9s/bbgo/pkg/bbgo.(*Trader).RunSingleExchangeStrategy(0x5113480?, {0x555c7f0, 0xc000111f80}, {0xf4029e8, 0xc000a43b80}, 0x0?, {0x55566e8, 0xc0002730a0})
...
```