### PR TITLE
fix: backtest

### DIFF
--- a/pkg/backtest/exchange.go
+++ b/pkg/backtest/exchange.go
@@ -377,14 +377,13 @@ func (e *Exchange) ConsumeKLine(k types.KLine) {
 	kline1m, ok := matching.klineCache[k.Interval]
 	if ok { // pop out all the old
 		if kline1m.Interval != types.Interval1m {
-			panic("expect 1m kline, get " + kline1m.Interval.String())
+			panic("expect 1m kline, got " + kline1m.Interval.String())
 		}
 		e.currentTime = kline1m.EndTime.Time()
 		// here we generate trades and order updates
 		matching.processKLine(kline1m)
 		matching.NextKLine = &k
 		for _, kline := range matching.klineCache {
-			// log.Errorf("kline %v, next %v", param.kline, matching.NextKLine)
 			e.MarketDataStream.EmitKLineClosed(kline)
 			for _, h := range e.Src.Callbacks {
 				h(kline, e.Src)

--- a/pkg/backtest/exchange.go
+++ b/pkg/backtest/exchange.go
@@ -167,7 +167,7 @@ func (e *Exchange) QueryOrder(ctx context.Context, q types.OrderQuery) (*types.O
 func (e *Exchange) SubmitOrders(ctx context.Context, orders ...types.SubmitOrder) (createdOrders types.OrderSlice, err error) {
 	for _, order := range orders {
 		symbol := order.Symbol
-		matching, ok := e.MatchingBook(symbol)
+		matching, ok := e.matchingBook(symbol)
 		if !ok {
 			return nil, fmt.Errorf("matching engine is not initialized for symbol %s", symbol)
 		}
@@ -192,7 +192,7 @@ func (e *Exchange) SubmitOrders(ctx context.Context, orders ...types.SubmitOrder
 }
 
 func (e *Exchange) QueryOpenOrders(ctx context.Context, symbol string) (orders []types.Order, err error) {
-	matching, ok := e.MatchingBook(symbol)
+	matching, ok := e.matchingBook(symbol)
 	if !ok {
 		return nil, fmt.Errorf("matching engine is not initialized for symbol %s", symbol)
 	}
@@ -211,7 +211,7 @@ func (e *Exchange) QueryClosedOrders(ctx context.Context, symbol string, since, 
 
 func (e *Exchange) CancelOrders(ctx context.Context, orders ...types.Order) error {
 	for _, order := range orders {
-		matching, ok := e.MatchingBook(order.Symbol)
+		matching, ok := e.matchingBook(order.Symbol)
 		if !ok {
 			return fmt.Errorf("matching engine is not initialized for symbol %s", order.Symbol)
 		}
@@ -250,7 +250,7 @@ func (e *Exchange) QueryTrades(ctx context.Context, symbol string, options *type
 }
 
 func (e *Exchange) QueryTicker(ctx context.Context, symbol string) (*types.Ticker, error) {
-	matching, ok := e.MatchingBook(symbol)
+	matching, ok := e.matchingBook(symbol)
 	if !ok {
 		return nil, fmt.Errorf("matching engine is not initialized for symbol %s", symbol)
 	}
@@ -293,7 +293,7 @@ func (e *Exchange) QueryWithdrawHistory(ctx context.Context, asset string, since
 	return nil, nil
 }
 
-func (e *Exchange) MatchingBook(symbol string) (*SimplePriceMatching, bool) {
+func (e *Exchange) matchingBook(symbol string) (*SimplePriceMatching, bool) {
 	e.matchingBooksMutex.Lock()
 	m, ok := e.matchingBooks[symbol]
 	e.matchingBooksMutex.Unlock()
@@ -363,7 +363,7 @@ func (e *Exchange) SubscribeMarketData(startTime, endTime time.Time, extraInterv
 }
 
 func (e *Exchange) ConsumeKLine(k types.KLine, handlers []func(types.KLine, *ExchangeDataSource), src *ExchangeDataSource) {
-	matching, ok := e.MatchingBook(k.Symbol)
+	matching, ok := e.matchingBook(k.Symbol)
 	if !ok {
 		log.Errorf("matching book of %s is not initialized", k.Symbol)
 		return
@@ -381,16 +381,16 @@ func (e *Exchange) ConsumeKLine(k types.KLine, handlers []func(types.KLine, *Exc
 			}
 			// log.Errorf("kline %v, next %v", param.kline, matching.NextKLine)
 			e.MarketDataStream.EmitKLineClosed(param.kline)
-			for _, h := range param.callback {
+			for _, h := range param.callbacks {
 				h(param.kline, param.src)
 			}
 		}
 		matching.ParamCache = make(map[types.Interval]Param)
 	}
 	matching.ParamCache[k.Interval] = Param{
-		callback: handlers,
-		src:      src,
-		kline:    k,
+		callbacks: handlers,
+		src:       src,
+		kline:     k,
 	}
 }
 

--- a/pkg/backtest/exchange.go
+++ b/pkg/backtest/exchange.go
@@ -379,6 +379,7 @@ func (e *Exchange) ConsumeKLine(k types.KLine) {
 		if kline1m.Interval != types.Interval1m {
 			panic("expect 1m kline, get " + kline1m.Interval.String())
 		}
+		e.currentTime = kline1m.EndTime.Time()
 		// here we generate trades and order updates
 		matching.processKLine(kline1m)
 		matching.NextKLine = &k

--- a/pkg/backtest/exchange_klinec.go
+++ b/pkg/backtest/exchange_klinec.go
@@ -6,7 +6,8 @@ import (
 )
 
 type ExchangeDataSource struct {
-	C        chan types.KLine
-	Exchange *Exchange
-	Session  *bbgo.ExchangeSession
+	C         chan types.KLine
+	Exchange  *Exchange
+	Session   *bbgo.ExchangeSession
+	Callbacks []func(types.KLine, *ExchangeDataSource)
 }

--- a/pkg/backtest/matching.go
+++ b/pkg/backtest/matching.go
@@ -48,9 +48,9 @@ func init() {
 }
 
 type Param struct {
-	callback []func(types.KLine, *ExchangeDataSource)
-	kline    types.KLine
-	src      *ExchangeDataSource
+	callbacks []func(types.KLine, *ExchangeDataSource)
+	kline     types.KLine
+	src       *ExchangeDataSource
 }
 
 // SimplePriceMatching implements a simple kline data driven matching engine for backtest
@@ -193,9 +193,9 @@ func (m *SimplePriceMatching) PlaceOrder(o types.SubmitOrder) (*types.Order, *ty
 			order.Price = m.Market.TruncatePrice(m.LastPrice)
 			price = order.Price
 		} else if order.Type == types.OrderTypeLimit {
-			if m.NextKLine.High.Compare(order.Price) > 0 && order.Side == types.SideTypeBuy {
+			if m.NextKLine != nil && m.NextKLine.High.Compare(order.Price) > 0 && order.Side == types.SideTypeBuy {
 				order.AveragePrice = order.Price
-			} else if m.NextKLine.Low.Compare(order.Price) < 0 && order.Side == types.SideTypeSell {
+			} else if m.NextKLine != nil && m.NextKLine.Low.Compare(order.Price) < 0 && order.Side == types.SideTypeSell {
 				order.AveragePrice = order.Price
 			} else {
 

--- a/pkg/backtest/matching.go
+++ b/pkg/backtest/matching.go
@@ -187,12 +187,15 @@ func (m *SimplePriceMatching) PlaceOrder(o types.SubmitOrder) (*types.Order, *ty
 			order.Price = m.Market.TruncatePrice(m.LastPrice)
 			price = order.Price
 		} else if order.Type == types.OrderTypeLimit {
+			// if limit order's price is with the range of next kline
+			// we assume it will be traded as a maker trade, and is traded at its original price
+			// TODO: if it is treated as a maker trade, fee should be specially handled
+			// otherwise, set NextKLine.Close(i.e., m.LastPrice) to be the taker traded price
 			if m.NextKLine != nil && m.NextKLine.High.Compare(order.Price) > 0 && order.Side == types.SideTypeBuy {
 				order.AveragePrice = order.Price
 			} else if m.NextKLine != nil && m.NextKLine.Low.Compare(order.Price) < 0 && order.Side == types.SideTypeSell {
 				order.AveragePrice = order.Price
 			} else {
-
 				order.AveragePrice = m.Market.TruncatePrice(m.LastPrice)
 			}
 			price = order.AveragePrice

--- a/pkg/backtest/matching.go
+++ b/pkg/backtest/matching.go
@@ -47,12 +47,6 @@ func init() {
 	}
 }
 
-type Param struct {
-	callbacks []func(types.KLine, *ExchangeDataSource)
-	kline     types.KLine
-	src       *ExchangeDataSource
-}
-
 // SimplePriceMatching implements a simple kline data driven matching engine for backtest
 //go:generate callbackgen -type SimplePriceMatching
 type SimplePriceMatching struct {
@@ -64,7 +58,7 @@ type SimplePriceMatching struct {
 	askOrders    []types.Order
 	closedOrders map[uint64]types.Order
 
-	ParamCache  map[types.Interval]Param
+	klineCache  map[types.Interval]types.KLine
 	LastPrice   fixedpoint.Value
 	LastKLine   types.KLine
 	NextKLine   *types.KLine

--- a/pkg/backtest/report.go
+++ b/pkg/backtest/report.go
@@ -79,8 +79,8 @@ type SessionSymbolReport struct {
 	InitialBalances types.BalanceMap          `json:"initialBalances,omitempty"`
 	FinalBalances   types.BalanceMap          `json:"finalBalances,omitempty"`
 	Manifests       Manifests                 `json:"manifests,omitempty"`
-	Sharpe          float64                   `json:"sharpeRatio"`
-	Sortino         float64                   `json:"sortinoRatio"`
+	Sharpe          fixedpoint.Value          `json:"sharpeRatio"`
+	Sortino         fixedpoint.Value          `json:"sortinoRatio"`
 }
 
 func (r *SessionSymbolReport) InitialEquityValue() fixedpoint.Value {
@@ -119,16 +119,16 @@ func (r *SessionSymbolReport) Print(wantBaseAssetBaseline bool) {
 		color.Red("ASSET DECREASED: %v %s (%s)", finalQuoteAsset.Sub(initQuoteAsset), r.Market.QuoteCurrency, finalQuoteAsset.Sub(initQuoteAsset).Div(initQuoteAsset).FormatPercentage(2))
 	}
 
-	if r.Sharpe > 0.0 {
-		color.Green("REALIZED SHARPE RATIO: %.4f", r.Sharpe)
+	if r.Sharpe.Sign() > 0 {
+		color.Green("REALIZED SHARPE RATIO: %s", r.Sharpe.FormatString(4))
 	} else {
-		color.Red("REALIZED SHARPE RATIO: %.4f", r.Sharpe)
+		color.Red("REALIZED SHARPE RATIO: %s", r.Sharpe.FormatString(4))
 	}
 
-	if r.Sortino > 0.0 {
-		color.Green("REALIZED SORTINO RATIO: %.4f", r.Sortino)
+	if r.Sortino.Sign() > 0 {
+		color.Green("REALIZED SORTINO RATIO: %s", r.Sortino.FormatString(4))
 	} else {
-		color.Red("REALIZED SORTINO RATIO: %.4f", r.Sortino)
+		color.Red("REALIZED SORTINO RATIO: %s", r.Sortino.FormatString(4))
 	}
 
 	if wantBaseAssetBaseline {

--- a/pkg/cmd/backtest.go
+++ b/pkg/cmd/backtest.go
@@ -446,12 +446,7 @@ var BacktestCmd = &cobra.Command{
 			if numOfExchangeSources == 1 {
 				exSource := exchangeSources[0]
 				for k := range exSource.C {
-					exSource.Exchange.ConsumeKLine(k)
-
-					for _, h := range kLineHandlers {
-						h(k, &exSource)
-					}
-
+					exSource.Exchange.ConsumeKLine(k, kLineHandlers, &exSource)
 				}
 
 				if err := exSource.Exchange.CloseMarketData(); err != nil {
@@ -472,11 +467,7 @@ var BacktestCmd = &cobra.Command{
 						break RunMultiExchangeData
 					}
 
-					exK.Exchange.ConsumeKLine(k)
-
-					for _, h := range kLineHandlers {
-						h(k, &exK)
-					}
+					exK.Exchange.ConsumeKLine(k, kLineHandlers, &exK)
 				}
 			}
 		}()

--- a/pkg/fixedpoint/convert.go
+++ b/pkg/fixedpoint/convert.go
@@ -23,6 +23,8 @@ type Value int64
 const Zero = Value(0)
 const One = Value(1e8)
 const NegOne = Value(-1e8)
+const PosInf = Value(math.MaxInt64)
+const NegInf = Value(math.MinInt64)
 
 type RoundingMode int
 
@@ -81,6 +83,11 @@ func (v *Value) Scan(src interface{}) error {
 }
 
 func (v Value) Float64() float64 {
+	if v == PosInf {
+		return math.Inf(1)
+	} else if v == NegInf {
+		return math.Inf(-1)
+	}
 	return float64(v) / DefaultPow
 }
 
@@ -92,10 +99,20 @@ func (v Value) Abs() Value {
 }
 
 func (v Value) String() string {
+	if v == PosInf {
+		return "inf"
+	} else if v == NegInf {
+		return "-inf"
+	}
 	return strconv.FormatFloat(float64(v)/DefaultPow, 'f', -1, 64)
 }
 
 func (v Value) FormatString(prec int) string {
+	if v == PosInf {
+		return "inf"
+	} else if v == NegInf {
+		return "-inf"
+	}
 	pow := math.Pow10(prec)
 	return strconv.FormatFloat(
 		math.Trunc(float64(v)/DefaultPow*pow)/pow, 'f', prec, 64)
@@ -105,12 +122,22 @@ func (v Value) Percentage() string {
 	if v == 0 {
 		return "0"
 	}
+	if v == PosInf {
+		return "inf%"
+	} else if v == NegInf {
+		return "-inf%"
+	}
 	return strconv.FormatFloat(float64(v)/DefaultPow*100., 'f', -1, 64) + "%"
 }
 
 func (v Value) FormatPercentage(prec int) string {
 	if v == 0 {
 		return "0"
+	}
+	if v == PosInf {
+		return "inf%"
+	} else if v == NegInf {
+		return "-inf%"
 	}
 	pow := math.Pow10(prec)
 	result := strconv.FormatFloat(
@@ -407,6 +434,11 @@ func Must(v Value, err error) Value {
 }
 
 func NewFromFloat(val float64) Value {
+	if math.IsInf(val, 1) {
+		return PosInf
+	} else if math.IsInf(val, -1) {
+		return NegInf
+	}
 	return Value(int64(math.Trunc(val * DefaultPow)))
 }
 

--- a/pkg/fixedpoint/convert.go
+++ b/pkg/fixedpoint/convert.go
@@ -242,6 +242,9 @@ func (v Value) MarshalYAML() (interface{}, error) {
 }
 
 func (v Value) MarshalJSON() ([]byte, error) {
+	if v.IsInf() {
+		return []byte("\"" + v.String() + "\""), nil
+	}
 	return []byte(v.FormatString(DefaultPrecision)), nil
 }
 
@@ -444,6 +447,10 @@ func NewFromFloat(val float64) Value {
 
 func NewFromInt(val int64) Value {
 	return Value(val * DefaultPow)
+}
+
+func (a Value) IsInf() bool {
+	return a == PosInf || a == NegInf
 }
 
 func (a Value) MulExp(exp int) Value {

--- a/pkg/fixedpoint/dec.go
+++ b/pkg/fixedpoint/dec.go
@@ -1033,7 +1033,7 @@ func (x Value) Compare(y Value) int {
 }
 
 func (v Value) MarshalYAML() (interface{}, error) {
-        return v.FormatString(8), nil
+	return v.FormatString(8), nil
 }
 
 func (v *Value) UnmarshalYAML(unmarshal func(a interface{}) error) (err error) {
@@ -1061,6 +1061,9 @@ func (v *Value) UnmarshalYAML(unmarshal func(a interface{}) error) (err error) {
 
 // FIXME: should we limit to 8 prec?
 func (v Value) MarshalJSON() ([]byte, error) {
+	if v.IsInf() {
+		return []byte("\"" + v.String() + "\""), nil
+	}
 	return []byte(v.FormatString(8)), nil
 }
 

--- a/pkg/service/backtest.go
+++ b/pkg/service/backtest.go
@@ -210,10 +210,12 @@ func (s *BacktestService) QueryKLinesCh(since, until time.Time, exchange types.E
 	tableName := targetKlineTable(exchange.Name())
 	var query string
 
+	// need to sort by start_time desc in order to let matching engine process 1m first
+	// otherwise any other close event could peek on the final close price
 	if len(symbols) == 1 {
-		query = "SELECT * FROM `binance_klines` WHERE `end_time` BETWEEN :since AND :until AND `symbol` = :symbols AND `interval` IN (:intervals) ORDER BY end_time ASC"
+		query = "SELECT * FROM `binance_klines` WHERE `end_time` BETWEEN :since AND :until AND `symbol` = :symbols AND `interval` IN (:intervals) ORDER BY end_time ASC, start_time DESC"
 	} else {
-		query = "SELECT * FROM `binance_klines` WHERE `end_time` BETWEEN :since AND :until AND `symbol` IN (:symbols) AND `interval` IN (:intervals) ORDER BY end_time ASC"
+		query = "SELECT * FROM `binance_klines` WHERE `end_time` BETWEEN :since AND :until AND `symbol` IN (:symbols) AND `interval` IN (:intervals) ORDER BY end_time ASC, start_time DESC"
 	}
 
 	query = strings.ReplaceAll(query, "binance_klines", tableName)

--- a/pkg/strategy/output.go
+++ b/pkg/strategy/output.go
@@ -1,2 +1,0 @@
-package strategy
-

--- a/pkg/types/indicator.go
+++ b/pkg/types/indicator.go
@@ -754,6 +754,9 @@ func Stdev(a Series, params ...int) float64 {
 		diff := a.Index(i) - avg
 		s += diff * diff
 	}
+	if length-ddof == 0 {
+		return 0
+	}
 	return math.Sqrt(s / float64(length-ddof))
 }
 

--- a/pkg/types/indicator.go
+++ b/pkg/types/indicator.go
@@ -180,6 +180,9 @@ func Sum(a Series, limit ...int) (sum float64) {
 // otherwise will operate on all elements
 func Mean(a Series, limit ...int) (mean float64) {
 	l := a.Length()
+	if l == 0 {
+		return 0
+	}
 	if len(limit) > 0 && limit[0] < l {
 		l = limit[0]
 	}
@@ -741,6 +744,9 @@ func PercentageChange(a Series, offset ...int) SeriesExtend {
 
 func Stdev(a Series, params ...int) float64 {
 	length := a.Length()
+	if length == 0 {
+		return 0
+	}
 	if len(params) > 0 && params[0] < length {
 		length = params[0]
 	}

--- a/pkg/types/sharpe.go
+++ b/pkg/types/sharpe.go
@@ -16,6 +16,16 @@ func Sharpe(returns Series, periods int, annualize bool, smart bool) float64 {
 	if smart {
 		divisor *= autocorrPenalty(returns)
 	}
+	if divisor == 0 {
+		mean := Mean(data)
+		if mean > 0 {
+			return math.Inf(1)
+		} else if mean < 0 {
+			return math.Inf(-1)
+		} else {
+			return 0
+		}
+	}
 	result := Mean(data) / divisor
 	if annualize {
 		return result * math.Sqrt(float64(periods))

--- a/pkg/types/sortino.go
+++ b/pkg/types/sortino.go
@@ -24,6 +24,9 @@ func Sortino(returns Series, riskFreeReturns float64, periods int, annualize boo
 	}
 
 	num := returns.Length()
+	if num == 0 {
+		return 0
+	}
 	var sum = 0.
 	for i := 0; i < num; i++ {
 		exRet := returns.Index(i) - avgRiskFreeReturns
@@ -35,7 +38,15 @@ func Sortino(returns Series, riskFreeReturns float64, periods int, annualize boo
 	if smart {
 		risk *= autocorrPenalty(returns)
 	}
-
+	if risk == 0 {
+		if excessReturn > 0 {
+			return math.Inf(1)
+		} else if excessReturn < 0 {
+			return math.Inf(-1)
+		} else {
+			return 0
+		}
+	}
 	result := excessReturn / risk
 	if annualize {
 		return result * math.Sqrt(float64(periods))

--- a/pkg/types/trade_stats.go
+++ b/pkg/types/trade_stats.go
@@ -2,9 +2,10 @@ package types
 
 import (
 	"encoding/json"
-	"log"
 	"math"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"gopkg.in/yaml.v3"
 


### PR DESCRIPTION
- fix taker price (not always use m.LastPrice on instant limit trade)
- reorder LastKLine assignment
- reorder interval emit order
- reorder matching engine processing to the beginning of all the kline close event