### PR TITLE
refactor: simplify submit order

### DIFF
--- a/examples/exchange-api/binance-margin/main.go
+++ b/examples/exchange-api/binance-margin/main.go
@@ -94,7 +94,7 @@ var rootCmd = &cobra.Command{
 
 		time.Sleep(time.Second)
 
-		createdOrders, err := exchange.SubmitOrders(ctx, types.SubmitOrder{
+		createdOrders, err := exchange.SubmitOrder(ctx, types.SubmitOrder{
 			Symbol:           symbol,
 			Market:           market,
 			Side:             types.SideTypeBuy,

--- a/examples/exchange-api/binance-margin/main.go
+++ b/examples/exchange-api/binance-margin/main.go
@@ -94,7 +94,7 @@ var rootCmd = &cobra.Command{
 
 		time.Sleep(time.Second)
 
-		createdOrders, err := exchange.SubmitOrder(ctx, types.SubmitOrder{
+		createdOrder, err := exchange.SubmitOrder(ctx, types.SubmitOrder{
 			Symbol:           symbol,
 			Market:           market,
 			Side:             types.SideTypeBuy,
@@ -108,7 +108,7 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		log.Info(createdOrders)
+		log.Info(createdOrder)
 
 		cmdutil.WaitForSignal(ctx, syscall.SIGINT, syscall.SIGTERM)
 		return nil

--- a/pkg/bbgo/exit_trailing_stop_test.go
+++ b/pkg/bbgo/exit_trailing_stop_test.go
@@ -35,7 +35,7 @@ func TestTrailingStop_ShortPosition(t *testing.T) {
 
 	mockEx := mocks.NewMockExchange(mockCtrl)
 	mockEx.EXPECT().NewStream().Return(&types.StandardStream{}).Times(2)
-	mockEx.EXPECT().SubmitOrders(gomock.Any(), types.SubmitOrder{
+	mockEx.EXPECT().SubmitOrder(gomock.Any(), types.SubmitOrder{
 		Symbol:           "BTCUSDT",
 		Side:             types.SideTypeBuy,
 		Type:             types.OrderTypeMarket,
@@ -113,7 +113,7 @@ func TestTrailingStop_LongPosition(t *testing.T) {
 
 	mockEx := mocks.NewMockExchange(mockCtrl)
 	mockEx.EXPECT().NewStream().Return(&types.StandardStream{}).Times(2)
-	mockEx.EXPECT().SubmitOrders(gomock.Any(), types.SubmitOrder{
+	mockEx.EXPECT().SubmitOrder(gomock.Any(), types.SubmitOrder{
 		Symbol:           "BTCUSDT",
 		Side:             types.SideTypeSell,
 		Type:             types.OrderTypeMarket,

--- a/pkg/bbgo/order_execution.go
+++ b/pkg/bbgo/order_execution.go
@@ -62,6 +62,7 @@ func BatchRetryPlaceOrder(ctx context.Context, exchange types.Exchange, errIdx [
 	return createdOrders, err
 }
 
+// BatchPlaceOrder
 func BatchPlaceOrder(ctx context.Context, exchange types.Exchange, submitOrders ...types.SubmitOrder) (types.OrderSlice, []int, error) {
 	var createdOrders types.OrderSlice
 	var err error

--- a/pkg/bbgo/order_executor_general.go
+++ b/pkg/bbgo/order_executor_general.go
@@ -132,24 +132,34 @@ func (e *GeneralOrderExecutor) SubmitOrders(ctx context.Context, submitOrders ..
 type OpenPositionOptions struct {
 	// Long is for open a long position
 	// Long or Short must be set
-	Long bool
+	Long bool `json:"long"`
 
 	// Short is for open a short position
 	// Long or Short must be set
-	Short bool
+	Short bool `json:"short"`
 
 	// Leverage is used for leveraged position and account
-	Leverage fixedpoint.Value
+	Leverage fixedpoint.Value `json:"leverage,omitempty"`
 
-	Quantity        fixedpoint.Value
-	MarketOrder     bool
-	LimitOrder      bool
+	// Quantity will be used first, it will override the leverage if it's given.
+	Quantity fixedpoint.Value `json:"quantity,omitempty"`
+
+	// MarketOrder set to true to open a position with a market order
+	MarketOrder bool
+
+	// LimitOrder set to true to open a position with a limit order
+	LimitOrder bool
+
+	// LimitTakerRatio is used when LimitOrder = true, it adjusts the price of the limit order with a ratio.
+	// So you can ensure that the limit order can be a taker order. Higher the ratio, higher the chance it could be a taker order.
 	LimitTakerRatio fixedpoint.Value
 	CurrentPrice    fixedpoint.Value
 	Tag             string
 }
 
 func (e *GeneralOrderExecutor) OpenPosition(ctx context.Context, options OpenPositionOptions) error {
+	log.Infof("opening %s position: %+v", e.position.Symbol, options)
+
 	price := options.CurrentPrice
 	submitOrder := types.SubmitOrder{
 		Symbol:           e.position.Symbol,

--- a/pkg/bbgo/order_executor_general.go
+++ b/pkg/bbgo/order_executor_general.go
@@ -257,8 +257,11 @@ func (e *GeneralOrderExecutor) ClosePosition(ctx context.Context, percentage fix
 		return nil
 	}
 
-	log.Infof("closing %s position with tags: %v", e.symbol, tags)
-	submitOrder.Tag = strings.Join(tags, ",")
+	tagStr := strings.Join(tags, ",")
+	submitOrder.Tag = tagStr
+
+	Notify("closing %s position %s with tags: %v", e.symbol, percentage.Percentage(), tagStr)
+	
 	_, err := e.SubmitOrders(ctx, *submitOrder)
 	return err
 }

--- a/pkg/bbgo/order_executor_general.go
+++ b/pkg/bbgo/order_executor_general.go
@@ -248,6 +248,9 @@ func (e *GeneralOrderExecutor) GracefulCancel(ctx context.Context) error {
 	return e.GracefulCancelActiveOrderBook(ctx, e.activeMakerOrders)
 }
 
+// ClosePosition closes the current position by a percentage.
+// percentage 0.1 means close 10% position
+// tag is the order tag you want to attach, you may pass multiple tags, the tags will be combined into one tag string by commas.
 func (e *GeneralOrderExecutor) ClosePosition(ctx context.Context, percentage fixedpoint.Value, tags ...string) error {
 	submitOrder := e.position.NewMarketCloseOrder(percentage)
 	if submitOrder == nil {

--- a/pkg/cmd/orders.go
+++ b/pkg/cmd/orders.go
@@ -384,12 +384,12 @@ var submitOrderCmd = &cobra.Command{
 			so.TimeInForce = types.TimeInForceGTC
 		}
 
-		co, err := session.Exchange.SubmitOrders(ctx, so)
+		co, err := session.Exchange.SubmitOrder(ctx, so)
 		if err != nil {
 			return err
 		}
 
-		log.Infof("submitted order: %+v\ncreated order: %+v", so, co[0])
+		log.Infof("submitted order: %+v\ncreated order: %+v", so, co)
 		return nil
 	},
 }

--- a/pkg/datatype/floats/funcs_test.go
+++ b/pkg/datatype/floats/funcs_test.go
@@ -11,7 +11,6 @@ func TestLower(t *testing.T) {
 	assert.Equal(t, []float64{10.0, 11.0}, out)
 }
 
-
 func TestHigher(t *testing.T) {
 	out := Higher([]float64{10.0, 11.0, 12.0, 13.0, 15.0}, 12.0)
 	assert.Equal(t, []float64{13.0, 15.0}, out)

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -1251,33 +1251,20 @@ func (e *Exchange) submitSpotOrder(ctx context.Context, order types.SubmitOrder)
 	return createdOrder, err
 }
 
-func (e *Exchange) SubmitOrders(ctx context.Context, orders ...types.SubmitOrder) (createdOrders types.OrderSlice, err error) {
-	for _, order := range orders {
-		if err := orderLimiter.Wait(ctx); err != nil {
-			log.WithError(err).Errorf("order rate limiter wait error")
-		}
-
-		var createdOrder *types.Order
-		if e.IsMargin {
-			createdOrder, err = e.submitMarginOrder(ctx, order)
-		} else if e.IsFutures {
-			createdOrder, err = e.submitFuturesOrder(ctx, order)
-		} else {
-			createdOrder, err = e.submitSpotOrder(ctx, order)
-		}
-
-		if err != nil {
-			return createdOrders, err
-		}
-
-		if createdOrder == nil {
-			return createdOrders, errors.New("nil converted order")
-		}
-
-		createdOrders = append(createdOrders, *createdOrder)
+func (e *Exchange) SubmitOrder(ctx context.Context, order types.SubmitOrder) (createdOrder *types.Order, err error) {
+	if err := orderLimiter.Wait(ctx); err != nil {
+		log.WithError(err).Errorf("order rate limiter wait error")
 	}
 
-	return createdOrders, err
+	if e.IsMargin {
+		createdOrder, err = e.submitMarginOrder(ctx, order)
+	} else if e.IsFutures {
+		createdOrder, err = e.submitFuturesOrder(ctx, order)
+	} else {
+		createdOrder, err = e.submitSpotOrder(ctx, order)
+	}
+
+	return createdOrder, err
 }
 
 // QueryKLines queries the Kline/candlestick bars for a symbol. Klines are uniquely identified by their open time.

--- a/pkg/exchange/ftx/exchange_test.go
+++ b/pkg/exchange/ftx/exchange_test.go
@@ -34,7 +34,7 @@ func TestExchange_IOCOrder(t *testing.T) {
 	}
 
 	ex := NewExchange(key, secret, "")
-	createdOrder, err := ex.SubmitOrders(context.Background(), types.SubmitOrder{
+	createdOrder, err := ex.SubmitOrder(context.Background(), types.SubmitOrder{
 		Symbol:   "LTCUSDT",
 		Side:     types.SideTypeBuy,
 		Type:     types.OrderTypeLimitMaker,

--- a/pkg/strategy/fmaker/strategy.go
+++ b/pkg/strategy/fmaker/strategy.go
@@ -132,13 +132,14 @@ func (s *Strategy) ClosePosition(ctx context.Context, percentage fixedpoint.Valu
 
 	// s.Notify("Submitting %s %s order to close position by %v", s.Symbol, side.String(), percentage, submitOrder)
 
-	createdOrders, err := s.session.Exchange.SubmitOrders(ctx, submitOrder)
+	createdOrder, err := s.session.Exchange.SubmitOrder(ctx, submitOrder)
 	if err != nil {
 		log.WithError(err).Errorf("can not place position close order")
+	} else if createdOrder != nil {
+		s.orderStore.Add(*createdOrder)
+		s.activeMakerOrders.Add(*createdOrder)
 	}
 
-	s.orderStore.Add(createdOrders...)
-	s.activeMakerOrders.Add(createdOrders...)
 	return err
 }
 func (s *Strategy) InstanceID() string {
@@ -464,7 +465,7 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 			//	Price:    kline.Close.Mul(fixedpoint.One.Add(s.Spread)),
 			//	Quantity: fixedpoint.NewFromFloat(math.Max(math.Min(eq, 0.003), 0.0005)), //0.0005
 			// }
-			// createdOrders, err = orderExecutor.SubmitOrders(ctx, submitOrder)
+			// createdOrders, err = orderExecutor.SubmitOrder(ctx, submitOrder)
 			// if err != nil {
 			//	log.WithError(err).Errorf("can not place orders")
 			// }
@@ -495,7 +496,7 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 			//	Price:    kline.Close.Mul(fixedpoint.One.Sub(s.Spread)),
 			//	Quantity: fixedpoint.NewFromFloat(math.Max(math.Min(eq, 0.003), 0.0005)), //0.0005
 			// }
-			// createdOrders, err = orderExecutor.SubmitOrders(ctx, submitOrder)
+			// createdOrders, err = orderExecutor.SubmitOrder(ctx, submitOrder)
 			// if err != nil {
 			//	log.WithError(err).Errorf("can not place orders")
 			// }

--- a/pkg/strategy/xgap/strategy.go
+++ b/pkg/strategy/xgap/strategy.go
@@ -350,7 +350,7 @@ func (s *Strategy) CrossRun(ctx context.Context, _ bbgo.OrderExecutionRouter, se
 						s.tradingMarket.MinNotional.Mul(NotionModifier).Div(price))
 				}
 
-				createdOrders, err := tradingSession.Exchange.SubmitOrders(ctx, types.SubmitOrder{
+				createdOrders, _, err := bbgo.BatchPlaceOrder(ctx, tradingSession.Exchange, types.SubmitOrder{
 					Symbol:   s.Symbol,
 					Side:     types.SideTypeBuy,
 					Type:     types.OrderTypeLimit,
@@ -369,6 +369,7 @@ func (s *Strategy) CrossRun(ctx context.Context, _ bbgo.OrderExecutionRouter, se
 					// TimeInForce: types.TimeInForceGTC,
 					GroupID: s.groupID,
 				})
+
 				if err != nil {
 					log.WithError(err).Error("order submit error")
 				}

--- a/pkg/types/exchange.go
+++ b/pkg/types/exchange.go
@@ -96,7 +96,7 @@ type ExchangeTradeService interface {
 
 	QueryAccountBalances(ctx context.Context) (BalanceMap, error)
 
-	SubmitOrders(ctx context.Context, orders ...SubmitOrder) (createdOrders OrderSlice, err error)
+	SubmitOrder(ctx context.Context, order SubmitOrder) (createdOrder *Order, err error)
 
 	QueryOpenOrders(ctx context.Context, symbol string) (orders []Order, err error)
 

--- a/pkg/types/mocks/mock_exchange.go
+++ b/pkg/types/mocks/mock_exchange.go
@@ -206,22 +206,17 @@ func (mr *MockExchangeMockRecorder) QueryTickers(arg0 interface{}, arg1 ...inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryTickers", reflect.TypeOf((*MockExchange)(nil).QueryTickers), varargs...)
 }
 
-// SubmitOrders mocks base method.
-func (m *MockExchange) SubmitOrders(arg0 context.Context, arg1 ...types.SubmitOrder) (types.OrderSlice, error) {
+// SubmitOrder mocks base method.
+func (m *MockExchange) SubmitOrder(arg0 context.Context, arg1 types.SubmitOrder) (*types.Order, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
-	for _, a := range arg1 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "SubmitOrders", varargs...)
-	ret0, _ := ret[0].(types.OrderSlice)
+	ret := m.ctrl.Call(m, "SubmitOrder", arg0, arg1)
+	ret0, _ := ret[0].(*types.Order)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SubmitOrders indicates an expected call of SubmitOrders.
-func (mr *MockExchangeMockRecorder) SubmitOrders(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+// SubmitOrder indicates an expected call of SubmitOrder.
+func (mr *MockExchangeMockRecorder) SubmitOrder(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitOrders", reflect.TypeOf((*MockExchange)(nil).SubmitOrders), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitOrder", reflect.TypeOf((*MockExchange)(nil).SubmitOrder), arg0, arg1)
 }


### PR DESCRIPTION
all: simplify underlying exchange submitOrder method

- Replace SubmitOrders with SubmitOrder
- Accept only one submit order and return one created order
- Add bbgo.BatchPlaceOrders helper method and bbgo.BatchRetryPlaceOrders method