### PR TITLE
fix: add rate limit on telegram api and split messages by unicode

### DIFF
--- a/pkg/interact/telegram.go
+++ b/pkg/interact/telegram.go
@@ -68,6 +68,7 @@ type TelegramReply struct {
 }
 
 func (r *TelegramReply) Send(message string) {
+	ctx := context.Background()
 	splits := util.StringSplitByLength(message, maxMessageSize)
 	for _, split := range splits {
 		if err := sendLimiter.Wait(ctx); err != nil {

--- a/pkg/interact/telegram.go
+++ b/pkg/interact/telegram.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
 	"gopkg.in/tucnak/telebot.v2"
 )
 
@@ -14,6 +16,10 @@ func init() {
 	// force interface type check
 	_ = Reply(&TelegramReply{})
 }
+
+var sendLimiter = rate.NewLimiter(10, 2)
+
+const maxMessageSize int = 3000
 
 type TelegramSessionMap map[int64]*TelegramSession
 
@@ -62,7 +68,14 @@ type TelegramReply struct {
 }
 
 func (r *TelegramReply) Send(message string) {
-	checkSendErr(r.bot.Send(r.session.Chat, message))
+	var left, right int
+	for left, right = 0, maxMessageSize; right < len(message); left, right = right, right+maxMessageSize {
+		for !utf8.RuneStart(message[right]) {
+			right--
+		}
+		checkSendErr(r.bot.Send(r.session.Chat, message[left:right]))
+	}
+	checkSendErr(r.bot.Send(r.session.Chat, message[left:]))
 }
 
 func (r *TelegramReply) Message(message string) {
@@ -132,7 +145,7 @@ func (tm *Telegram) SetTextMessageResponder(responder Responder) {
 	tm.textMessageResponder = responder
 }
 
-func (tm *Telegram) Start(context.Context) {
+func (tm *Telegram) Start(ctx context.Context) {
 	tm.Bot.Handle(telebot.OnCallback, func(c *telebot.Callback) {
 		log.Infof("[telegram] onCallback: %+v", c)
 	})
@@ -158,7 +171,24 @@ func (tm *Telegram) Start(context.Context) {
 		if reply.set {
 			reply.build()
 			if len(reply.message) > 0 || reply.menu != nil {
-				checkSendErr(tm.Bot.Send(m.Chat, reply.message, reply.menu))
+				var left, right int
+				for left, right = 0, maxMessageSize; right < len(reply.message); left, right = right, right+maxMessageSize {
+					for !utf8.RuneStart(reply.message[right]) {
+						right--
+					}
+					if err := sendLimiter.Wait(ctx); err != nil {
+						log.WithError(err).Errorf("telegram send limit exceeded")
+					}
+					checkSendErr(tm.Bot.Send(m.Chat, reply.message[left:right]))
+
+				}
+				if left < len(reply.message) {
+					if err := sendLimiter.Wait(ctx); err != nil {
+						log.WithError(err).Errorf("telegram send limit exceeded")
+					}
+					// only set menu on the last message
+					checkSendErr(tm.Bot.Send(m.Chat, reply.message[left:], reply.menu))
+				}
 			}
 		}
 	})

--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -1,6 +1,9 @@
 package util
 
-import "strings"
+import (
+	"strings"
+	"unicode/utf8"
+)
 
 func StringSliceContains(slice []string, needle string) bool {
 	for _, s := range slice {
@@ -26,4 +29,18 @@ func MaskKey(key string) string {
 	maskKey += strings.Repeat("*", len(key)-h*2)
 	maskKey += key[len(key)-h:]
 	return maskKey
+}
+
+func StringSplitByLength(s string, length int) (result []string) {
+	var left, right int
+	for left, right = 0, length; right < len(s); left, right = right, right+length {
+		for !utf8.RuneStart(s[right]) {
+			right--
+		}
+		result = append(result, s[left:right])
+	}
+	if len(s)-left > 0 {
+		result = append(result, s[left:])
+	}
+	return result
 }

--- a/pkg/util/string_test.go
+++ b/pkg/util/string_test.go
@@ -1,6 +1,10 @@
 package util
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestMaskKey(t *testing.T) {
 	type args struct {
@@ -39,4 +43,11 @@ func TestMaskKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStringSplitByLength(t *testing.T) {
+	result := StringSplitByLength("1234567890", 3)
+	assert.Equal(t, result, []string{"123", "456", "789", "0"})
+	result = StringSplitByLength("123許456", 4)
+	assert.Equal(t, result, []string{"123", "許4", "56"})
 }


### PR DESCRIPTION
- add rate limit in telegram.
- split messages by size limit and unicode header.

not strictly following the size limit (4096 bytes) and rate limit (100req/s) written in telegram api doc.  
use 3000, 10 instead.