### PR TITLE
strategy:irr: a mean reversion based on box of klines in same direction

### DIFF
--- a/config/irr.yaml
+++ b/config/irr.yaml
@@ -17,8 +17,12 @@ exchangeStrategies:
     symbol: BTCBUSD
     # in milliseconds(ms)
     hftInterval: 5
-    # maxima position in USD
-    amount: 500.0
+    # indicator window
+    window: 100
+    # limit maker order quantity
+    quantity: 0.01
+    # bonus spread in USD
+    spread: 0.25
     # alpha1: negative return reversion
     NR: true
     # alpha2: moving average reversion

--- a/config/irr.yaml
+++ b/config/irr.yaml
@@ -15,9 +15,10 @@ exchangeStrategies:
 - on: binance
   irr:
     symbol: BTCBUSD
-    interval: 1m
+    interval: 1s
     window: 120
-    amount: 5_000.0
+    amount: 500.0
+    humpThreshold: 0.000025
     # Draw pnl
     drawGraph: true
     graphPNLPath: "./pnl.png"
@@ -26,8 +27,9 @@ exchangeStrategies:
 backtest:
   sessions:
     - binance
-  startTime: "2022-09-01"
-  endTime: "2022-10-04"
+  startTime: "2022-10-09"
+  endTime: "2022-10-11"
+#  syncSecKLines: true
   symbols:
     - BTCBUSD
   accounts:

--- a/config/irr.yaml
+++ b/config/irr.yaml
@@ -22,18 +22,10 @@ exchangeStrategies:
   irr:
     symbol: BTCBUSD
     # in milliseconds(ms)
+    # must > 10 ms
     hftInterval: 1000
-    # indicator window
-    window: 0
-    # maxima position in USD
-    amount: 100
+    # qty per trade
     quantity: 0.001
-    # minProfit pips in USD
-    pips: 0.0
-    # alpha1: negative return reversion
-    NR: true
-    # alpha2: moving average reversion
-    MR: true
     # Draw pnl
     drawGraph: true
     graphPNLPath: "./pnl.png"

--- a/config/irr.yaml
+++ b/config/irr.yaml
@@ -15,25 +15,11 @@ exchangeStrategies:
 - on: binance
   irr:
     symbol: BTCBUSD
-    interval: 1s
-    window: 120
+    # in milliseconds(ms)
+    hftInterval: 1000
+    # maxima position in USD
     amount: 500.0
-    humpThreshold: 0.000025
     # Draw pnl
     drawGraph: true
     graphPNLPath: "./pnl.png"
     graphCumPNLPath: "./cumpnl.png"
-
-backtest:
-  sessions:
-    - binance
-  startTime: "2022-10-09"
-  endTime: "2022-10-11"
-#  syncSecKLines: true
-  symbols:
-    - BTCBUSD
-  accounts:
-    binance:
-      takerFeeRate: 0.0
-      balances:
-        BUSD: 5_000.0

--- a/config/irr.yaml
+++ b/config/irr.yaml
@@ -10,19 +10,26 @@ sessions:
   binance:
     exchange: binance
     envVarPrefix: binance
+  max:
+    exchange: max
+    envVarPrefix:  max
+  ftx:
+    exchange: ftx
+    envVarPrefix: ftx
 
 exchangeStrategies:
 - on: binance
   irr:
     symbol: BTCBUSD
     # in milliseconds(ms)
-    hftInterval: 5
+    hftInterval: 1000
     # indicator window
-    window: 100
-    # limit maker order quantity
-    quantity: 0.01
-    # bonus spread in USD
-    spread: 0.25
+    window: 0
+    # maxima position in USD
+    amount: 100
+    quantity: 0.001
+    # minProfit pips in USD
+    pips: 0.0
     # alpha1: negative return reversion
     NR: true
     # alpha2: moving average reversion

--- a/config/irr.yaml
+++ b/config/irr.yaml
@@ -19,6 +19,10 @@ exchangeStrategies:
     hftInterval: 1000
     # maxima position in USD
     amount: 500.0
+    # alpha1: negative return reversion
+    NR: false
+    # alpha2: moving average reversion
+    MR: true
     # Draw pnl
     drawGraph: true
     graphPNLPath: "./pnl.png"

--- a/config/irr.yaml
+++ b/config/irr.yaml
@@ -16,11 +16,11 @@ exchangeStrategies:
   irr:
     symbol: BTCBUSD
     # in milliseconds(ms)
-    hftInterval: 1000
+    hftInterval: 5
     # maxima position in USD
     amount: 500.0
     # alpha1: negative return reversion
-    NR: false
+    NR: true
     # alpha2: moving average reversion
     MR: true
     # Draw pnl

--- a/pkg/strategy/irr/draw.go
+++ b/pkg/strategy/irr/draw.go
@@ -11,26 +11,41 @@ import (
 	"github.com/wcharczuk/go-chart/v2"
 )
 
-func (s *Strategy) InitDrawCommands(profit, cumProfit types.Series) {
-	bbgo.RegisterCommand("/pnl", "Draw PNL(%) per trade", func(reply interact.Reply) {
+func (s *Strategy) InitDrawCommands(profit, cumProfit, cumProfitDollar types.Series) {
+	bbgo.RegisterCommand("/rt", "Draw Return Rate(%) Per Trade", func(reply interact.Reply) {
+
 		canvas := DrawPNL(s.InstanceID(), profit)
 		var buffer bytes.Buffer
 		if err := canvas.Render(chart.PNG, &buffer); err != nil {
-			log.WithError(err).Errorf("cannot render pnl in drift")
-			reply.Message(fmt.Sprintf("[error] cannot render pnl in ewo: %v", err))
+			log.WithError(err).Errorf("cannot render return in irr")
+			reply.Message(fmt.Sprintf("[error] cannot render return in irr: %v", err))
 			return
 		}
-		bbgo.SendPhoto(&buffer)
+		go bbgo.SendPhoto(&buffer)
 	})
-	bbgo.RegisterCommand("/cumpnl", "Draw Cummulative PNL(Quote)", func(reply interact.Reply) {
+	bbgo.RegisterCommand("/nav", "Draw Net Assets Value", func(reply interact.Reply) {
+
 		canvas := DrawCumPNL(s.InstanceID(), cumProfit)
 		var buffer bytes.Buffer
 		if err := canvas.Render(chart.PNG, &buffer); err != nil {
-			log.WithError(err).Errorf("cannot render cumpnl in drift")
-			reply.Message(fmt.Sprintf("[error] canot render cumpnl in drift: %v", err))
+			log.WithError(err).Errorf("cannot render nav in irr")
+			reply.Message(fmt.Sprintf("[error] canot render nav in irr: %v", err))
 			return
 		}
-		bbgo.SendPhoto(&buffer)
+		go bbgo.SendPhoto(&buffer)
+
+	})
+	bbgo.RegisterCommand("/pnl", "Draw Cumulative Profit & Loss", func(reply interact.Reply) {
+
+		canvas := DrawCumPNL(s.InstanceID(), cumProfitDollar)
+		var buffer bytes.Buffer
+		if err := canvas.Render(chart.PNG, &buffer); err != nil {
+			log.WithError(err).Errorf("cannot render pnl in irr")
+			reply.Message(fmt.Sprintf("[error] canot render pnl in irr: %v", err))
+			return
+		}
+		go bbgo.SendPhoto(&buffer)
+
 	})
 }
 
@@ -77,7 +92,7 @@ func DrawPNL(instanceID string, profit types.Series) *types.Canvas {
 
 func DrawCumPNL(instanceID string, cumProfit types.Series) *types.Canvas {
 	canvas := types.NewCanvas(instanceID)
-	canvas.PlotRaw("cummulative pnl", cumProfit, cumProfit.Length())
+	canvas.PlotRaw("cumulative pnl", cumProfit, cumProfit.Length())
 	canvas.YAxis = chart.YAxis{
 		ValueFormatter: func(v interface{}) string {
 			if vf, isFloat := v.(float64); isFloat {

--- a/pkg/strategy/irr/draw.go
+++ b/pkg/strategy/irr/draw.go
@@ -16,44 +16,38 @@ func (s *Strategy) InitDrawCommands(profit, cumProfit, cumProfitDollar types.Ser
 
 		canvas := DrawPNL(s.InstanceID(), profit)
 		var buffer bytes.Buffer
-		go func() {
-			if err := canvas.Render(chart.PNG, &buffer); err != nil {
-				log.WithError(err).Errorf("cannot render return in irr")
-				reply.Message(fmt.Sprintf("[error] cannot render return in irr: %v", err))
-				return
-			}
-			bbgo.SendPhoto(&buffer)
+		if err := canvas.Render(chart.PNG, &buffer); err != nil {
+			log.WithError(err).Errorf("cannot render return in irr")
+			reply.Message(fmt.Sprintf("[error] cannot render return in irr: %v", err))
 			return
-		}()
+		}
+		bbgo.SendPhoto(&buffer)
+		return
 	})
 	bbgo.RegisterCommand("/nav", "Draw Net Assets Value", func(reply interact.Reply) {
 
 		canvas := DrawCumPNL(s.InstanceID(), cumProfit)
 		var buffer bytes.Buffer
-		go func() {
-			if err := canvas.Render(chart.PNG, &buffer); err != nil {
-				log.WithError(err).Errorf("cannot render nav in irr")
-				reply.Message(fmt.Sprintf("[error] canot render nav in irr: %v", err))
-				return
-			}
-			bbgo.SendPhoto(&buffer)
+		if err := canvas.Render(chart.PNG, &buffer); err != nil {
+			log.WithError(err).Errorf("cannot render nav in irr")
+			reply.Message(fmt.Sprintf("[error] canot render nav in irr: %v", err))
 			return
-		}()
+		}
+		bbgo.SendPhoto(&buffer)
+		return
 
 	})
 	bbgo.RegisterCommand("/pnl", "Draw Cumulative Profit & Loss", func(reply interact.Reply) {
 
 		canvas := DrawCumPNL(s.InstanceID(), cumProfitDollar)
 		var buffer bytes.Buffer
-		go func() {
-			if err := canvas.Render(chart.PNG, &buffer); err != nil {
-				log.WithError(err).Errorf("cannot render pnl in irr")
-				reply.Message(fmt.Sprintf("[error] canot render pnl in irr: %v", err))
-				return
-			}
-			bbgo.SendPhoto(&buffer)
+		if err := canvas.Render(chart.PNG, &buffer); err != nil {
+			log.WithError(err).Errorf("cannot render pnl in irr")
+			reply.Message(fmt.Sprintf("[error] canot render pnl in irr: %v", err))
 			return
-		}()
+		}
+		bbgo.SendPhoto(&buffer)
+		return
 	})
 }
 

--- a/pkg/strategy/irr/draw.go
+++ b/pkg/strategy/irr/draw.go
@@ -16,36 +16,44 @@ func (s *Strategy) InitDrawCommands(profit, cumProfit, cumProfitDollar types.Ser
 
 		canvas := DrawPNL(s.InstanceID(), profit)
 		var buffer bytes.Buffer
-		if err := canvas.Render(chart.PNG, &buffer); err != nil {
-			log.WithError(err).Errorf("cannot render return in irr")
-			reply.Message(fmt.Sprintf("[error] cannot render return in irr: %v", err))
+		go func() {
+			if err := canvas.Render(chart.PNG, &buffer); err != nil {
+				log.WithError(err).Errorf("cannot render return in irr")
+				reply.Message(fmt.Sprintf("[error] cannot render return in irr: %v", err))
+				return
+			}
+			bbgo.SendPhoto(&buffer)
 			return
-		}
-		go bbgo.SendPhoto(&buffer)
+		}()
 	})
 	bbgo.RegisterCommand("/nav", "Draw Net Assets Value", func(reply interact.Reply) {
 
 		canvas := DrawCumPNL(s.InstanceID(), cumProfit)
 		var buffer bytes.Buffer
-		if err := canvas.Render(chart.PNG, &buffer); err != nil {
-			log.WithError(err).Errorf("cannot render nav in irr")
-			reply.Message(fmt.Sprintf("[error] canot render nav in irr: %v", err))
+		go func() {
+			if err := canvas.Render(chart.PNG, &buffer); err != nil {
+				log.WithError(err).Errorf("cannot render nav in irr")
+				reply.Message(fmt.Sprintf("[error] canot render nav in irr: %v", err))
+				return
+			}
+			bbgo.SendPhoto(&buffer)
 			return
-		}
-		go bbgo.SendPhoto(&buffer)
+		}()
 
 	})
 	bbgo.RegisterCommand("/pnl", "Draw Cumulative Profit & Loss", func(reply interact.Reply) {
 
 		canvas := DrawCumPNL(s.InstanceID(), cumProfitDollar)
 		var buffer bytes.Buffer
-		if err := canvas.Render(chart.PNG, &buffer); err != nil {
-			log.WithError(err).Errorf("cannot render pnl in irr")
-			reply.Message(fmt.Sprintf("[error] canot render pnl in irr: %v", err))
+		go func() {
+			if err := canvas.Render(chart.PNG, &buffer); err != nil {
+				log.WithError(err).Errorf("cannot render pnl in irr")
+				reply.Message(fmt.Sprintf("[error] canot render pnl in irr: %v", err))
+				return
+			}
+			bbgo.SendPhoto(&buffer)
 			return
-		}
-		go bbgo.SendPhoto(&buffer)
-
+		}()
 	})
 }
 

--- a/pkg/strategy/irr/draw.go
+++ b/pkg/strategy/irr/draw.go
@@ -22,7 +22,6 @@ func (s *Strategy) InitDrawCommands(profit, cumProfit, cumProfitDollar types.Ser
 			return
 		}
 		bbgo.SendPhoto(&buffer)
-		return
 	})
 	bbgo.RegisterCommand("/nav", "Draw Net Assets Value", func(reply interact.Reply) {
 
@@ -34,8 +33,6 @@ func (s *Strategy) InitDrawCommands(profit, cumProfit, cumProfitDollar types.Ser
 			return
 		}
 		bbgo.SendPhoto(&buffer)
-		return
-
 	})
 	bbgo.RegisterCommand("/pnl", "Draw Cumulative Profit & Loss", func(reply interact.Reply) {
 
@@ -47,7 +44,6 @@ func (s *Strategy) InitDrawCommands(profit, cumProfit, cumProfitDollar types.Ser
 			return
 		}
 		bbgo.SendPhoto(&buffer)
-		return
 	})
 }
 

--- a/pkg/strategy/irr/strategy.go
+++ b/pkg/strategy/irr/strategy.go
@@ -412,12 +412,12 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 					rtMrRank = s.rtMr.Rank(s.rtMr.Length()).Last() / float64(s.rtMr.Length())
 				}
 				s.rtWeight.Update((rtNrRank + rtMrRank) / 2)
-				rtWeightRank := 0.
-				if s.rtWeight.Length() >= 100 {
-					rtWeightRank = s.rtWeight.Rank(s.rtWeight.Length()).Last() / float64(s.rtWeight.Length())
-				}
-				log.Infof("Alpha: %f/1.0", rtWeightRank)
-				s.rebalancePosition(s.obBuyPrice.Load(), s.obSellPrice.Load(), rtWeightRank)
+				//rtWeightRank := 0.
+				//if s.rtWeight.Length() >= 100 {
+				//	rtWeightRank = s.rtWeight.Rank(s.rtWeight.Length()).Last() / float64(s.rtWeight.Length())
+				//}
+				log.Infof("Alpha: %f/1.0", s.rtWeight.Last())
+				s.rebalancePosition(s.obBuyPrice.Load(), s.obSellPrice.Load(), s.rtWeight.Last())
 			}
 
 			previousRoundTime = currentRoundTime

--- a/pkg/strategy/irr/strategy.go
+++ b/pkg/strategy/irr/strategy.go
@@ -377,18 +377,18 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 
 					if s.currentTradePrice > 0 {
 						s.closePrice = float64(s.currentTradePrice)
-						log.Infof("Close Price: %f", float64(s.closePrice))
+						log.Infof("Close Price: %f", s.closePrice)
 						if s.closePrice > 0 && s.openPrice > 0 {
 							direction := s.closePrice - s.openPrice
-							klinDirections.Update(float64(direction))
+							klinDirections.Update(direction)
 							regimeShift := klinDirections.Index(0)*klinDirections.Index(1) < 0
 							if regimeShift && !started {
-								boxOpenPrice = float64(s.openPrice)
+								boxOpenPrice = s.openPrice
 								started = true
 								boxCounter = 0
 								log.Infof("box started at price: %f", boxOpenPrice)
 							} else if regimeShift && started {
-								boxClosePrice = float64(s.openPrice)
+								boxClosePrice = s.closePrice
 								started = false
 								log.Infof("box ended at price: %f with time length: %d", boxClosePrice, boxCounter)
 								// box ending, should re-balance position

--- a/pkg/strategy/irr/strategy.go
+++ b/pkg/strategy/irr/strategy.go
@@ -48,7 +48,9 @@ type Strategy struct {
 
 	bbgo.QuantityOrAmount
 
-	Interval int `json:"hftInterval"`
+	Interval int  `json:"hftInterval"`
+	NR       bool `json:"NR"`
+	MR       bool `json:"MR"`
 
 	// for back-test
 	Nrr *NRR
@@ -411,7 +413,15 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 				if s.rtMr.Length() >= 100 {
 					rtMrRank = s.rtMr.Rank(s.rtMr.Length()).Last() / float64(s.rtMr.Length())
 				}
-				s.rtWeight.Update((rtNrRank + rtMrRank) / 2)
+				alpha := 0.
+				if s.NR && s.MR {
+					alpha = (rtNrRank + rtMrRank) / 2
+				} else if s.NR && !s.MR {
+					alpha = rtNrRank
+				} else if !s.NR && s.MR {
+					alpha = rtMrRank
+				}
+				s.rtWeight.Update(alpha)
 				//rtWeightRank := 0.
 				//if s.rtWeight.Length() >= 100 {
 				//	rtWeightRank = s.rtWeight.Rank(s.rtWeight.Length()).Last() / float64(s.rtWeight.Length())


### PR DESCRIPTION
Due to the severe "delay" issue in binance 1s kline stream.
~~We've refactored irr strategy into backtesting mode (consume KLine onClose), and real-time mode (consume bookTicker which triggered every interval via goroutine)~~

~~Now we've redesigned the time ticker(goroutine) to consume aggerate trade market stream based on web socket .~~

Rollback to interval time trigger for a much easier programming model and really small intervals.