### PR TITLE
strategy: grid2 [part2] -- reverse order and arb profit calculation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data/bbgo_test.sql filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 data/bbgo_test.sql filter=lfs diff=lfs merge=lfs -text
+data/bbgo_test.sqlite3 filter=lfs diff=lfs merge=lfs -text

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -50,9 +50,10 @@ exchangeStrategies:
     ## triggerPrice is used for opening your grid only when the last price touches your pre-set price.
     ## this is useful when you don't want to create a grid from a higher price.
     ## for example, when the last price hit 17_000.0 then open a grid with the price range 13_000 to 20_000
-    triggerPrice: 17_000.0
+    triggerPrice: 16_900.0
 
-    stopLossPrice: 10_000.0
+    stopLossPrice: 16_000.0
+
     takeProfitPrice: 20_000.0
 
     ## profitSpread is the profit spread of the arbitrage order (sell order)

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -32,6 +32,9 @@ exchangeStrategies:
     # default: false
     compound: true
 
+    stopLossPrice: 10_000.0
+    takeProfitPrice: 20_000.0
+
     ## profitSpread is the profit spread of the arbitrage order (sell order)
     ## greater the profitSpread, greater the profit you make when the sell order is filled.
     ## you can set this instead of the default grid profit spread.

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -27,6 +27,11 @@ exchangeStrategies:
     lowerPrice: 12_000.0
     gridNumber: 100
 
+    # compound is used for buying more inventory when the profit is made by the filled SELL order.
+    # when compound is disabled, fixed quantity is used for each grid order.
+    # default: false
+    compound: true
+
     ## profitSpread is the profit spread of the arbitrage order (sell order)
     ## greater the profitSpread, greater the profit you make when the sell order is filled.
     ## you can set this instead of the default grid profit spread.

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -27,10 +27,14 @@ exchangeStrategies:
     lowerPrice: 12_000.0
     gridNumber: 100
 
-    # compound is used for buying more inventory when the profit is made by the filled SELL order.
-    # when compound is disabled, fixed quantity is used for each grid order.
-    # default: false
+    ## compound is used for buying more inventory when the profit is made by the filled SELL order.
+    ## when compound is disabled, fixed quantity is used for each grid order.
+    ## default: false
     compound: true
+
+    ## earnBase is used to profit base quantity instead of quote quantity.
+    ## meaning that earn BTC instead of USDT when trading in the BTCUSDT pair.
+    # earnBase: true
 
     stopLossPrice: 10_000.0
     takeProfitPrice: 20_000.0

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -35,8 +35,8 @@ exchangeStrategies:
   grid2:
     symbol: BTCUSDT
     upperPrice: 18_000.0
-    lowerPrice: 13_000.0
-    gridNumber: 100
+    lowerPrice: 15_000.0
+    gridNumber: 30
 
     ## compound is used for buying more inventory when the profit is made by the filled SELL order.
     ## when compound is disabled, fixed quantity is used for each grid order.

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -79,7 +79,7 @@ exchangeStrategies:
     # baseInvestment: 1.0
 
     feeRate: 0.075%
-    closeWhenCancelOrder: false
+    closeWhenCancelOrder: true
     resetPositionWhenStart: true
     clearOpenOrdersWhenStart: false
     keepOrdersWhenShutdown: false

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -1,4 +1,13 @@
 ---
+notifications:
+  slack:
+    defaultChannel: "dev-bbgo"
+    errorChannel: "bbgo-error"
+  switches:
+    trade: false
+    orderUpdate: false
+    submitOrder: false
+
 sessions:
   max:
     exchange: max
@@ -11,7 +20,7 @@ backtest:
   endTime: "2022-11-25"
   symbols:
   - BTCUSDT
-  sessions: [max]
+  sessions: [ max ]
   accounts:
     binance:
       balances:
@@ -26,8 +35,8 @@ exchangeStrategies:
   grid2:
     symbol: BTCUSDT
     upperPrice: 18_000.0
-    lowerPrice: 12_000.0
-    gridNumber: 10
+    lowerPrice: 13_000.0
+    gridNumber: 100
 
     ## compound is used for buying more inventory when the profit is made by the filled SELL order.
     ## when compound is disabled, fixed quantity is used for each grid order.

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -47,7 +47,11 @@ exchangeStrategies:
     ## meaning that earn BTC instead of USDT when trading in the BTCUSDT pair.
     # earnBase: true
 
+    ## triggerPrice is used for opening your grid only when the last price touches your pre-set price.
+    ## this is useful when you don't want to create a grid from a higher price.
+    ## for example, when the last price hit 17_000.0 then open a grid with the price range 13_000 to 20_000
     triggerPrice: 17_000.0
+
     stopLossPrice: 10_000.0
     takeProfitPrice: 20_000.0
 

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -50,7 +50,7 @@ exchangeStrategies:
     ## triggerPrice is used for opening your grid only when the last price touches your pre-set price.
     ## this is useful when you don't want to create a grid from a higher price.
     ## for example, when the last price hit 17_000.0 then open a grid with the price range 13_000 to 20_000
-    triggerPrice: 16_900.0
+    # triggerPrice: 16_900.0
 
     stopLossPrice: 16_000.0
 

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -47,6 +47,7 @@ exchangeStrategies:
     ## meaning that earn BTC instead of USDT when trading in the BTCUSDT pair.
     # earnBase: true
 
+    triggerPrice: 17_000.0
     stopLossPrice: 10_000.0
     takeProfitPrice: 20_000.0
 
@@ -70,4 +71,4 @@ exchangeStrategies:
     ##    quoteInvestment is required, and baseInvestment is optional (could be zero)
     ##    if you have existing BTC position and want to reuse it you can set the baseInvestment.
     quoteInvestment: 10_000
-    baseInvestment: 1.0
+    # baseInvestment: 1.0

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -35,8 +35,8 @@ exchangeStrategies:
   grid2:
     symbol: BTCUSDT
     upperPrice: 18_000.0
-    lowerPrice: 15_000.0
-    gridNumber: 30
+    lowerPrice: 16_000.0
+    gridNumber: 200
 
     ## compound is used for buying more inventory when the profit is made by the filled SELL order.
     ## when compound is disabled, fixed quantity is used for each grid order.

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -20,12 +20,14 @@ backtest:
 
 exchangeStrategies:
 
+## You can run the following command to cancel all grid orders if the orders are not successfully canceled:
+## go run ./cmd/bbgo --dotenv .env.local.max-staging cancel-order --all --symbol BTCUSDT --config config/grid2-max.yaml
 - on: max
   grid2:
     symbol: BTCUSDT
     upperPrice: 18_000.0
     lowerPrice: 12_000.0
-    gridNumber: 100
+    gridNumber: 10
 
     ## compound is used for buying more inventory when the profit is made by the filled SELL order.
     ## when compound is disabled, fixed quantity is used for each grid order.

--- a/config/grid2-max.yaml
+++ b/config/grid2-max.yaml
@@ -77,3 +77,9 @@ exchangeStrategies:
     ##    if you have existing BTC position and want to reuse it you can set the baseInvestment.
     quoteInvestment: 10_000
     # baseInvestment: 1.0
+
+    feeRate: 0.075%
+    closeWhenCancelOrder: false
+    resetPositionWhenStart: true
+    clearOpenOrdersWhenStart: false
+    keepOrdersWhenShutdown: false

--- a/config/grid2.yaml
+++ b/config/grid2.yaml
@@ -50,6 +50,8 @@ exchangeStrategies:
     ## for example, when the last price hit 17_000.0 then open a grid with the price range 13_000 to 20_000
     triggerPrice: 17_000.0
 
+    stopLossPrice: 10_000.0
+
     ## profitSpread is the profit spread of the arbitrage order (sell order)
     ## greater the profitSpread, greater the profit you make when the sell order is filled.
     ## you can set this instead of the default grid profit spread.

--- a/config/grid2.yaml
+++ b/config/grid2.yaml
@@ -45,11 +45,13 @@ exchangeStrategies:
     ## meaning that earn BTC instead of USDT when trading in the BTCUSDT pair.
     # earnBase: true
 
-    ## triggerPrice is used for opening your grid only when the last price touches your pre-set price.
+    ## triggerPrice is used for opening your grid only when the last price touches your trigger price.
     ## this is useful when you don't want to create a grid from a higher price.
     ## for example, when the last price hit 17_000.0 then open a grid with the price range 13_000 to 20_000
     triggerPrice: 17_000.0
 
+    ## triggerPrice is used for closing your grid only when the last price touches your stop loss price.
+    ## for example, when the price drops to 17_000.0 then close the grid and sell all base inventory.
     stopLossPrice: 10_000.0
 
     ## profitSpread is the profit spread of the arbitrage order (sell order)

--- a/config/grid2.yaml
+++ b/config/grid2.yaml
@@ -45,6 +45,11 @@ exchangeStrategies:
     ## meaning that earn BTC instead of USDT when trading in the BTCUSDT pair.
     # earnBase: true
 
+    ## triggerPrice is used for opening your grid only when the last price touches your pre-set price.
+    ## this is useful when you don't want to create a grid from a higher price.
+    ## for example, when the last price hit 17_000.0 then open a grid with the price range 13_000 to 20_000
+    triggerPrice: 17_000.0
+    
     ## profitSpread is the profit spread of the arbitrage order (sell order)
     ## greater the profitSpread, greater the profit you make when the sell order is filled.
     ## you can set this instead of the default grid profit spread.

--- a/config/grid2.yaml
+++ b/config/grid2.yaml
@@ -27,6 +27,11 @@ exchangeStrategies:
     lowerPrice: 10_000.0
     gridNumber: 10
 
+    # compound is used for buying more inventory when the profit is made by the filled SELL order.
+    # when compound is disabled, fixed quantity is used for each grid order.
+    # default: false
+    compound: true
+
     ## profitSpread is the profit spread of the arbitrage order (sell order)
     ## greater the profitSpread, greater the profit you make when the sell order is filled.
     ## you can set this instead of the default grid profit spread.

--- a/config/grid2.yaml
+++ b/config/grid2.yaml
@@ -74,4 +74,11 @@ exchangeStrategies:
     ##    quoteInvestment is required, and baseInvestment is optional (could be zero)
     ##    if you have existing BTC position and want to reuse it you can set the baseInvestment.
     quoteInvestment: 10_000
-    baseInvestment: 1.0
+
+    ## baseInvestment is optional
+    baseInvestment: 0.0
+
+    closeWhenCancelOrder: true
+    resetPositionWhenStart: false
+    clearOpenOrdersWhenStart: false
+    keepOrdersWhenShutdown: false

--- a/config/grid2.yaml
+++ b/config/grid2.yaml
@@ -16,8 +16,8 @@ sessions:
 # example command:
 #   go run ./cmd/bbgo backtest --config config/grid2.yaml --base-asset-baseline
 backtest:
-  startTime: "2022-01-01"
-  endTime: "2022-11-25"
+  startTime: "2022-06-01"
+  endTime: "2022-06-30"
   symbols:
   - BTCUSDT
   sessions: [binance]

--- a/config/grid2.yaml
+++ b/config/grid2.yaml
@@ -35,7 +35,7 @@ exchangeStrategies:
     ## earnBase is used to profit base quantity instead of quote quantity.
     ## meaning that earn BTC instead of USDT when trading in the BTCUSDT pair.
     # earnBase: true
-    
+
     ## profitSpread is the profit spread of the arbitrage order (sell order)
     ## greater the profitSpread, greater the profit you make when the sell order is filled.
     ## you can set this instead of the default grid profit spread.

--- a/config/grid2.yaml
+++ b/config/grid2.yaml
@@ -27,11 +27,15 @@ exchangeStrategies:
     lowerPrice: 10_000.0
     gridNumber: 10
 
-    # compound is used for buying more inventory when the profit is made by the filled SELL order.
-    # when compound is disabled, fixed quantity is used for each grid order.
-    # default: false
+    ## compound is used for buying more inventory when the profit is made by the filled SELL order.
+    ## when compound is disabled, fixed quantity is used for each grid order.
+    ## default: false
     compound: true
 
+    ## earnBase is used to profit base quantity instead of quote quantity.
+    ## meaning that earn BTC instead of USDT when trading in the BTCUSDT pair.
+    # earnBase: true
+    
     ## profitSpread is the profit spread of the arbitrage order (sell order)
     ## greater the profitSpread, greater the profit you make when the sell order is filled.
     ## you can set this instead of the default grid profit spread.

--- a/config/grid2.yaml
+++ b/config/grid2.yaml
@@ -1,4 +1,13 @@
 ---
+notifications:
+  slack:
+    defaultChannel: "dev-bbgo"
+    errorChannel: "bbgo-error"
+  switches:
+    trade: false
+    orderUpdate: false
+    submitOrder: false
+
 sessions:
   binance:
     exchange: binance

--- a/config/grid2.yaml
+++ b/config/grid2.yaml
@@ -49,7 +49,7 @@ exchangeStrategies:
     ## this is useful when you don't want to create a grid from a higher price.
     ## for example, when the last price hit 17_000.0 then open a grid with the price range 13_000 to 20_000
     triggerPrice: 17_000.0
-    
+
     ## profitSpread is the profit spread of the arbitrage order (sell order)
     ## greater the profitSpread, greater the profit you make when the sell order is filled.
     ## you can set this instead of the default grid profit spread.

--- a/data/bbgo_test.sql
+++ b/data/bbgo_test.sql
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e470f6615d327da7170df0ee0d846e04e0657f8aa4fece708c259725780a450
+size 24070617

--- a/data/bbgo_test.sqlite3
+++ b/data/bbgo_test.sqlite3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b771c3d1caace778141254c37d7e90a9bfaf757ffbfefb5e7c86694503c67d9
+size 31141888

--- a/doc/topics/strategy-testing.md
+++ b/doc/topics/strategy-testing.md
@@ -1,0 +1,18 @@
+## Strategy Testing
+
+A pre-built small backtest data db file is located at `data/bbgo_test.sql`.
+
+You can use this file for environments without networking to test your strategy.
+
+A small backtest data set is synchronized in the database:
+
+- exchange: binance
+- symbol: BTCUSDT
+- startDate: 2022-06-01
+- endDate: 2022-06-30
+
+To import the database, you can do:
+
+```shell
+mysql -uroot -pYOUR_PASSWORD < data/bbgo_test.sql
+```

--- a/doc/topics/strategy-testing.md
+++ b/doc/topics/strategy-testing.md
@@ -1,6 +1,8 @@
-## Strategy Testing
+# Strategy Testing
 
-A pre-built small backtest data db file is located at `data/bbgo_test.sql`, which contains 30days BTCUSDT kline data from binance.
+A pre-built small backtest data mysql database file is located at `data/bbgo_test.sql`, which contains 30days BTCUSDT kline data from binance.
+
+for SQLite, it's `data/bbgo_test.sqlite3`.
 
 You can use this file for environments without networking to test your strategy.
 
@@ -17,8 +19,32 @@ The SQL file is added via git-lfs, so you need to install git-lfs first:
 git lfs install
 ```
 
-To import the database, you can do:
+## Testing with MySQL
+
+To import the SQL file into your MySQL database, you can do:
 
 ```shell
 mysql -uroot -pYOUR_PASSWORD < data/bbgo_test.sql
+```
+
+Setup your database correctly:
+
+```shell
+DB_DRIVER=mysql
+DB_DSN=root:123123@tcp(127.0.0.1:3306)/bbgo
+```
+
+## Testing with SQLite3
+
+Create your own sqlite3 database copy in local:
+
+```shell
+cp -v data/bbgo_test.sqlite3 bbgo_test.sqlite3
+```
+
+Configure the environment variables to use SQLite3:
+
+```shell
+DB_DRIVER="sqlite3"
+DB_DSN="bbgo_test.sqlite3"
 ```

--- a/doc/topics/strategy-testing.md
+++ b/doc/topics/strategy-testing.md
@@ -1,6 +1,6 @@
 ## Strategy Testing
 
-A pre-built small backtest data db file is located at `data/bbgo_test.sql`.
+A pre-built small backtest data db file is located at `data/bbgo_test.sql`, which contains 30days BTCUSDT kline data from binance.
 
 You can use this file for environments without networking to test your strategy.
 
@@ -10,6 +10,12 @@ A small backtest data set is synchronized in the database:
 - symbol: BTCUSDT
 - startDate: 2022-06-01
 - endDate: 2022-06-30
+
+The SQL file is added via git-lfs, so you need to install git-lfs first:
+
+```shell
+git lfs install
+```
 
 To import the database, you can do:
 

--- a/pkg/bbgo/activeorderbook_callbacks.go
+++ b/pkg/bbgo/activeorderbook_callbacks.go
@@ -15,3 +15,13 @@ func (b *ActiveOrderBook) EmitFilled(o types.Order) {
 		cb(o)
 	}
 }
+
+func (b *ActiveOrderBook) OnCanceled(cb func(o types.Order)) {
+	b.canceledCallbacks = append(b.canceledCallbacks, cb)
+}
+
+func (b *ActiveOrderBook) EmitCanceled(o types.Order) {
+	for _, cb := range b.canceledCallbacks {
+		cb(o)
+	}
+}

--- a/pkg/bbgo/trade_store.go
+++ b/pkg/bbgo/trade_store.go
@@ -11,10 +11,6 @@ type TradeStore struct {
 	sync.Mutex
 
 	trades map[uint64]types.Trade
-
-	RemoveCancelled bool
-	RemoveFilled    bool
-	AddOrderUpdate  bool
 }
 
 func NewTradeStore() *TradeStore {
@@ -98,4 +94,10 @@ func (s *TradeStore) Add(trades ...types.Trade) {
 	for _, trade := range trades {
 		s.trades[trade.ID] = trade
 	}
+}
+
+func (s *TradeStore) BindStream(stream types.Stream) {
+	stream.OnTradeUpdate(func(trade types.Trade) {
+		s.Add(trade)
+	})
 }

--- a/pkg/bbgo/trade_store.go
+++ b/pkg/bbgo/trade_store.go
@@ -69,10 +69,21 @@ func (s *TradeStore) Filter(filter TradeFilter) {
 	s.Unlock()
 }
 
+func (s *TradeStore) GetOrderTrades(o types.Order) (trades []types.Trade) {
+	s.Lock()
+	for _, t := range s.trades {
+		if t.OrderID == o.OrderID {
+			trades = append(trades, t)
+		}
+	}
+	s.Unlock()
+	return trades
+}
+
 func (s *TradeStore) GetAndClear() (trades []types.Trade) {
 	s.Lock()
-	for _, o := range s.trades {
-		trades = append(trades, o)
+	for _, t := range s.trades {
+		trades = append(trades, t)
 	}
 	s.trades = make(map[uint64]types.Trade)
 	s.Unlock()

--- a/pkg/strategy/grid2/grid.go
+++ b/pkg/strategy/grid2/grid.go
@@ -188,5 +188,5 @@ func (g *Grid) updatePinsCache() {
 }
 
 func (g *Grid) String() string {
-	return fmt.Sprintf("grid: priceRange: %f <=> %f size: %f spread: %f", g.LowerPrice.Float64(), g.UpperPrice.Float64(), g.Size.Float64(), g.Spread.Float64())
+	return fmt.Sprintf("GRID: priceRange: %f <=> %f size: %f spread: %f", g.LowerPrice.Float64(), g.UpperPrice.Float64(), g.Size.Float64(), g.Spread.Float64())
 }

--- a/pkg/strategy/grid2/profit.go
+++ b/pkg/strategy/grid2/profit.go
@@ -1,0 +1,45 @@
+package grid2
+
+import (
+	"time"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+type GridProfit struct {
+	Currency string
+	Profit   fixedpoint.Value
+	Time     time.Time
+}
+
+type GridProfitStats struct {
+	Symbol           string           `json:"symbol"`
+	TotalBaseProfit  fixedpoint.Value `json:"totalBaseProfit"`
+	TotalQuoteProfit fixedpoint.Value `json:"totalQuoteProfit"`
+	FloatProfit      fixedpoint.Value `json:"floatProfit"`
+	GridProfit       fixedpoint.Value `json:"gridProfit"`
+	ArbitrageCount   int              `json:"arbitrageCount"`
+	TotalFee         fixedpoint.Value `json:"totalFee"`
+	Volume           fixedpoint.Value `json:"volume"`
+	Market           types.Market     `json:"market"`
+	ProfitEntries    []*GridProfit    `json:"profitEntries"`
+}
+
+func newGridProfitStats(market types.Market) *GridProfitStats {
+	return &GridProfitStats{
+		Symbol: market.Symbol,
+		Market: market,
+	}
+}
+
+func (s *GridProfitStats) AddProfit(profit *GridProfit) {
+	switch profit.Currency {
+	case s.Market.QuoteCurrency:
+		s.TotalQuoteProfit = s.TotalQuoteProfit.Add(profit.Profit)
+	case s.Market.BaseCurrency:
+		s.TotalBaseProfit = s.TotalBaseProfit.Add(profit.Profit)
+	}
+
+	s.ProfitEntries = append(s.ProfitEntries, profit)
+}

--- a/pkg/strategy/grid2/profit.go
+++ b/pkg/strategy/grid2/profit.go
@@ -29,8 +29,16 @@ type GridProfitStats struct {
 
 func newGridProfitStats(market types.Market) *GridProfitStats {
 	return &GridProfitStats{
-		Symbol: market.Symbol,
-		Market: market,
+		Symbol:           market.Symbol,
+		TotalBaseProfit:  fixedpoint.Zero,
+		TotalQuoteProfit: fixedpoint.Zero,
+		FloatProfit:      fixedpoint.Zero,
+		GridProfit:       fixedpoint.Zero,
+		ArbitrageCount:   0,
+		TotalFee:         fixedpoint.Zero,
+		Volume:           fixedpoint.Zero,
+		Market:           market,
+		ProfitEntries:    nil,
 	}
 }
 

--- a/pkg/strategy/grid2/profit.go
+++ b/pkg/strategy/grid2/profit.go
@@ -8,9 +8,10 @@ import (
 )
 
 type GridProfit struct {
-	Currency string
-	Profit   fixedpoint.Value
-	Time     time.Time
+	Currency string           `json:"currency"`
+	Profit   fixedpoint.Value `json:"profit"`
+	Time     time.Time        `json:"time"`
+	Order    types.Order      `json:"order"`
 }
 
 type GridProfitStats struct {

--- a/pkg/strategy/grid2/profit.go
+++ b/pkg/strategy/grid2/profit.go
@@ -16,15 +16,15 @@ type GridProfit struct {
 
 type GridProfitStats struct {
 	Symbol           string           `json:"symbol"`
-	TotalBaseProfit  fixedpoint.Value `json:"totalBaseProfit"`
-	TotalQuoteProfit fixedpoint.Value `json:"totalQuoteProfit"`
-	FloatProfit      fixedpoint.Value `json:"floatProfit"`
-	GridProfit       fixedpoint.Value `json:"gridProfit"`
-	ArbitrageCount   int              `json:"arbitrageCount"`
-	TotalFee         fixedpoint.Value `json:"totalFee"`
-	Volume           fixedpoint.Value `json:"volume"`
-	Market           types.Market     `json:"market"`
-	ProfitEntries    []*GridProfit    `json:"profitEntries"`
+	TotalBaseProfit  fixedpoint.Value `json:"totalBaseProfit,omitempty"`
+	TotalQuoteProfit fixedpoint.Value `json:"totalQuoteProfit,omitempty"`
+	FloatProfit      fixedpoint.Value `json:"floatProfit,omitempty"`
+	GridProfit       fixedpoint.Value `json:"gridProfit,omitempty"`
+	ArbitrageCount   int              `json:"arbitrageCount,omitempty"`
+	TotalFee         fixedpoint.Value `json:"totalFee,omitempty"`
+	Volume           fixedpoint.Value `json:"volume,omitempty"`
+	Market           types.Market     `json:"market,omitempty"`
+	ProfitEntries    []*GridProfit    `json:"profitEntries,omitempty"`
 }
 
 func newGridProfitStats(market types.Market) *GridProfitStats {

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -804,7 +804,7 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 	}
 
 	session.UserDataStream.OnStart(func() {
-		if !s.TriggerPrice.IsZero() {
+		if s.TriggerPrice.IsZero() {
 			if err := s.openGrid(ctx, session); err != nil {
 				s.logger.WithError(err).Errorf("failed to setup grid orders")
 			}

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -152,7 +152,7 @@ func (s *Strategy) handleOrderFilled(o types.Order) {
 		}
 
 		// use the profit to buy more inventory in the grid
-		if s.Compound {
+		if s.Compound || s.EarnBase {
 			quoteQuantity := o.Quantity.Mul(o.Price)
 			newQuantity = quoteQuantity.Div(newPrice)
 		}
@@ -161,6 +161,11 @@ func (s *Strategy) handleOrderFilled(o types.Order) {
 		newSide = types.SideTypeSell
 		if pin, ok := s.grid.NextHigherPin(newPrice); ok {
 			newPrice = fixedpoint.Value(pin)
+		}
+
+		if s.EarnBase {
+			quoteQuantity := o.Quantity.Mul(o.Price)
+			newQuantity = quoteQuantity.Div(newPrice)
 		}
 	}
 

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -809,6 +809,7 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 	})
 	s.orderExecutor.ActiveMakerOrders().OnFilled(s.handleOrderFilled)
 
+	// TODO: detect if there are previous grid orders on the order book
 	if s.ClearOpenOrdersWhenStart {
 		if err := s.clearOpenOrders(ctx, session); err != nil {
 			return err
@@ -819,6 +820,7 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 		defer wg.Done()
 
 		if s.KeepOrdersWhenShutdown {
+			s.logger.Infof("KeepOrdersWhenShutdown is set, will keep the orders on the exchange")
 			return
 		}
 

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -216,7 +216,7 @@ func (s *Strategy) handleOrderFilled(o types.Order) {
 	newSide := types.SideTypeSell
 	newPrice := o.Price
 	newQuantity := o.Quantity
-	quoteQuantity := o.Quantity.Mul(o.Price)
+	orderQuoteQuantity := o.Quantity.Mul(o.Price)
 
 	switch o.Side {
 	case types.SideTypeSell:
@@ -232,7 +232,7 @@ func (s *Strategy) handleOrderFilled(o types.Order) {
 
 		// use the profit to buy more inventory in the grid
 		if s.Compound || s.EarnBase {
-			newQuantity = quoteQuantity.Div(newPrice)
+			newQuantity = orderQuoteQuantity.Div(newPrice)
 		}
 
 		// calculate profit
@@ -250,8 +250,7 @@ func (s *Strategy) handleOrderFilled(o types.Order) {
 		}
 
 		if s.EarnBase {
-			quoteQuantity := o.Quantity.Mul(o.Price)
-			newQuantity = quoteQuantity.Div(newPrice)
+			newQuantity = orderQuoteQuantity.Div(newPrice)
 		}
 	}
 

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -497,6 +497,7 @@ func (s *Strategy) newTriggerPriceHandler(ctx context.Context, session *bbgo.Exc
 			return
 		}
 
+		s.logger.Infof("the last price %f hits triggerPrice %f, opening grid", k.Close.Float64(), s.TriggerPrice.Float64())
 		if err := s.openGrid(ctx, session); err != nil {
 			s.logger.WithError(err).Errorf("failed to setup grid orders")
 			return

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -776,6 +776,9 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 		s.Position = types.NewPositionFromMarket(s.Market)
 	}
 
+	// make this an option
+	// s.Position.Reset()
+
 	s.orderExecutor = bbgo.NewGeneralOrderExecutor(session, s.Symbol, ID, instanceID, s.Position)
 	s.orderExecutor.BindEnvironment(s.Environment)
 	s.orderExecutor.BindProfitStats(s.ProfitStats)

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -283,7 +283,8 @@ func (s *Strategy) checkRequiredInvestmentByQuantity(baseBalance, quoteBalance, 
 				requiredBase = requiredBase.Add(quantity)
 			} else if i > 0 { // we do not want to sell at i == 0
 				// convert sell to buy quote and add to requiredQuote
-				nextLowerPin := pins[i-1]
+				i--
+				nextLowerPin := pins[i]
 				nextLowerPrice := fixedpoint.Value(nextLowerPin)
 				requiredQuote = requiredQuote.Add(quantity.Mul(nextLowerPrice))
 				buyPlacedPrice = nextLowerPrice
@@ -343,7 +344,8 @@ func (s *Strategy) checkRequiredInvestmentByAmount(baseBalance, quoteBalance, am
 				requiredBase = requiredBase.Add(quantity)
 			} else if i > 0 { // we do not want to sell at i == 0
 				// convert sell to buy quote and add to requiredQuote
-				nextLowerPin := pins[i-1]
+				i--
+				nextLowerPin := pins[i]
 				nextLowerPrice := fixedpoint.Value(nextLowerPin)
 				requiredQuote = requiredQuote.Add(quantity.Mul(nextLowerPrice))
 				buyPlacedPrice = nextLowerPrice
@@ -400,7 +402,8 @@ func (s *Strategy) calculateQuoteInvestmentQuantity(quoteInvestment, lastPrice f
 			// quantity := amount.Div(lastPrice)
 			if i > 0 { // we do not want to sell at i == 0
 				// convert sell to buy quote and add to requiredQuote
-				nextLowerPin := pins[i-1]
+				i--
+				nextLowerPin := pins[i]
 				nextLowerPrice := fixedpoint.Value(nextLowerPin)
 				// requiredQuote = requiredQuote.Add(quantity.Mul(nextLowerPrice))
 				totalQuotePrice = totalQuotePrice.Add(nextLowerPrice)
@@ -467,7 +470,8 @@ func (s *Strategy) calculateQuoteBaseInvestmentQuantity(quoteInvestment, baseInv
 			// quantity := amount.Div(lastPrice)
 			if i > 0 { // we do not want to sell at i == 0
 				// convert sell to buy quote and add to requiredQuote
-				nextLowerPin := pins[i-1]
+				i--
+				nextLowerPin := pins[i]
 				nextLowerPrice := fixedpoint.Value(nextLowerPin)
 				// requiredQuote = requiredQuote.Add(quantity.Mul(nextLowerPrice))
 				totalQuotePrice = totalQuotePrice.Add(nextLowerPrice)
@@ -517,6 +521,10 @@ func (s *Strategy) newStopLossPriceHandler(ctx context.Context, session *bbgo.Ex
 
 		if err := s.closeGrid(ctx); err != nil {
 			s.logger.WithError(err).Errorf("can not close grid")
+			return
+		}
+
+		if s.Position.GetBase().Sign() < 0 {
 			return
 		}
 

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -653,7 +653,7 @@ func (s *Strategy) openGrid(ctx context.Context, session *bbgo.ExchangeSession) 
 	s.grid = NewGrid(s.LowerPrice, s.UpperPrice, fixedpoint.NewFromInt(s.GridNum), s.Market.TickSize)
 	s.grid.CalculateArithmeticPins()
 
-	s.logger.Info(s.grid.String())
+	s.logger.Info("OPENING GRID: ", s.grid.String())
 
 	lastPrice, err := s.getLastTradePrice(ctx, session)
 	if err != nil {
@@ -732,7 +732,12 @@ func (s *Strategy) openGrid(ctx context.Context, session *bbgo.ExchangeSession) 
 
 	// debug info
 	s.logger.Infof("GRID ORDERS: [")
-	for _, order := range submitOrders {
+	for i, order := range submitOrders {
+
+		if i > 0 && lastPrice.Compare(order.Price) >= 0 && lastPrice.Compare(submitOrders[i-1].Price) <= 0 {
+			s.logger.Info("  - LAST PRICE: %f", lastPrice.Float64())
+		}
+
 		s.logger.Info("  - ", order.String())
 	}
 	s.logger.Infof("] END OF GRID ORDERS")

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -88,11 +88,11 @@ type Strategy struct {
 	// If this is set, when bbgo started, it will clear the open orders in the same market (by symbol)
 	ClearOpenOrdersWhenStart bool `json:"clearOpenOrdersWhenStart"`
 
-	grid *Grid
-
 	ProfitStats *types.ProfitStats `persistence:"profit_stats"`
 	Position    *types.Position    `persistence:"position"`
 
+	grid          *Grid
+	session       *bbgo.ExchangeSession
 	orderExecutor *bbgo.GeneralOrderExecutor
 
 	// groupID is the group ID used for the strategy instance for canceling orders
@@ -692,12 +692,12 @@ func (s *Strategy) getLastTradePrice(ctx context.Context, session *bbgo.Exchange
 func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, session *bbgo.ExchangeSession) error {
 	instanceID := s.InstanceID()
 
+	s.session = session
 	s.logger = log.WithFields(logrus.Fields{
 		"symbol": s.Symbol,
 	})
 
 	s.groupID = util.FNV32(instanceID)
-
 	s.logger.Infof("using group id %d from fnv(%s)", s.groupID, instanceID)
 
 	if s.ProfitStats == nil {

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -83,8 +83,10 @@ type Strategy struct {
 	ProfitStats     *types.ProfitStats `persistence:"profit_stats"`
 	Position        *types.Position    `persistence:"position"`
 
-	grid          *Grid
-	session       *bbgo.ExchangeSession
+	grid              *Grid
+	session           *bbgo.ExchangeSession
+	orderQueryService types.ExchangeOrderQueryService
+
 	orderExecutor *bbgo.GeneralOrderExecutor
 
 	// groupID is the group ID used for the strategy instance for canceling orders
@@ -715,6 +717,11 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 	instanceID := s.InstanceID()
 
 	s.session = session
+
+	if service, ok := session.Exchange.(types.ExchangeOrderQueryService); ok {
+		s.orderQueryService = service
+	}
+
 	s.logger = log.WithFields(logrus.Fields{
 		"symbol": s.Symbol,
 	})

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -651,7 +651,8 @@ func (s *Strategy) openGrid(ctx context.Context, session *bbgo.ExchangeSession) 
 				usedBase = usedBase.Add(quantity)
 			} else if i > 0 {
 				// next price
-				nextPin := pins[i-1]
+				i--
+				nextPin := pins[i]
 				nextPrice := fixedpoint.Value(nextPin)
 				submitOrders = append(submitOrders, types.SubmitOrder{
 					Symbol:      s.Symbol,

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -165,6 +165,10 @@ func (s *Strategy) handleOrderCanceled(o types.Order) {
 }
 
 func (s *Strategy) handleOrderFilled(o types.Order) {
+	if s.grid == nil {
+		return
+	}
+
 	s.logger.Infof("GRID ORDER FILLED: %s", o.String())
 
 	// check order fee
@@ -485,6 +489,8 @@ func (s *Strategy) closeGrid(ctx context.Context) error {
 		return err
 	}
 
+	// free the grid object
+	s.grid = nil
 	return nil
 }
 

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -497,6 +497,10 @@ func (s *Strategy) newTriggerPriceHandler(ctx context.Context, session *bbgo.Exc
 			return
 		}
 
+		if s.grid != nil {
+			return
+		}
+
 		s.logger.Infof("the last price %f hits triggerPrice %f, opening grid", k.Close.Float64(), s.TriggerPrice.Float64())
 		if err := s.openGrid(ctx, session); err != nil {
 			s.logger.WithError(err).Errorf("failed to setup grid orders")

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -58,6 +58,11 @@ type Strategy struct {
 	// the profit is made by the filled sell order.
 	Compound bool `json:"compound"`
 
+	// EarnBase option is used for earning profit in base currency.
+	// e.g. earn BTC in BTCUSDT and earn ETH in ETHUSDT
+	// instead of earn USDT in BTCUSD
+	EarnBase bool `json:"earnBase"`
+
 	// QuantityOrAmount embeds the Quantity field and the Amount field
 	// If you set up the Quantity field or the Amount field, you don't need to set the QuoteInvestment and BaseInvestment
 	bbgo.QuantityOrAmount

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -82,11 +82,6 @@ type Strategy struct {
 	ProfitStats *types.ProfitStats `persistence:"profit_stats"`
 	Position    *types.Position    `persistence:"position"`
 
-	// orderStore is used to store all the created orders, so that we can filter the trades.
-	orderStore *bbgo.OrderStore
-
-	tradeCollector *bbgo.TradeCollector
-
 	orderExecutor *bbgo.GeneralOrderExecutor
 
 	// groupID is the group ID used for the strategy instance for canceling orders

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -165,6 +165,7 @@ func (s *Strategy) calculateProfit(o types.Order, buyPrice, buyQuantity fixedpoi
 			Currency: s.Market.BaseCurrency,
 			Profit:   profitQuantity,
 			Time:     o.UpdateTime.Time(),
+			Order:    o,
 		}
 		return profit
 	}
@@ -176,6 +177,7 @@ func (s *Strategy) calculateProfit(o types.Order, buyPrice, buyQuantity fixedpoi
 		Currency: s.Market.QuoteCurrency,
 		Profit:   profitQuantity,
 		Time:     o.UpdateTime.Time(),
+		Order:    o,
 	}
 	return profit
 }

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -114,7 +114,7 @@ func (s *Strategy) Validate() error {
 
 	if !s.ProfitSpread.IsZero() {
 		percent := s.ProfitSpread.Div(s.LowerPrice)
-		feeRate := fixedpoint.NewFromFloat(0.075 * 0.01)
+		feeRate := fixedpoint.NewFromFloat(0.1 * 0.01) // 0.1%, 0.075% with BNB
 		if percent.Compare(feeRate) < 0 {
 			return fmt.Errorf("profitSpread %f %s is too small, less than the fee rate: %s", s.ProfitSpread.Float64(), percent.Percentage(), feeRate.Percentage())
 		}

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -54,6 +54,10 @@ type Strategy struct {
 
 	LowerPrice fixedpoint.Value `json:"lowerPrice"`
 
+	// Compound option is used for buying more inventory when
+	// the profit is made by the filled sell order.
+	Compound bool `json:"compound"`
+
 	// QuantityOrAmount embeds the Quantity field and the Amount field
 	// If you set up the Quantity field or the Amount field, you don't need to set the QuoteInvestment and BaseInvestment
 	bbgo.QuantityOrAmount
@@ -143,8 +147,10 @@ func (s *Strategy) handleOrderFilled(o types.Order) {
 		}
 
 		// use the profit to buy more inventory in the grid
-		quoteQuantity := o.Quantity.Mul(o.Price)
-		newQuantity = quoteQuantity.Div(newPrice)
+		if s.Compound {
+			quoteQuantity := o.Quantity.Mul(o.Price)
+			newQuantity = quoteQuantity.Div(newPrice)
+		}
 
 	case types.SideTypeBuy:
 		newSide = types.SideTypeSell

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -685,22 +685,22 @@ func (s *Strategy) openGrid(ctx context.Context, session *bbgo.ExchangeSession) 
 			quoteQuantity := quantity.Mul(price)
 			usedQuote = usedQuote.Add(quoteQuantity)
 		}
+	}
 
-		createdOrders, err2 := s.orderExecutor.SubmitOrders(ctx, submitOrders...)
-		if err2 != nil {
-			return err
-		}
+	createdOrders, err2 := s.orderExecutor.SubmitOrders(ctx, submitOrders...)
+	if err2 != nil {
+		return err
+	}
 
-		// debug info
-		s.logger.Infof("GRID ORDERS: [")
-		for _, order := range submitOrders {
-			s.logger.Info("  - ", order.String())
-		}
-		s.logger.Infof("] END OF GRID ORDERS")
+	// debug info
+	s.logger.Infof("GRID ORDERS: [")
+	for _, order := range submitOrders {
+		s.logger.Info("  - ", order.String())
+	}
+	s.logger.Infof("] END OF GRID ORDERS")
 
-		for _, order := range createdOrders {
-			s.logger.Info(order.String())
-		}
+	for _, order := range createdOrders {
+		s.logger.Info(order.String())
 	}
 
 	return nil

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -658,7 +658,7 @@ func (s *Strategy) openGrid(ctx context.Context, session *bbgo.ExchangeSession) 
 					Quantity:    quantity,
 					Market:      s.Market,
 					TimeInForce: types.TimeInForceGTC,
-					Tag:         "grid",
+					Tag:         "grid2",
 				})
 				usedBase = usedBase.Add(quantity)
 			} else if i > 0 {
@@ -674,7 +674,7 @@ func (s *Strategy) openGrid(ctx context.Context, session *bbgo.ExchangeSession) 
 					Quantity:    quantity,
 					Market:      s.Market,
 					TimeInForce: types.TimeInForceGTC,
-					Tag:         "grid",
+					Tag:         "grid2",
 				})
 				quoteQuantity := quantity.Mul(price)
 				usedQuote = usedQuote.Add(quoteQuantity)

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -690,8 +690,16 @@ func (s *Strategy) openGrid(ctx context.Context, session *bbgo.ExchangeSession) 
 		if err2 != nil {
 			return err
 		}
+
+		// debug info
+		s.logger.Infof("GRID ORDERS: [")
+		for _, order := range submitOrders {
+			s.logger.Info("  - ", order.String())
+		}
+		s.logger.Infof("] END OF GRID ORDERS")
+
 		for _, order := range createdOrders {
-			s.logger.Infof(order.String())
+			s.logger.Info(order.String())
 		}
 	}
 

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -283,8 +283,7 @@ func (s *Strategy) checkRequiredInvestmentByQuantity(baseBalance, quoteBalance, 
 				requiredBase = requiredBase.Add(quantity)
 			} else if i > 0 { // we do not want to sell at i == 0
 				// convert sell to buy quote and add to requiredQuote
-				i--
-				nextLowerPin := pins[i]
+				nextLowerPin := pins[i-1]
 				nextLowerPrice := fixedpoint.Value(nextLowerPin)
 				requiredQuote = requiredQuote.Add(quantity.Mul(nextLowerPrice))
 				buyPlacedPrice = nextLowerPrice
@@ -344,8 +343,7 @@ func (s *Strategy) checkRequiredInvestmentByAmount(baseBalance, quoteBalance, am
 				requiredBase = requiredBase.Add(quantity)
 			} else if i > 0 { // we do not want to sell at i == 0
 				// convert sell to buy quote and add to requiredQuote
-				i--
-				nextLowerPin := pins[i]
+				nextLowerPin := pins[i-1]
 				nextLowerPrice := fixedpoint.Value(nextLowerPin)
 				requiredQuote = requiredQuote.Add(quantity.Mul(nextLowerPrice))
 				buyPlacedPrice = nextLowerPrice
@@ -402,8 +400,7 @@ func (s *Strategy) calculateQuoteInvestmentQuantity(quoteInvestment, lastPrice f
 			// quantity := amount.Div(lastPrice)
 			if i > 0 { // we do not want to sell at i == 0
 				// convert sell to buy quote and add to requiredQuote
-				i--
-				nextLowerPin := pins[i]
+				nextLowerPin := pins[i-1]
 				nextLowerPrice := fixedpoint.Value(nextLowerPin)
 				// requiredQuote = requiredQuote.Add(quantity.Mul(nextLowerPrice))
 				totalQuotePrice = totalQuotePrice.Add(nextLowerPrice)
@@ -470,8 +467,7 @@ func (s *Strategy) calculateQuoteBaseInvestmentQuantity(quoteInvestment, baseInv
 			// quantity := amount.Div(lastPrice)
 			if i > 0 { // we do not want to sell at i == 0
 				// convert sell to buy quote and add to requiredQuote
-				i--
-				nextLowerPin := pins[i]
+				nextLowerPin := pins[i-1]
 				nextLowerPrice := fixedpoint.Value(nextLowerPin)
 				// requiredQuote = requiredQuote.Add(quantity.Mul(nextLowerPrice))
 				totalQuotePrice = totalQuotePrice.Add(nextLowerPrice)
@@ -659,7 +655,6 @@ func (s *Strategy) openGrid(ctx context.Context, session *bbgo.ExchangeSession) 
 }
 
 func (s *Strategy) generateGridOrders(totalQuote, totalBase, lastPrice fixedpoint.Value) ([]types.SubmitOrder, error) {
-	var buyPlacedPrice = fixedpoint.Zero
 	var pins = s.grid.Pins
 	var usedBase = fixedpoint.Zero
 	var usedQuote = fixedpoint.Zero
@@ -692,8 +687,7 @@ func (s *Strategy) generateGridOrders(totalQuote, totalBase, lastPrice fixedpoin
 				usedBase = usedBase.Add(quantity)
 			} else if i > 0 {
 				// next price
-				i--
-				nextPin := pins[i]
+				nextPin := pins[i-1]
 				nextPrice := fixedpoint.Value(nextPin)
 				submitOrders = append(submitOrders, types.SubmitOrder{
 					Symbol:      s.Symbol,
@@ -707,16 +701,11 @@ func (s *Strategy) generateGridOrders(totalQuote, totalBase, lastPrice fixedpoin
 				})
 				quoteQuantity := quantity.Mul(price)
 				usedQuote = usedQuote.Add(quoteQuantity)
-				buyPlacedPrice = nextPrice
 			} else if i == 0 {
 				// skip i == 0
 			}
 		} else {
 			if i+1 == si {
-				continue
-			}
-
-			if !buyPlacedPrice.IsZero() && price.Compare(buyPlacedPrice) >= 0 {
 				continue
 			}
 

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -735,7 +735,7 @@ func (s *Strategy) openGrid(ctx context.Context, session *bbgo.ExchangeSession) 
 	for i, order := range submitOrders {
 
 		if i > 0 && lastPrice.Compare(order.Price) >= 0 && lastPrice.Compare(submitOrders[i-1].Price) <= 0 {
-			s.logger.Info("  - LAST PRICE: %f", lastPrice.Float64())
+			s.logger.Infof("  - LAST PRICE: %f", lastPrice.Float64())
 		}
 
 		s.logger.Info("  - ", order.String())

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -127,7 +127,7 @@ func (s *Strategy) Validate() error {
 		// the min fee rate from 2 maker/taker orders
 		minProfitSpread := s.FeeRate.Mul(fixedpoint.NewFromInt(2))
 		if percent.Compare(minProfitSpread) < 0 {
-			return fmt.Errorf("profitSpread %f %s is too small, less than the fee rate: %s", s.ProfitSpread.Float64(), percent.Percentage(), feeRate.Percentage())
+			return fmt.Errorf("profitSpread %f %s is too small, less than the fee rate: %s", s.ProfitSpread.Float64(), percent.Percentage(), s.FeeRate.Percentage())
 		}
 	}
 

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -519,15 +519,19 @@ func (s *Strategy) newStopLossPriceHandler(ctx context.Context, session *bbgo.Ex
 			return
 		}
 
+		s.logger.Infof("last low price %f hits stopLossPrice %f, closing grid", k.Low.Float64(), s.StopLossPrice.Float64())
+
 		if err := s.closeGrid(ctx); err != nil {
 			s.logger.WithError(err).Errorf("can not close grid")
 			return
 		}
 
-		if s.Position.GetBase().Sign() < 0 {
+		base := s.Position.GetBase()
+		if base.Sign() < 0 {
 			return
 		}
 
+		s.logger.Infof("position base %f > 0, closing position...", base.Float64())
 		if err := s.orderExecutor.ClosePosition(ctx, fixedpoint.One, "grid2:stopLoss"); err != nil {
 			s.logger.WithError(err).Errorf("can not close position")
 			return

--- a/pkg/strategy/grid2/strategy_test.go
+++ b/pkg/strategy/grid2/strategy_test.go
@@ -119,6 +119,36 @@ func TestStrategy_generateGridOrders(t *testing.T) {
 			{number(10000.0), types.SideTypeBuy},
 		}, orders)
 	})
+
+	t.Run("enough base + quote", func(t *testing.T) {
+		s := newTestStrategy()
+		s.grid = NewGrid(s.LowerPrice, s.UpperPrice, fixedpoint.NewFromInt(s.GridNum), s.Market.TickSize)
+		s.grid.CalculateArithmeticPins()
+		s.QuantityOrAmount.Quantity = number(0.01)
+
+		lastPrice := number(15300)
+		orders, err := s.generateGridOrders(number(10000.0), number(1.0), lastPrice)
+		assert.NoError(t, err)
+		if !assert.Equal(t, 10, len(orders)) {
+			for _, o := range orders {
+				t.Logf("- %s %s", o.Price.String(), o.Side)
+			}
+		}
+
+		assertPriceSide(t, []PriceSideAssert{
+			{number(20000.0), types.SideTypeSell},
+			{number(19000.0), types.SideTypeSell},
+			{number(18000.0), types.SideTypeSell},
+			{number(17000.0), types.SideTypeSell},
+			{number(16000.0), types.SideTypeSell},
+			{number(14000.0), types.SideTypeBuy},
+			{number(13000.0), types.SideTypeBuy},
+			{number(12000.0), types.SideTypeBuy},
+			{number(11000.0), types.SideTypeBuy},
+			{number(10000.0), types.SideTypeBuy},
+		}, orders)
+	})
+
 }
 
 func TestStrategy_checkRequiredInvestmentByAmount(t *testing.T) {

--- a/pkg/strategy/grid2/strategy_test.go
+++ b/pkg/strategy/grid2/strategy_test.go
@@ -70,8 +70,8 @@ func TestStrategy_checkRequiredInvestmentByAmount(t *testing.T) {
 				Pin(number(14_000.0)),
 				Pin(number(15_000.0)),
 			})
-		assert.EqualError(t, err, "quote balance (3000.000000 USDT) is not enough, required = quote 4999.999890")
-		assert.InDelta(t, 4999.99989, requiredQuote.Float64(), number(0.001).Float64())
+		assert.EqualError(t, err, "quote balance (3000.000000 USDT) is not enough, required = quote 5037.036980")
+		assert.InDelta(t, 5037.036980, requiredQuote.Float64(), number(0.001).Float64())
 	})
 }
 

--- a/pkg/strategy/grid2/strategy_test.go
+++ b/pkg/strategy/grid2/strategy_test.go
@@ -107,10 +107,14 @@ func newTestStrategy() *Strategy {
 		BaseCurrency:  "BTC",
 		QuoteCurrency: "USDT",
 	}
+
 	s := &Strategy{
 		logger:          logrus.NewEntry(logrus.New()),
 		Market:          market,
 		GridProfitStats: newGridProfitStats(market),
+		UpperPrice:      number(20_000),
+		LowerPrice:      number(10_000),
+		GridNum:         10,
 	}
 	return s
 }

--- a/pkg/types/kline.go
+++ b/pkg/types/kline.go
@@ -544,7 +544,7 @@ func (k KLineWindow) SlackAttachment() slack.Attachment {
 	}
 }
 
-type KLineCallback func(kline KLine)
+type KLineCallback func(k KLine)
 
 type KValueType int
 
@@ -642,9 +642,7 @@ func (k *KLineSeries) Length() int {
 
 var _ Series = &KLineSeries{}
 
-type KLineCallBack func(k KLine)
-
-func KLineWith(symbol string, interval Interval, callback KLineCallBack) KLineCallBack {
+func KLineWith(symbol string, interval Interval, callback KLineCallback) KLineCallback {
 	return func(k KLine) {
 		if k.Symbol != symbol || (k.Interval != "" && k.Interval != interval) {
 			return

--- a/pkg/types/position.go
+++ b/pkg/types/position.go
@@ -296,6 +296,7 @@ func (p *Position) Reset() {
 	p.Base = fixedpoint.Zero
 	p.Quote = fixedpoint.Zero
 	p.AverageCost = fixedpoint.Zero
+	p.TotalFee = make(map[string]fixedpoint.Value)
 }
 
 func (p *Position) SetFeeRate(exchangeFee ExchangeFee) {


### PR DESCRIPTION
- [x] quoteInvestment, baseInvestment calculation
- [ ] persist grid orders (without canceling grid orders)
- [x] shutdownCloseGrid option (close grid when shutting down bbgo)
- [ ] auto priceRange detection 
- [ ] replay order update from the RESTful API (for updating grid state)
- [x] earn: quote or earn: base
- [ ] grid number limitation calculation
- [x] order fee calculation
- [x] handle filled orders
- [ ] geometric grid calculation
- [x] create grid trigger
- [x] stop loss (close grid trigger)
- [x] take profit (close grid trigger)