### PR TITLE
FIX: add context to LoadState

### DIFF
--- a/cmd/bbgo-lorca/main.go
+++ b/cmd/bbgo-lorca/main.go
@@ -101,7 +101,7 @@ func main() {
 			return
 		}
 
-		if err := trader.LoadState(); err != nil {
+		if err := trader.LoadState(ctx); err != nil {
 			log.WithError(err).Error("failed to load strategy states")
 			return
 		}

--- a/cmd/bbgo-webview/main.go
+++ b/cmd/bbgo-webview/main.go
@@ -109,7 +109,7 @@ func main() {
 				return
 			}
 
-			if err := trader.LoadState(); err != nil {
+			if err := trader.LoadState(ctx); err != nil {
 				log.WithError(err).Error("failed to load strategy states")
 				return
 			}

--- a/pkg/bbgo/trader.go
+++ b/pkg/bbgo/trader.go
@@ -365,16 +365,14 @@ func (trader *Trader) Run(ctx context.Context) error {
 	return trader.environment.Connect(ctx)
 }
 
-func (trader *Trader) LoadState() error {
+func (trader *Trader) LoadState(ctx context.Context) error {
 	if trader.environment.BacktestService != nil {
 		return nil
 	}
 
-	if persistenceServiceFacade == nil {
-		return nil
-	}
+	isolation := GetIsolationFromContext(ctx)
 
-	ps := persistenceServiceFacade.Get()
+	ps := isolation.persistenceServiceFacade.Get()
 
 	log.Infof("loading strategies states...")
 

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -163,7 +163,7 @@ func runConfig(basectx context.Context, cmd *cobra.Command, userConfig *bbgo.Con
 		return err
 	}
 
-	if err := trader.LoadState(); err != nil {
+	if err := trader.LoadState(tradingCtx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Always use persistence facade from the given context.