### PR TITLE
FIX: supertrend config type error

### DIFF
--- a/config/supertrend.yaml
+++ b/config/supertrend.yaml
@@ -90,7 +90,7 @@ exchangeStrategies:
           closePosition: 100%
       - higherHighLowerLowStopLoss:
           # interval is the kline interval used by this exit
-          interval: 15
+          interval: 15m
           # window is used as the range to determining higher highs and lower lows
           window: 5
           # highLowWindow is the range to calculate the number of higher highs and lower lows


### PR DESCRIPTION
`interval` only accepts string

The error from backtest

```
[0000] FATAL cannot execute command error=json: cannot unmarshal number into Go struct field HigherHighLowerLowStop.exits.higherHighLowerLowStopLoss.interval of type string
```