### PR TITLE
REFACTOR: apply market.GreaterThanMinimalOrderQuantity on both convert and xalign

### DIFF
--- a/pkg/types/market_test.go
+++ b/pkg/types/market_test.go
@@ -13,6 +13,31 @@ import (
 
 var s func(string) fixedpoint.Value = fixedpoint.MustNewFromString
 
+func TestMarket_GreaterThanMinimalOrderQuantity(t *testing.T) {
+	market := Market{
+		Symbol:          "BTCUSDT",
+		LocalSymbol:     "BTCUSDT",
+		PricePrecision:  8,
+		VolumePrecision: 8,
+		QuoteCurrency:   "USDT",
+		BaseCurrency:    "BTC",
+		MinNotional:     number(10.0),
+		MinAmount:       number(10.0),
+		MinQuantity:     number(0.0001),
+		StepSize:        number(0.00001),
+		TickSize:        number(0.01),
+	}
+
+	_, ok := market.GreaterThanMinimalOrderQuantity(SideTypeSell, number(20000.0), number(0.00051))
+	assert.True(t, ok)
+
+	_, ok = market.GreaterThanMinimalOrderQuantity(SideTypeBuy, number(20000.0), number(10.0))
+	assert.True(t, ok)
+
+	_, ok = market.GreaterThanMinimalOrderQuantity(SideTypeBuy, number(20000.0), number(0.99999))
+	assert.False(t, ok)
+}
+
 func TestFormatQuantity(t *testing.T) {
 	quantity := formatQuantity(
 		s("0.12511"),

--- a/pkg/util/tradingutil/trades_test.go
+++ b/pkg/util/tradingutil/trades_test.go
@@ -1,0 +1,41 @@
+package tradingutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+var number = fixedpoint.MustNewFromString
+
+func Test_CollectTradeFee(t *testing.T) {
+	trades := []types.Trade{
+		{
+			ID:            1,
+			Price:         number("21000"),
+			Quantity:      number("0.001"),
+			Symbol:        "BTCUSDT",
+			Side:          types.SideTypeBuy,
+			Fee:           number("0.00001"),
+			FeeCurrency:   "BTC",
+			FeeDiscounted: false,
+		},
+		{
+			ID:            2,
+			Price:         number("21200"),
+			Quantity:      number("0.001"),
+			Symbol:        "BTCUSDT",
+			Side:          types.SideTypeBuy,
+			Fee:           number("0.00002"),
+			FeeCurrency:   "BTC",
+			FeeDiscounted: false,
+		},
+	}
+
+	fees := CollectTradeFee(trades)
+	assert.NotNil(t, fees)
+	assert.Equal(t, number("0.00003"), fees["BTC"])
+}


### PR DESCRIPTION
GreaterThanMinimalOrderQuantity uses the order side for the quantity truncation, and use the truncated quantity to validate the MOQ (minimal order quantity), which is more precise than just IsDustQuantity() since the quantity might have more decimal numbers outside of the precision that is supported by the exchange.