### PR TITLE
FIX: [bybit] fix quantity unit from quote coin to base coin

### DIFF
--- a/pkg/exchange/bybit/bybitapi/get_open_orders_request.go
+++ b/pkg/exchange/bybit/bybitapi/get_open_orders_request.go
@@ -16,47 +16,66 @@ type OrdersResponse struct {
 }
 
 type Order struct {
-	OrderId            string                     `json:"orderId"`
-	OrderLinkId        string                     `json:"orderLinkId"`
-	BlockTradeId       string                     `json:"blockTradeId"`
-	Symbol             string                     `json:"symbol"`
-	Price              fixedpoint.Value           `json:"price"`
-	Qty                fixedpoint.Value           `json:"qty"`
-	Side               Side                       `json:"side"`
-	IsLeverage         string                     `json:"isLeverage"`
-	PositionIdx        int                        `json:"positionIdx"`
-	OrderStatus        OrderStatus                `json:"orderStatus"`
-	CancelType         string                     `json:"cancelType"`
-	RejectReason       string                     `json:"rejectReason"`
-	AvgPrice           fixedpoint.Value           `json:"avgPrice"`
-	LeavesQty          fixedpoint.Value           `json:"leavesQty"`
-	LeavesValue        fixedpoint.Value           `json:"leavesValue"`
-	CumExecQty         fixedpoint.Value           `json:"cumExecQty"`
-	CumExecValue       fixedpoint.Value           `json:"cumExecValue"`
-	CumExecFee         fixedpoint.Value           `json:"cumExecFee"`
-	TimeInForce        TimeInForce                `json:"timeInForce"`
-	OrderType          OrderType                  `json:"orderType"`
-	StopOrderType      string                     `json:"stopOrderType"`
-	OrderIv            string                     `json:"orderIv"`
-	TriggerPrice       fixedpoint.Value           `json:"triggerPrice"`
-	TakeProfit         fixedpoint.Value           `json:"takeProfit"`
-	StopLoss           fixedpoint.Value           `json:"stopLoss"`
-	TpTriggerBy        string                     `json:"tpTriggerBy"`
-	SlTriggerBy        string                     `json:"slTriggerBy"`
-	TriggerDirection   int                        `json:"triggerDirection"`
-	TriggerBy          string                     `json:"triggerBy"`
-	LastPriceOnCreated string                     `json:"lastPriceOnCreated"`
-	ReduceOnly         bool                       `json:"reduceOnly"`
-	CloseOnTrigger     bool                       `json:"closeOnTrigger"`
-	SmpType            string                     `json:"smpType"`
-	SmpGroup           int                        `json:"smpGroup"`
-	SmpOrderId         string                     `json:"smpOrderId"`
-	TpslMode           string                     `json:"tpslMode"`
-	TpLimitPrice       string                     `json:"tpLimitPrice"`
-	SlLimitPrice       string                     `json:"slLimitPrice"`
-	PlaceType          string                     `json:"placeType"`
-	CreatedTime        types.MillisecondTimestamp `json:"createdTime"`
-	UpdatedTime        types.MillisecondTimestamp `json:"updatedTime"`
+	OrderId     string                     `json:"orderId"`
+	OrderLinkId string                     `json:"orderLinkId"`
+	Symbol      string                     `json:"symbol"`
+	Side        Side                       `json:"side"`
+	OrderStatus OrderStatus                `json:"orderStatus"`
+	OrderType   OrderType                  `json:"orderType"`
+	TimeInForce TimeInForce                `json:"timeInForce"`
+	Price       fixedpoint.Value           `json:"price"`
+	CreatedTime types.MillisecondTimestamp `json:"createdTime"`
+	UpdatedTime types.MillisecondTimestamp `json:"updatedTime"`
+
+	// Qty represents **quote coin** if order is market buy
+	Qty fixedpoint.Value `json:"qty"`
+
+	// AvgPrice is supported in both RESTful API and WebSocket.
+	//
+	// For websocket must notice that:
+	// - Normal account is not supported.
+	// - For normal account USDT Perp and Inverse derivatives trades, if a partially filled order, and the
+	// final orderStatus is Cancelled, then avgPrice is "0"
+	AvgPrice fixedpoint.Value `json:"avgPrice"`
+
+	// CumExecQty is supported in both RESTful API and WebSocket.
+	CumExecQty fixedpoint.Value `json:"cumExecQty"`
+
+	// CumExecValue is supported in both RESTful API and WebSocket.
+	// However, it's **not** supported for **normal accounts** in RESTful API.
+	CumExecValue fixedpoint.Value `json:"cumExecValue"`
+
+	// CumExecFee is supported in both RESTful API and WebSocket.
+	// However, it's **not** supported for **normal accounts** in RESTful API.
+	// For websocket normal spot, it is the execution fee per single fill.
+	CumExecFee fixedpoint.Value `json:"cumExecFee"`
+
+	BlockTradeId       string           `json:"blockTradeId"`
+	IsLeverage         string           `json:"isLeverage"`
+	PositionIdx        int              `json:"positionIdx"`
+	CancelType         string           `json:"cancelType"`
+	RejectReason       string           `json:"rejectReason"`
+	LeavesQty          fixedpoint.Value `json:"leavesQty"`
+	LeavesValue        fixedpoint.Value `json:"leavesValue"`
+	StopOrderType      string           `json:"stopOrderType"`
+	OrderIv            string           `json:"orderIv"`
+	TriggerPrice       fixedpoint.Value `json:"triggerPrice"`
+	TakeProfit         fixedpoint.Value `json:"takeProfit"`
+	StopLoss           fixedpoint.Value `json:"stopLoss"`
+	TpTriggerBy        string           `json:"tpTriggerBy"`
+	SlTriggerBy        string           `json:"slTriggerBy"`
+	TriggerDirection   int              `json:"triggerDirection"`
+	TriggerBy          string           `json:"triggerBy"`
+	LastPriceOnCreated string           `json:"lastPriceOnCreated"`
+	ReduceOnly         bool             `json:"reduceOnly"`
+	CloseOnTrigger     bool             `json:"closeOnTrigger"`
+	SmpType            string           `json:"smpType"`
+	SmpGroup           int              `json:"smpGroup"`
+	SmpOrderId         string           `json:"smpOrderId"`
+	TpslMode           string           `json:"tpslMode"`
+	TpLimitPrice       string           `json:"tpLimitPrice"`
+	SlLimitPrice       string           `json:"slLimitPrice"`
+	PlaceType          string           `json:"placeType"`
 }
 
 //go:generate GetRequest -url "/v5/order/realtime" -type GetOpenOrdersRequest -responseDataType .OrdersResponse

--- a/pkg/exchange/bybit/bybitapi/types.go
+++ b/pkg/exchange/bybit/bybitapi/types.go
@@ -68,9 +68,10 @@ const (
 	// OrderStatusCreated order has been accepted by the system but not yet put through the matching engine
 	OrderStatusCreated OrderStatus = "Created"
 	// OrderStatusNew is order has been placed successfully.
-	OrderStatusNew                     OrderStatus = "New"
-	OrderStatusRejected                OrderStatus = "Rejected"
-	OrderStatusPartiallyFilled         OrderStatus = "PartiallyFilled"
+	OrderStatusNew             OrderStatus = "New"
+	OrderStatusRejected        OrderStatus = "Rejected"
+	OrderStatusPartiallyFilled OrderStatus = "PartiallyFilled"
+	// OrderStatusPartiallyFilledCanceled means that the order has been partially filled but not all then cancel.
 	OrderStatusPartiallyFilledCanceled OrderStatus = "PartiallyFilledCanceled"
 	OrderStatusFilled                  OrderStatus = "Filled"
 	OrderStatusCancelled               OrderStatus = "Cancelled"

--- a/pkg/exchange/bybit/convert.go
+++ b/pkg/exchange/bybit/convert.go
@@ -2,13 +2,13 @@ package bybit
 
 import (
 	"fmt"
-	"hash/fnv"
 	"math"
 	"strconv"
 	"time"
 
 	"github.com/c9s/bbgo/pkg/exchange/bybit/bybitapi"
 	"github.com/c9s/bbgo/pkg/exchange/bybit/bybitapi/v3"
+	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
 )
 
@@ -53,22 +53,22 @@ func toGlobalOrder(order bybitapi.Order) (*types.Order, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	orderType, err := toGlobalOrderType(order.OrderType)
 	if err != nil {
 		return nil, err
 	}
+
 	timeInForce, err := toGlobalTimeInForce(order.TimeInForce)
 	if err != nil {
 		return nil, err
 	}
-	status, err := toGlobalOrderStatus(order.OrderStatus)
+
+	status, err := toGlobalOrderStatus(order.OrderStatus, order.Side, order.OrderType)
 	if err != nil {
 		return nil, err
 	}
-	working, err := isWorking(order.OrderStatus)
-	if err != nil {
-		return nil, err
-	}
+
 	// linear and inverse : 42f4f364-82e1-49d3-ad1d-cd8cf9aa308d (UUID format)
 	// spot : 1468264727470772736 (only numbers)
 	// Now we only use spot trading.
@@ -77,13 +77,18 @@ func toGlobalOrder(order bybitapi.Order) (*types.Order, error) {
 		return nil, fmt.Errorf("unexpected order id: %s, err: %w", order.OrderId, err)
 	}
 
+	qty, err := processQuantity(order)
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.Order{
 		SubmitOrder: types.SubmitOrder{
 			ClientOrderID: order.OrderLinkId,
 			Symbol:        order.Symbol,
 			Side:          side,
 			Type:          orderType,
-			Quantity:      order.Qty,
+			Quantity:      qty,
 			Price:         order.Price,
 			TimeInForce:   timeInForce,
 		},
@@ -92,7 +97,7 @@ func toGlobalOrder(order bybitapi.Order) (*types.Order, error) {
 		UUID:             order.OrderId,
 		Status:           status,
 		ExecutedQuantity: order.CumExecQty,
-		IsWorking:        working,
+		IsWorking:        status == types.OrderStatusNew || status == types.OrderStatusPartiallyFilled,
 		CreationTime:     types.Time(order.CreatedTime.Time()),
 		UpdateTime:       types.Time(order.UpdatedTime.Time()),
 	}, nil
@@ -140,7 +145,23 @@ func toGlobalTimeInForce(force bybitapi.TimeInForce) (types.TimeInForce, error) 
 	}
 }
 
-func toGlobalOrderStatus(status bybitapi.OrderStatus) (types.OrderStatus, error) {
+func toGlobalOrderStatus(status bybitapi.OrderStatus, side bybitapi.Side, orderType bybitapi.OrderType) (types.OrderStatus, error) {
+	switch status {
+
+	case bybitapi.OrderStatusPartiallyFilledCanceled:
+		// market buy order	-> PartiallyFilled -> PartiallyFilledCanceled
+		if orderType == bybitapi.OrderTypeMarket && side == bybitapi.SideBuy {
+			return types.OrderStatusFilled, nil
+		}
+		// limit buy/sell order -> PartiallyFilled -> PartiallyFilledCanceled(Canceled)
+		return types.OrderStatusCanceled, nil
+
+	default:
+		return processOtherOrderStatus(status)
+	}
+}
+
+func processOtherOrderStatus(status bybitapi.OrderStatus) (types.OrderStatus, error) {
 	switch status {
 	case bybitapi.OrderStatusCreated,
 		bybitapi.OrderStatusNew,
@@ -154,7 +175,6 @@ func toGlobalOrderStatus(status bybitapi.OrderStatus) (types.OrderStatus, error)
 		return types.OrderStatusPartiallyFilled, nil
 
 	case bybitapi.OrderStatusCancelled,
-		bybitapi.OrderStatusPartiallyFilledCanceled,
 		bybitapi.OrderStatusDeactivated:
 		return types.OrderStatusCanceled, nil
 
@@ -169,15 +189,44 @@ func toGlobalOrderStatus(status bybitapi.OrderStatus) (types.OrderStatus, error)
 	}
 }
 
-func hashStringID(s string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte(s))
-	return h.Sum64()
-}
+// processQuantity converts the quantity unit from quote coin to base coin if the order is a **MARKET BUY**.
+//
+// If the status is OrderStatusPartiallyFilled, it returns the estimated quantity based on the base coin.
+//
+// If the order status is OrderStatusPartiallyFilledCanceled, it indicates that the order is not fully filled,
+// and the system has automatically canceled it. In this scenario, CumExecQty is considered equal to Qty.
+func processQuantity(o bybitapi.Order) (fixedpoint.Value, error) {
+	if o.Side != bybitapi.SideBuy || o.OrderType != bybitapi.OrderTypeMarket {
+		return o.Qty, nil
+	}
 
-func isWorking(status bybitapi.OrderStatus) (bool, error) {
-	s, err := toGlobalOrderStatus(status)
-	return s == types.OrderStatusNew || s == types.OrderStatusPartiallyFilled, err
+	var qty fixedpoint.Value
+	switch o.OrderStatus {
+	case bybitapi.OrderStatusPartiallyFilled:
+		// if CumExecValue is zero, it indicates the caller is from the RESTFUL API.
+		// we can use AvgPrice to estimate quantity.
+		if o.CumExecValue.IsZero() {
+			qty = o.Qty.Div(o.AvgPrice)
+		} else {
+			// from web socket event
+			qty = o.Qty.Div(o.CumExecValue.Div(o.CumExecQty))
+		}
+
+	case bybitapi.OrderStatusPartiallyFilledCanceled,
+		// Considering extreme scenarios, there's a possibility that 'OrderStatusFilled' could occur.
+		bybitapi.OrderStatusFilled:
+		qty = o.CumExecQty
+
+	case bybitapi.OrderStatusCreated,
+		bybitapi.OrderStatusNew,
+		bybitapi.OrderStatusRejected:
+		qty = fixedpoint.Zero
+
+	default:
+		return fixedpoint.Zero, fmt.Errorf("unexpected order status: %s", o.OrderStatus)
+	}
+
+	return qty, nil
 }
 
 func toLocalOrderType(orderType types.OrderType) (bybitapi.OrderType, error) {

--- a/pkg/exchange/bybit/convert_test.go
+++ b/pkg/exchange/bybit/convert_test.go
@@ -133,6 +133,260 @@ func TestToGlobalTicker(t *testing.T) {
 	assert.Equal(t, toGlobalTicker(ticker, timeNow), exp)
 }
 
+func Test_processQuantity(t *testing.T) {
+	t.Run("websocket event", func(t *testing.T) {
+		t.Run("Market/Buy/OrderStatusPartiallyFilled", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:          fixedpoint.NewFromFloat(5),
+				OrderType:    bybitapi.OrderTypeMarket,
+				Side:         bybitapi.SideBuy,
+				CumExecValue: fixedpoint.NewFromFloat(200),
+				CumExecQty:   fixedpoint.NewFromFloat(2),
+				OrderStatus:  bybitapi.OrderStatusPartiallyFilled,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.Qty.Div(o.CumExecValue.Div(o.CumExecQty)), res)
+		})
+
+		t.Run("Market/Buy/OrderStatusPartiallyFilledCanceled", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:          fixedpoint.NewFromFloat(5),
+				OrderType:    bybitapi.OrderTypeMarket,
+				Side:         bybitapi.SideBuy,
+				CumExecValue: fixedpoint.NewFromFloat(200),
+				CumExecQty:   fixedpoint.NewFromFloat(2),
+				OrderStatus:  bybitapi.OrderStatusPartiallyFilled,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.Qty.Div(o.CumExecValue.Div(o.CumExecQty)), res)
+		})
+
+		t.Run("Market/Buy/OrderStatusFilled", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:          fixedpoint.NewFromFloat(5),
+				OrderType:    bybitapi.OrderTypeMarket,
+				Side:         bybitapi.SideBuy,
+				CumExecValue: fixedpoint.NewFromFloat(200),
+				CumExecQty:   fixedpoint.NewFromFloat(2),
+				OrderStatus:  bybitapi.OrderStatusFilled,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.CumExecQty, res)
+		})
+
+		t.Run("Market/Buy/OrderStatusCreated", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:          fixedpoint.NewFromFloat(5),
+				OrderType:    bybitapi.OrderTypeMarket,
+				Side:         bybitapi.SideBuy,
+				CumExecValue: fixedpoint.NewFromFloat(200),
+				CumExecQty:   fixedpoint.NewFromFloat(2),
+				OrderStatus:  bybitapi.OrderStatusCreated,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, fixedpoint.Zero, res)
+		})
+
+		t.Run("Market/Buy/OrderStatusNew", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:          fixedpoint.NewFromFloat(5),
+				OrderType:    bybitapi.OrderTypeMarket,
+				Side:         bybitapi.SideBuy,
+				CumExecValue: fixedpoint.NewFromFloat(200),
+				CumExecQty:   fixedpoint.NewFromFloat(2),
+				OrderStatus:  bybitapi.OrderStatusNew,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, fixedpoint.Zero, res)
+		})
+
+		t.Run("Market/Buy/OrderStatusRejected", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:          fixedpoint.NewFromFloat(5),
+				OrderType:    bybitapi.OrderTypeMarket,
+				Side:         bybitapi.SideBuy,
+				CumExecValue: fixedpoint.NewFromFloat(200),
+				CumExecQty:   fixedpoint.NewFromFloat(2),
+				OrderStatus:  bybitapi.OrderStatusRejected,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, fixedpoint.Zero, res)
+		})
+
+		t.Run("Market/Buy/Unexpected status", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:          fixedpoint.NewFromFloat(5),
+				OrderType:    bybitapi.OrderTypeMarket,
+				Side:         bybitapi.SideBuy,
+				CumExecValue: fixedpoint.NewFromFloat(200),
+				CumExecQty:   fixedpoint.NewFromFloat(2),
+				OrderStatus:  bybitapi.OrderStatus("unexpected"),
+			}
+			res, err := processQuantity(o)
+			assert.Error(t, err)
+			assert.Equal(t, fmt.Errorf("unexpected order status: %s", o.OrderStatus), err)
+			assert.Equal(t, fixedpoint.Zero, res)
+		})
+
+		t.Run("Market/Sell", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:       fixedpoint.NewFromFloat(5.55),
+				OrderType: bybitapi.OrderTypeMarket,
+				Side:      bybitapi.SideSell,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.Qty, res)
+		})
+
+		t.Run("Limit/Buy", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:       fixedpoint.NewFromFloat(5.55),
+				OrderType: bybitapi.OrderTypeLimit,
+				Side:      bybitapi.SideBuy,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.Qty, res)
+		})
+
+		t.Run("Limit/Sell", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:       fixedpoint.NewFromFloat(5.55),
+				OrderType: bybitapi.OrderTypeLimit,
+				Side:      bybitapi.SideSell,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.Qty, res)
+		})
+	})
+
+	t.Run("Restful API", func(t *testing.T) {
+		t.Run("Market/Buy/OrderStatusPartiallyFilled", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:         fixedpoint.NewFromFloat(200),
+				OrderType:   bybitapi.OrderTypeMarket,
+				Side:        bybitapi.SideBuy,
+				AvgPrice:    fixedpoint.NewFromFloat(25000),
+				OrderStatus: bybitapi.OrderStatusPartiallyFilled,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.Qty.Div(o.AvgPrice), res)
+		})
+
+		t.Run("Market/Buy/OrderStatusPartiallyFilledCanceled", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:         fixedpoint.NewFromFloat(200),
+				OrderType:   bybitapi.OrderTypeMarket,
+				Side:        bybitapi.SideBuy,
+				AvgPrice:    fixedpoint.NewFromFloat(25000),
+				OrderStatus: bybitapi.OrderStatusPartiallyFilledCanceled,
+				CumExecQty:  fixedpoint.NewFromFloat(0.002),
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.CumExecQty, res)
+		})
+
+		t.Run("Market/Buy/OrderStatusFilled", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:         fixedpoint.NewFromFloat(200),
+				OrderType:   bybitapi.OrderTypeMarket,
+				Side:        bybitapi.SideBuy,
+				AvgPrice:    fixedpoint.NewFromFloat(25000),
+				OrderStatus: bybitapi.OrderStatusFilled,
+				CumExecQty:  fixedpoint.NewFromFloat(0.002),
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.CumExecQty, res)
+		})
+
+		t.Run("Market/Buy/OrderStatusCreated", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:         fixedpoint.NewFromFloat(200),
+				OrderType:   bybitapi.OrderTypeMarket,
+				Side:        bybitapi.SideBuy,
+				AvgPrice:    fixedpoint.NewFromFloat(25000),
+				OrderStatus: bybitapi.OrderStatusCreated,
+				CumExecQty:  fixedpoint.NewFromFloat(0.002),
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, fixedpoint.Zero, res)
+		})
+
+		t.Run("Market/Buy/OrderStatusNew", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:         fixedpoint.NewFromFloat(200),
+				OrderType:   bybitapi.OrderTypeMarket,
+				Side:        bybitapi.SideBuy,
+				AvgPrice:    fixedpoint.NewFromFloat(25000),
+				OrderStatus: bybitapi.OrderStatusNew,
+				CumExecQty:  fixedpoint.NewFromFloat(0.002),
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, fixedpoint.Zero, res)
+		})
+
+		t.Run("Market/Buy/OrderStatusRejected", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:         fixedpoint.NewFromFloat(200),
+				OrderType:   bybitapi.OrderTypeMarket,
+				Side:        bybitapi.SideBuy,
+				AvgPrice:    fixedpoint.NewFromFloat(25000),
+				OrderStatus: bybitapi.OrderStatusRejected,
+				CumExecQty:  fixedpoint.NewFromFloat(0.002),
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, fixedpoint.Zero, res)
+		})
+
+		t.Run("Market/Sell", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:       fixedpoint.NewFromFloat(5.55),
+				OrderType: bybitapi.OrderTypeMarket,
+				Side:      bybitapi.SideSell,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.Qty, res)
+		})
+
+		t.Run("Limit/Buy", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:       fixedpoint.NewFromFloat(5.55),
+				OrderType: bybitapi.OrderTypeLimit,
+				Side:      bybitapi.SideBuy,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.Qty, res)
+		})
+
+		t.Run("Limit/Sell", func(t *testing.T) {
+			o := bybitapi.Order{
+				Qty:       fixedpoint.NewFromFloat(5.55),
+				OrderType: bybitapi.OrderTypeLimit,
+				Side:      bybitapi.SideSell,
+			}
+			res, err := processQuantity(o)
+			assert.NoError(t, err)
+			assert.Equal(t, o.Qty, res)
+		})
+	})
+}
+
 func TestToGlobalOrder(t *testing.T) {
 	// sample: partialFilled
 	//{
@@ -228,9 +482,7 @@ func TestToGlobalOrder(t *testing.T) {
 	assert.NoError(t, err)
 	tif, err := toGlobalTimeInForce(openOrder.TimeInForce)
 	assert.NoError(t, err)
-	status, err := toGlobalOrderStatus(openOrder.OrderStatus)
-	assert.NoError(t, err)
-	working, err := isWorking(openOrder.OrderStatus)
+	status, err := toGlobalOrderStatus(openOrder.OrderStatus, openOrder.Side, openOrder.OrderType)
 	assert.NoError(t, err)
 	orderIdNum, err := strconv.ParseUint(openOrder.OrderId, 10, 64)
 	assert.NoError(t, err)
@@ -250,9 +502,9 @@ func TestToGlobalOrder(t *testing.T) {
 		UUID:             openOrder.OrderId,
 		Status:           status,
 		ExecutedQuantity: openOrder.CumExecQty,
-		IsWorking:        working,
-		CreationTime:     types.Time(timeNow),
-		UpdateTime:       types.Time(timeNow),
+		IsWorking:        status == types.OrderStatusNew || status == types.OrderStatusPartiallyFilled,
+		CreationTime:     types.Time(openOrder.CreatedTime),
+		UpdateTime:       types.Time(openOrder.UpdatedTime),
 		IsFutures:        false,
 		IsMargin:         false,
 		IsIsolated:       false,
@@ -305,60 +557,71 @@ func TestToGlobalTimeInForce(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestToGlobalOrderStatus(t *testing.T) {
+func Test_toGlobalOrderStatus(t *testing.T) {
+	t.Run("market/buy", func(t *testing.T) {
+		res, err := toGlobalOrderStatus(bybitapi.OrderStatusPartiallyFilledCanceled, bybitapi.SideBuy, bybitapi.OrderTypeMarket)
+		assert.NoError(t, err)
+		assert.Equal(t, types.OrderStatusFilled, res)
+	})
+
+	t.Run("limit/buy", func(t *testing.T) {
+		res, err := toGlobalOrderStatus(bybitapi.OrderStatusPartiallyFilledCanceled, bybitapi.SideBuy, bybitapi.OrderTypeLimit)
+		assert.NoError(t, err)
+		assert.Equal(t, types.OrderStatusCanceled, res)
+	})
+
+	t.Run("limit/sell", func(t *testing.T) {
+		res, err := toGlobalOrderStatus(bybitapi.OrderStatusPartiallyFilledCanceled, bybitapi.SideSell, bybitapi.OrderTypeLimit)
+		assert.NoError(t, err)
+		assert.Equal(t, types.OrderStatusCanceled, res)
+	})
+}
+
+func Test_processOtherOrderStatus(t *testing.T) {
 	t.Run("New", func(t *testing.T) {
-		res, err := toGlobalOrderStatus(bybitapi.OrderStatusNew)
+		res, err := processOtherOrderStatus(bybitapi.OrderStatusNew)
 		assert.NoError(t, err)
 		assert.Equal(t, types.OrderStatusNew, res)
 
-		res, err = toGlobalOrderStatus(bybitapi.OrderStatusActive)
+		res, err = processOtherOrderStatus(bybitapi.OrderStatusActive)
 		assert.NoError(t, err)
 		assert.Equal(t, types.OrderStatusNew, res)
 	})
 
 	t.Run("Filled", func(t *testing.T) {
-		res, err := toGlobalOrderStatus(bybitapi.OrderStatusFilled)
+		res, err := processOtherOrderStatus(bybitapi.OrderStatusFilled)
 		assert.NoError(t, err)
 		assert.Equal(t, types.OrderStatusFilled, res)
 	})
 
 	t.Run("PartiallyFilled", func(t *testing.T) {
-		res, err := toGlobalOrderStatus(bybitapi.OrderStatusPartiallyFilled)
+		res, err := processOtherOrderStatus(bybitapi.OrderStatusPartiallyFilled)
 		assert.NoError(t, err)
 		assert.Equal(t, types.OrderStatusPartiallyFilled, res)
 	})
 
 	t.Run("OrderStatusCanceled", func(t *testing.T) {
-		res, err := toGlobalOrderStatus(bybitapi.OrderStatusCancelled)
+		res, err := processOtherOrderStatus(bybitapi.OrderStatusCancelled)
 		assert.NoError(t, err)
 		assert.Equal(t, types.OrderStatusCanceled, res)
 
-		res, err = toGlobalOrderStatus(bybitapi.OrderStatusPartiallyFilledCanceled)
-		assert.NoError(t, err)
-		assert.Equal(t, types.OrderStatusCanceled, res)
-
-		res, err = toGlobalOrderStatus(bybitapi.OrderStatusDeactivated)
+		res, err = processOtherOrderStatus(bybitapi.OrderStatusDeactivated)
 		assert.NoError(t, err)
 		assert.Equal(t, types.OrderStatusCanceled, res)
 	})
 
 	t.Run("OrderStatusRejected", func(t *testing.T) {
-		res, err := toGlobalOrderStatus(bybitapi.OrderStatusRejected)
+		res, err := processOtherOrderStatus(bybitapi.OrderStatusRejected)
 		assert.NoError(t, err)
 		assert.Equal(t, types.OrderStatusRejected, res)
 	})
-}
 
-func TestIsWorking(t *testing.T) {
-	for _, s := range bybitapi.AllOrderStatuses {
-		res, err := isWorking(s)
-		assert.NoError(t, err)
-		if res {
-			gos, err := toGlobalOrderStatus(s)
-			assert.NoError(t, err)
-			assert.True(t, gos == types.OrderStatusNew || gos == types.OrderStatusPartiallyFilled)
-		}
-	}
+	t.Run("OrderStatusPartiallyFilledCanceled", func(t *testing.T) {
+		res, err := processOtherOrderStatus(bybitapi.OrderStatusPartiallyFilledCanceled)
+		assert.Equal(t, types.OrderStatus(bybitapi.OrderStatusPartiallyFilledCanceled), res)
+		assert.Error(t, err)
+		assert.Equal(t, fmt.Errorf("unexpected order status: %s", bybitapi.OrderStatusPartiallyFilledCanceled), err)
+	})
 }
 
 func Test_toLocalOrderType(t *testing.T) {


### PR DESCRIPTION
測試結果如下，包含 Market buy/sell, Limit buy/sell
### websocket 
```
    stream_test.go:80: got update ORDER bybit | Aug 18 00:50:33.692 | UUID 1489439576071192320 (1489439576071192320) | BTCUSDT | MARKET BUY  | 0/0 @ 0 | NEW
    stream_test.go:80: got update ORDER bybit | Aug 18 00:50:33.692 | UUID 1489439576071192320 (1489439576071192320) | BTCUSDT | MARKET BUY  | 0.008403/0.00840311 @ 0 | PARTIALLY_FILLED
    stream_test.go:80: got update ORDER bybit | Aug 18 00:50:33.692 | UUID 1489439576071192320 (1489439576071192320) | BTCUSDT | MARKET BUY  | 0.008403/0.008403 @ 0 | FILLED
    stream_test.go:80: got update ORDER bybit | Aug 18 00:50:46.386 | UUID 1489439682556087040 (1489439682556087040) | BTCUSDT | LIMIT BUY  | 0/0.01 @ 23800.6898 | NEW
    stream_test.go:80: got update ORDER bybit | Aug 18 00:50:46.386 | UUID 1489439682556087040 (1489439682556087040) | BTCUSDT | LIMIT BUY  | 0.01/0.01 @ 23800.6898 | FILLED
    stream_test.go:80: got update ORDER bybit | Aug 18 00:51:07.873 | UUID 1489439862802202368 (1489439862802202368) | BTCUSDT | LIMIT SELL | 0/0.01 @ 23800.6892 | NEW
    stream_test.go:80: got update ORDER bybit | Aug 18 00:51:07.873 | UUID 1489439862802202368 (1489439862802202368) | BTCUSDT | LIMIT SELL | 0.002517/0.01 @ 23800.6892 | PARTIALLY_FILLED
    stream_test.go:80: got update ORDER bybit | Aug 18 00:51:07.873 | UUID 1489439862802202368 (1489439862802202368) | BTCUSDT | LIMIT SELL | 0.00479/0.01 @ 23800.6892 | PARTIALLY_FILLED
    stream_test.go:80: got update ORDER bybit | Aug 18 00:51:07.873 | UUID 1489439862802202368 (1489439862802202368) | BTCUSDT | LIMIT SELL | 0.008157/0.01 @ 23800.6892 | PARTIALLY_FILLED
    stream_test.go:80: got update ORDER bybit | Aug 18 00:51:07.873 | UUID 1489439862802202368 (1489439862802202368) | BTCUSDT | LIMIT SELL | 0.01/0.01 @ 23800.6892 | FILLED
    stream_test.go:80: got update ORDER bybit | Aug 18 00:51:19.838 | UUID 1489439963171897088 (1489439963171897088) | BTCUSDT | MARKET SELL | 0/0.01 @ 0 | NEW
    stream_test.go:80: got update ORDER bybit | Aug 18 00:51:19.838 | UUID 1489439963171897088 (1489439963171897088) | BTCUSDT | MARKET SELL | 0.002546/0.01 @ 0 | PARTIALLY_FILLED
    stream_test.go:80: got update ORDER bybit | Aug 18 00:51:19.838 | UUID 1489439963171897088 (1489439963171897088) | BTCUSDT | MARKET SELL | 0.008234/0.01 @ 0 | PARTIALLY_FILLED
    stream_test.go:80: got update ORDER bybit | Aug 18 00:51:19.838 | UUID 1489439963171897088 (1489439963171897088) | BTCUSDT | MARKET SELL | 0.01/0.01 @ 0 | FILLED
```

### RESTful API
```
(⎈|N/A:N/A)➜  bbgo git:(edwin/fix-misc) ✗ godotenv -f .env.local -- go run ./cmd/bbgo get-order --session $BBGO_SESSION --order-id 1489045886702042880 --symbol BTCUSDT
[0000]  INFO ORDER bybit | Aug 17 11:48:22.262 | UUID 1489045886702042880 (1489045886702042880) | BTCUSDT | MARKET BUY  | 0.003893/0.003893 @ 0 | FILLED
(⎈|N/A:N/A)➜  bbgo git:(edwin/fix-misc) ✗ godotenv -f .env.local -- go run ./cmd/bbgo get-order --session $BBGO_SESSION --symbol BTCUSDT --order-id 1489439576071192320
[0000]  INFO ORDER bybit | Aug 18 00:50:33.692 | UUID 1489439576071192320 (1489439576071192320) | BTCUSDT | MARKET BUY  | 0.008403/0.008403 @ 0 | FILLED
(⎈|N/A:N/A)➜  bbgo git:(edwin/fix-misc) ✗ godotenv -f .env.local -- go run ./cmd/bbgo get-order --session $BBGO_SESSION --symbol BTCUSDT --order-id 1489439682556087040
[0000]  INFO ORDER bybit | Aug 18 00:50:46.386 | UUID 1489439682556087040 (1489439682556087040) | BTCUSDT | LIMIT BUY  | 0.01/0.01 @ 23800.6898 | FILLED
(⎈|N/A:N/A)➜  bbgo git:(edwin/fix-misc) ✗ godotenv -f .env.local -- go run ./cmd/bbgo get-order --session $BBGO_SESSION --symbol BTCUSDT --order-id 1489439862802202368
[0000]  INFO ORDER bybit | Aug 18 00:51:07.873 | UUID 1489439862802202368 (1489439862802202368) | BTCUSDT | LIMIT SELL | 0.01/0.01 @ 23800.6892 | FILLED
(⎈|N/A:N/A)➜  bbgo git:(edwin/fix-misc) ✗ godotenv -f .env.local -- go run ./cmd/bbgo get-order --session $BBGO_SESSION --symbol BTCUSDT --order-id 1489439963171897088
[0000]  INFO ORDER bybit | Aug 18 00:51:19.838 | UUID 1489439963171897088 (1489439963171897088) | BTCUSDT | MARKET SELL | 0.01/0.01 @ 0 | FILLED
```