### PR TITLE
FEATURE: [bybit] add kline backtest

### DIFF
--- a/migrations/mysql/20230815173104_add_bybit_klines.sql
+++ b/migrations/mysql/20230815173104_add_bybit_klines.sql
@@ -1,0 +1,10 @@
+-- +up
+-- +begin
+CREATE TABLE `bybit_klines` LIKE `binance_klines`;
+-- +end
+
+-- +down
+
+-- +begin
+DROP TABLE `bybit_klines`;
+-- +end

--- a/migrations/sqlite3/20230815173104_add_bybit_klines.sql
+++ b/migrations/sqlite3/20230815173104_add_bybit_klines.sql
@@ -1,0 +1,29 @@
+-- +up
+-- +begin
+CREATE TABLE `bybit_klines`
+(
+    `gid`                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    `exchange`               VARCHAR(10)    NOT NULL,
+    `start_time`             DATETIME(3)    NOT NULL,
+    `end_time`               DATETIME(3)    NOT NULL,
+    `interval`               VARCHAR(3)     NOT NULL,
+    `symbol`                 VARCHAR(7)     NOT NULL,
+    `open`                   DECIMAL(16, 8) NOT NULL,
+    `high`                   DECIMAL(16, 8) NOT NULL,
+    `low`                    DECIMAL(16, 8) NOT NULL,
+    `close`                  DECIMAL(16, 8) NOT NULL DEFAULT 0.0,
+    `volume`                 DECIMAL(16, 8) NOT NULL DEFAULT 0.0,
+    `closed`                 BOOLEAN        NOT NULL DEFAULT TRUE,
+    `last_trade_id`          INT            NOT NULL DEFAULT 0,
+    `num_trades`             INT            NOT NULL DEFAULT 0,
+    `quote_volume`           DECIMAL        NOT NULL DEFAULT 0.0,
+    `taker_buy_base_volume`  DECIMAL        NOT NULL DEFAULT 0.0,
+    `taker_buy_quote_volume` DECIMAL        NOT NULL DEFAULT 0.0
+);
+-- +end
+
+-- +down
+
+-- +begin
+DROP TABLE bybit_klines;
+-- +end

--- a/pkg/migrations/mysql/20230815173104_add_bybit_klines.go
+++ b/pkg/migrations/mysql/20230815173104_add_bybit_klines.go
@@ -1,0 +1,34 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/c9s/rockhopper"
+)
+
+func init() {
+	AddMigration(upAddBybitKlines, downAddBybitKlines)
+
+}
+
+func upAddBybitKlines(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is applied.
+
+	_, err = tx.ExecContext(ctx, "CREATE TABLE `bybit_klines` LIKE `binance_klines`;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func downAddBybitKlines(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is rolled back.
+
+	_, err = tx.ExecContext(ctx, "DROP TABLE `bybit_klines`;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/pkg/migrations/sqlite3/20230815173104_add_bybit_klines.go
+++ b/pkg/migrations/sqlite3/20230815173104_add_bybit_klines.go
@@ -1,0 +1,34 @@
+package sqlite3
+
+import (
+	"context"
+
+	"github.com/c9s/rockhopper"
+)
+
+func init() {
+	AddMigration(upAddBybitKlines, downAddBybitKlines)
+
+}
+
+func upAddBybitKlines(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is applied.
+
+	_, err = tx.ExecContext(ctx, "CREATE TABLE `bybit_klines`\n(\n    `gid`                    INTEGER PRIMARY KEY AUTOINCREMENT,\n    `exchange`               VARCHAR(10)    NOT NULL,\n    `start_time`             DATETIME(3)    NOT NULL,\n    `end_time`               DATETIME(3)    NOT NULL,\n    `interval`               VARCHAR(3)     NOT NULL,\n    `symbol`                 VARCHAR(7)     NOT NULL,\n    `open`                   DECIMAL(16, 8) NOT NULL,\n    `high`                   DECIMAL(16, 8) NOT NULL,\n    `low`                    DECIMAL(16, 8) NOT NULL,\n    `close`                  DECIMAL(16, 8) NOT NULL DEFAULT 0.0,\n    `volume`                 DECIMAL(16, 8) NOT NULL DEFAULT 0.0,\n    `closed`                 BOOLEAN        NOT NULL DEFAULT TRUE,\n    `last_trade_id`          INT            NOT NULL DEFAULT 0,\n    `num_trades`             INT            NOT NULL DEFAULT 0,\n    `quote_volume`           DECIMAL        NOT NULL DEFAULT 0.0,\n    `taker_buy_base_volume`  DECIMAL        NOT NULL DEFAULT 0.0,\n    `taker_buy_quote_volume` DECIMAL        NOT NULL DEFAULT 0.0\n);")
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func downAddBybitKlines(ctx context.Context, tx rockhopper.SQLExecutor) (err error) {
+	// This code is executed when the migration is rolled back.
+
+	_, err = tx.ExecContext(ctx, "DROP TABLE bybit_klines;")
+	if err != nil {
+		return err
+	}
+
+	return err
+}


### PR DESCRIPTION
### Config
```
---
sessions:
  bybit:
    exchange: bybit
    envVarPrefix: bybit

  #max:
  #  exchange: max
  #  envVarPrefix: max

riskControls:
  # This is the session-based risk controller, which let you configure different risk controller by session.
  sessionBased:
    # "max" is the session name that you want to configure the risk control
    max:
      # orderExecutor is one of the risk control
      orderExecutor:
        # symbol-routed order executor
        bySymbol:
          BTCUSDT:
            # basic risk control order executor
            basic:
              minQuoteBalance: 100.0
              maxBaseAssetBalance: 3.0
              minBaseAssetBalance: 0.0
              maxOrderAmount: 1000.0

# example command:
#    godotenv -f .env.local -- go run ./cmd/bbgo backtest --sync-from 2020-11-01 --config config/grid.yaml --base-asset-baseline
backtest:
  # for testing max draw down (MDD) at 03-12
  # see here for more details
  # https://www.investopedia.com/terms/m/maximum-drawdown-mdd.asp
  startTime: "2023-05-09"
  endTime: "2023-05-20"
  symbols:
    - BTCUSDT
  sessions: [bybit]
  accounts:
    bybit:
      balances:
        BTC: 0.0
        USDT: 10000.0

exchangeStrategies:

- on: bybit
  grid:
    symbol: BTCUSDT
    quantity: 0.001
    # scaleQuantity:
    #   byPrice:
    #     exp:
    #       domain: [20_000, 30_000]
    #       range: [0.2, 0.001]
    gridNumber: 30
    profitSpread: 100.0  # The profit price spread that you want to add to your sell order when your buy order is executed
    upperPrice: 28_000.0
    lowerPrice: 25_000.0
    # long: true  # The sell order is submitted in the same order amount as the filled corresponding buy order, rather than the same quantity.


```

### Command
```
go run ./cmd/bbgo backtest -v --sync --config config/grid.yaml
```

### Result
```
BACK-TEST REPORT
===============================================
START TIME: Tue, 09 May 2023 08:00:00 CST
END TIME: Sat, 20 May 2023 08:00:00 CST
INITIAL TOTAL BALANCE: BalanceMap[USDT: 10000, BTC: 0]
FINAL TOTAL BALANCE: BalanceMap[BTC: 0.009, USDT: 9816.69480485]
bybit BTCUSDT PROFIT AND LOSS REPORT
===============================================
TRADES SINCE: 2023-05-09 08:52:00 +0000 UTC
NUMBER OF TRADES: 2107
POSITION BTCUSDT: average cost = 26810.244614, base = 0.009, quote = -140.69440025
AVERAGE COST: $ 26,810.24
BASE ASSET POSITION: 0.009
TOTAL BUY VOLUME: 1.058
TOTAL SELL VOLUME: 1.049
CURRENT PRICE: $ 26,880.24
CURRENCY FEES:
 - USDT: 42.50519515
PROFIT: $ 121.80
UNREALIZED PROFIT: $ 0.63
INITIAL ASSET IN USDT ~= 10000.000000 USDT (1 BTC = 27775.01)
FINAL ASSET IN USDT ~= 10058.616964 USDT (1 BTC = 26880.24)
REALIZED PROFIT: +121.79760364 USDT
UNREALIZED PROFIT: +0.62995847 USDT
ASSET INCREASED: +58.61696485 USDT (+0.58%)
REALIZED SHARPE RATIO: 3.4624
REALIZED SORTINO RATIO: 118.7241
```