### PR TITLE
fix: listenKeyExpired event sends string timestamp

### DIFF
--- a/pkg/exchange/binance/parse.go
+++ b/pkg/exchange/binance/parse.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/adshao/go-binance/v2/futures"
@@ -18,8 +17,8 @@ import (
 )
 
 type EventBase struct {
-	Event string      `json:"e"` // event name
-	Time  json.Number `json:"E"` // event time
+	Event string                     `json:"e"` // event name
+	Time  types.MillisecondTimestamp `json:"E"` // event time
 }
 
 /*
@@ -462,11 +461,7 @@ func (e *DepthEvent) String() (o string) {
 
 func (e *DepthEvent) OrderBook() (book types.SliceOrderBook, err error) {
 	book.Symbol = e.Symbol
-	t, err := e.EventBase.Time.Int64()
-	if err != nil {
-		return book, err
-	}
-	book.Time = types.NewMillisecondTimestampFromInt(t).Time()
+	book.Time = e.EventBase.Time.Time()
 
 	// already in descending order
 	book.Bids = e.Bids
@@ -505,7 +500,7 @@ func parseDepthEvent(val *fastjson.Value) (*DepthEvent, error) {
 	var depth = &DepthEvent{
 		EventBase: EventBase{
 			Event: string(val.GetStringBytes("e")),
-			Time:  json.Number(strconv.FormatInt(val.GetInt64("E"), 10)),
+			Time:  types.NewMillisecondTimestampFromInt(val.GetInt64("E")),
 		},
 		Symbol:        string(val.GetStringBytes("s")),
 		FirstUpdateID: val.GetInt64("U"),

--- a/pkg/exchange/binance/parse_test.go
+++ b/pkg/exchange/binance/parse_test.go
@@ -397,7 +397,7 @@ func TestParseOrderFuturesUpdate(t *testing.T) {
 	assert.Equal(t, "SELL", orderTradeEvent.OrderTrade.Side)
 	assert.Equal(t, "x-NSUYEBKMe60cf610-f5c7-49a4-9c1", orderTradeEvent.OrderTrade.ClientOrderID)
 	assert.Equal(t, "MARKET", orderTradeEvent.OrderTrade.OrderType)
-	assert.Equal(t, int64(1639933384763), orderTradeEvent.Time)
+	assert.Equal(t, types.NewMillisecondTimestampFromInt(1639933384763), orderTradeEvent.Time)
 	assert.Equal(t, types.MillisecondTimestamp(time.UnixMilli(1639933384755)), orderTradeEvent.OrderTrade.OrderTradeTime)
 	assert.Equal(t, fixedpoint.MustNewFromString("0.001"), orderTradeEvent.OrderTrade.OriginalQuantity)
 	assert.Equal(t, fixedpoint.MustNewFromString("0.001"), orderTradeEvent.OrderTrade.OrderLastFilledQuantity)

--- a/pkg/exchange/binance/stream.go
+++ b/pkg/exchange/binance/stream.go
@@ -86,13 +86,9 @@ func NewStream(ex *Exchange, client *binance.Client, futuresClient *futures.Clie
 	stream.OnDepthEvent(func(e *DepthEvent) {
 		f, ok := stream.depthBuffers[e.Symbol]
 		if ok {
-			t, err := e.EventBase.Time.Int64()
-			if err != nil {
-				log.WithError(err).Errorf("Time parsing failed: %v", e.EventBase.Time)
-			}
-			err = f.AddUpdate(types.SliceOrderBook{
+			err := f.AddUpdate(types.SliceOrderBook{
 				Symbol: e.Symbol,
-				Time:   types.NewMillisecondTimestampFromInt(t).Time(),
+				Time:   e.EventBase.Time.Time(),
 				Bids:   e.Bids,
 				Asks:   e.Asks,
 			}, e.FirstUpdateID, e.FinalUpdateID)

--- a/pkg/exchange/binance/stream.go
+++ b/pkg/exchange/binance/stream.go
@@ -86,9 +86,13 @@ func NewStream(ex *Exchange, client *binance.Client, futuresClient *futures.Clie
 	stream.OnDepthEvent(func(e *DepthEvent) {
 		f, ok := stream.depthBuffers[e.Symbol]
 		if ok {
-			err := f.AddUpdate(types.SliceOrderBook{
+			t, err := e.EventBase.Time.Int64()
+			if err != nil {
+				log.WithError(err).Errorf("Time parsing failed: %v", e.EventBase.Time)
+			}
+			err = f.AddUpdate(types.SliceOrderBook{
 				Symbol: e.Symbol,
-				Time:   types.NewMillisecondTimestampFromInt(e.EventBase.Time).Time(),
+				Time:   types.NewMillisecondTimestampFromInt(t).Time(),
 				Bids:   e.Bids,
 				Asks:   e.Asks,
 			}, e.FirstUpdateID, e.FinalUpdateID)

--- a/pkg/strategy/xfunding/strategy.go
+++ b/pkg/strategy/xfunding/strategy.go
@@ -527,15 +527,19 @@ func (s *Strategy) handleAccountUpdate(ctx context.Context, e *binance.AccountUp
 			if b.Asset != s.ProfitStats.FundingFeeCurrency {
 				continue
 			}
-
-			txnTime := time.UnixMilli(e.Time)
+			t, err := e.EventBase.Time.Int64()
+			if err != nil {
+				log.WithError(err).Error("unable to parse event timestamp")
+				continue
+			}
+			txnTime := time.UnixMilli(t)
 			fee := FundingFee{
 				Asset:  b.Asset,
 				Amount: b.BalanceChange,
 				Txn:    e.Transaction,
 				Time:   txnTime,
 			}
-			err := s.ProfitStats.AddFundingFee(fee)
+			err = s.ProfitStats.AddFundingFee(fee)
 			if err != nil {
 				log.WithError(err).Error("unable to add funding fee to profitStats")
 				continue

--- a/pkg/strategy/xfunding/strategy.go
+++ b/pkg/strategy/xfunding/strategy.go
@@ -527,19 +527,14 @@ func (s *Strategy) handleAccountUpdate(ctx context.Context, e *binance.AccountUp
 			if b.Asset != s.ProfitStats.FundingFeeCurrency {
 				continue
 			}
-			t, err := e.EventBase.Time.Int64()
-			if err != nil {
-				log.WithError(err).Error("unable to parse event timestamp")
-				continue
-			}
-			txnTime := time.UnixMilli(t)
+			txnTime := e.EventBase.Time.Time()
 			fee := FundingFee{
 				Asset:  b.Asset,
 				Amount: b.BalanceChange,
 				Txn:    e.Transaction,
 				Time:   txnTime,
 			}
-			err = s.ProfitStats.AddFundingFee(fee)
+			err := s.ProfitStats.AddFundingFee(fee)
 			if err != nil {
 				log.WithError(err).Error("unable to add funding fee to profitStats")
 				continue


### PR DESCRIPTION
After listening for more than one hour, the event: ListenKeyExpired will be sent from binance server.
```text
ERROR websocket event parse error, message: {"e": "listenKeyExpired","E": "1695716647064","listenKey": "2rtkU3NxjtBFIw2zxhLMvTJ0jGsp87IZUDc4gY0F47aoF9pVvdxZUbozMog74fGU"} error=json: cannot unmarshal string into Go struct field ListenKeyExpired.E of type int64
```
To fix this elegantly, use json.Number to store timestamp.