### PR TITLE
CHORE: update xfixedmaker config for backtest

### DIFF
--- a/config/xfixedmaker.yaml
+++ b/config/xfixedmaker.yaml
@@ -7,18 +7,40 @@ sessions:
     exchange: binance
     envVarPrefix: binance
 
+backtest:
+  startTime: "2023-01-01"
+  endTime: "2023-01-02"
+  symbols:
+    - BTCUSDT
+  sessions:
+    - max
+    - binance
+  accounts:
+    max:
+      balances:
+        BTC: 0.5
+        USDT: 15000.0
+
 crossExchangeStrategies:
   - xfixedmaker:
       tradingExchange: max
       symbol: BTCUSDT
       interval: 5m
-      halfSpread: 0.05%
+      halfSpread: 0.01%
       quantity: 0.005
       orderType: LIMIT_MAKER
-      dryRun: true
+      dryRun: false
 
       referenceExchange: binance
       referencePriceEMA:
         interval: 1m
         window: 14
       orderPriceLossThreshold: -10
+
+      positionHardLimit: 200
+      maxPositionQuantity: 0.005
+
+      circuitBreakLossThreshold: -10
+      circuitBreakEMA:
+        interval: 1m
+        window: 14


### PR DESCRIPTION
```
BACK-TEST REPORT
===============================================
START TIME: Sun, 01 Jan 2023 08:00:00 CST
END TIME: Mon, 02 Jan 2023 08:00:00 CST
INITIAL TOTAL BALANCE: BalanceMap[USDT: 25000, BTC: 0.5]
FINAL TOTAL BALANCE: BalanceMap[USDT: 25073.18048103, BTC: 0.495]
max BTCUSDT PROFIT AND LOSS REPORT
===============================================
TRADES SINCE: 2023-01-01 00:05:59.999 +0000 UTC
NUMBER OF TRADES: 171
POSITION BTCUSDT: average cost = 16589.208756, base = -0.005, quote = 83.71661545
AVERAGE COST: $ 16,589.21
BASE ASSET POSITION: -0.005
TOTAL BUY VOLUME: 0.425
TOTAL SELL VOLUME: 0.43
CURRENT PRICE: $ 16,612.66
CURRENCY FEES:
 - USDT: 10.59896897
PROFIT: $ 2.57
UNREALIZED PROFIT: -$ 0.12
INITIAL ASSET IN USDT ~= 23261.325000 USDT (1 BTC = 16522.65)
FINAL ASSET IN USDT ~= 23296.447181 USDT (1 BTC = 16612.66)
REALIZED PROFIT: +2.56766907 USDT
UNREALIZED PROFIT: -0.11725622 USDT
ASSET INCREASED: +35.12218103 USDT (+0.15%)
REALIZED SHARPE RATIO: inf
REALIZED SORTINO RATIO: inf
```