### PR TITLE
FIX: [bybit][kucoin] fix negative volume, price precision

### DIFF
--- a/pkg/exchange/bybit/convert.go
+++ b/pkg/exchange/bybit/convert.go
@@ -16,8 +16,8 @@ func toGlobalMarket(m bybitapi.Instrument) types.Market {
 	return types.Market{
 		Symbol:          m.Symbol,
 		LocalSymbol:     m.Symbol,
-		PricePrecision:  int(math.Log10(m.LotSizeFilter.QuotePrecision.Float64())),
-		VolumePrecision: int(math.Log10(m.LotSizeFilter.BasePrecision.Float64())),
+		PricePrecision:  -int(math.Log10(m.LotSizeFilter.QuotePrecision.Float64())),
+		VolumePrecision: -int(math.Log10(m.LotSizeFilter.BasePrecision.Float64())),
 		QuoteCurrency:   m.QuoteCoin,
 		BaseCurrency:    m.BaseCoin,
 		MinNotional:     m.LotSizeFilter.MinOrderAmt,

--- a/pkg/exchange/bybit/convert.go
+++ b/pkg/exchange/bybit/convert.go
@@ -2,7 +2,6 @@ package bybit
 
 import (
 	"fmt"
-	"math"
 	"strconv"
 	"time"
 
@@ -16,8 +15,8 @@ func toGlobalMarket(m bybitapi.Instrument) types.Market {
 	return types.Market{
 		Symbol:          m.Symbol,
 		LocalSymbol:     m.Symbol,
-		PricePrecision:  -int(math.Log10(m.LotSizeFilter.QuotePrecision.Float64())),
-		VolumePrecision: -int(math.Log10(m.LotSizeFilter.BasePrecision.Float64())),
+		PricePrecision:  m.LotSizeFilter.QuotePrecision.NumFractionalDigits(),
+		VolumePrecision: m.LotSizeFilter.BasePrecision.NumFractionalDigits(),
 		QuoteCurrency:   m.QuoteCoin,
 		BaseCurrency:    m.BaseCoin,
 		MinNotional:     m.LotSizeFilter.MinOrderAmt,

--- a/pkg/exchange/bybit/convert_test.go
+++ b/pkg/exchange/bybit/convert_test.go
@@ -2,7 +2,6 @@ package bybit
 
 import (
 	"fmt"
-	"math"
 	"strconv"
 	"testing"
 	"time"
@@ -67,8 +66,8 @@ func TestToGlobalMarket(t *testing.T) {
 	exp := types.Market{
 		Symbol:          inst.Symbol,
 		LocalSymbol:     inst.Symbol,
-		PricePrecision:  int(math.Log10(inst.LotSizeFilter.QuotePrecision.Float64())),
-		VolumePrecision: int(math.Log10(inst.LotSizeFilter.BasePrecision.Float64())),
+		PricePrecision:  8,
+		VolumePrecision: 6,
 		QuoteCurrency:   inst.QuoteCoin,
 		BaseCurrency:    inst.BaseCoin,
 		MinNotional:     inst.LotSizeFilter.MinOrderAmt,

--- a/pkg/exchange/kucoin/convert.go
+++ b/pkg/exchange/kucoin/convert.go
@@ -3,7 +3,6 @@ package kucoin
 import (
 	"fmt"
 	"hash/fnv"
-	"math"
 	"strings"
 	"time"
 
@@ -39,8 +38,8 @@ func toGlobalMarket(m kucoinapi.Symbol) types.Market {
 	return types.Market{
 		Symbol:          symbol,
 		LocalSymbol:     m.Symbol,
-		PricePrecision:  -int(math.Log10(m.PriceIncrement.Float64())), // convert 0.0001 to 4
-		VolumePrecision: -int(math.Log10(m.BaseIncrement.Float64())),
+		PricePrecision:  m.PriceIncrement.NumFractionalDigits(), // convert 0.0001 to 4
+		VolumePrecision: m.BaseIncrement.NumFractionalDigits(),
 		QuoteCurrency:   m.QuoteCurrency,
 		BaseCurrency:    m.BaseCurrency,
 		MinNotional:     m.QuoteMinSize,

--- a/pkg/exchange/kucoin/convert.go
+++ b/pkg/exchange/kucoin/convert.go
@@ -39,8 +39,8 @@ func toGlobalMarket(m kucoinapi.Symbol) types.Market {
 	return types.Market{
 		Symbol:          symbol,
 		LocalSymbol:     m.Symbol,
-		PricePrecision:  int(math.Log10(m.PriceIncrement.Float64())), // convert 0.0001 to 4
-		VolumePrecision: int(math.Log10(m.BaseIncrement.Float64())),
+		PricePrecision:  -int(math.Log10(m.PriceIncrement.Float64())), // convert 0.0001 to 4
+		VolumePrecision: -int(math.Log10(m.BaseIncrement.Float64())),
 		QuoteCurrency:   m.QuoteCurrency,
 		BaseCurrency:    m.BaseCurrency,
 		MinNotional:     m.QuoteMinSize,


### PR DESCRIPTION
The precision should be positive. Bybit is according to Kucoin, so it is also incorrect..

Other exchanges are correct.

bybit document: https://bybit-exchange.github.io/docs/v5/market/instrument
```
              "basePrecision": "0.000001",
                "quotePrecision": "0.00000001",
```

kucoin document: https://www.kucoin.com/docs/rest/spot-trading/market-data/get-symbols-list
```
    "quoteIncrement": "0.000001",
    "priceIncrement": "0.000001",
```