### PR TITLE
FIX: [bybit] rm retry and add fee recover

### DIFF
--- a/pkg/exchange/bybit/market_info_poller.go
+++ b/pkg/exchange/bybit/market_info_poller.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/c9s/bbgo/pkg/exchange/bybit/bybitapi"
-	"github.com/c9s/bbgo/pkg/util"
 )
 
 const (
@@ -82,15 +81,12 @@ func (p *feeRatePoller) poll(ctx context.Context) error {
 	return nil
 }
 
-func (p *feeRatePoller) Get(symbol string) (symbolFeeDetail, error) {
+func (p *feeRatePoller) Get(symbol string) (symbolFeeDetail, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	fee, ok := p.symbolFeeDetail[symbol]
-	if !ok {
-		return symbolFeeDetail{}, fmt.Errorf("%s fee rate not found", symbol)
-	}
-	return fee, nil
+	fee, found := p.symbolFeeDetail[symbol]
+	return fee, found
 }
 
 func (e *feeRatePoller) getAllFeeRates(ctx context.Context) (map[string]symbolFeeDetail, error) {

--- a/pkg/exchange/bybit/market_info_poller_test.go
+++ b/pkg/exchange/bybit/market_info_poller_test.go
@@ -137,7 +137,7 @@ func Test_feeRatePoller_Get(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockMarketProvider := mocks.NewMockStreamDataProvider(mockCtrl)
-	t.Run("succeeds", func(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
 		symbol := "BTCUSDT"
 		expFeeDetail := symbolFeeDetail{
 			FeeRate: bybitapi.FeeRate{
@@ -156,18 +156,18 @@ func Test_feeRatePoller_Get(t *testing.T) {
 			},
 		}
 
-		res, err := s.Get(symbol)
-		assert.NoError(t, err)
+		res, found := s.Get(symbol)
+		assert.True(t, found)
 		assert.Equal(t, expFeeDetail, res)
 	})
-	t.Run("succeeds", func(t *testing.T) {
+	t.Run("not found", func(t *testing.T) {
 		symbol := "BTCUSDT"
 		s := &feeRatePoller{
 			client:          mockMarketProvider,
 			symbolFeeDetail: map[string]symbolFeeDetail{},
 		}
 
-		_, err := s.Get(symbol)
-		assert.ErrorContains(t, err, symbol)
+		_, found := s.Get(symbol)
+		assert.False(t, found)
 	})
 }


### PR DESCRIPTION
1. Remove the retry func and we can rely on the ticker instead.
2. Add fee rate recover.

REMARK:
The default rate for takers/markets on Bybit SPOT is 0.1%
https://www.bybit.com/en-US/help-center/article/Trading-Fee-Structure
![image](https://github.com/c9s/bbgo/assets/5364396/81f3ede1-638e-4811-9b76-b2c443c3d8a3)
