### PR TITLE
FEATURE: [bitget] implement order, trade user stream

### DIFF
--- a/pkg/bbgo/session.go
+++ b/pkg/bbgo/session.go
@@ -58,6 +58,10 @@ type ExchangeSession struct {
 	// This option is exchange specific
 	PrivateChannels []string `json:"privateChannels,omitempty" yaml:"privateChannels,omitempty"`
 
+	// PrivateChannelSymbols is used for filtering the private user data channel, .e.g, order symbol subscription.
+	// This option is exchange specific
+	PrivateChannelSymbols []string `json:"privateChannelSymbols,omitempty" yaml:"privateChannelSymbols,omitempty"`
+
 	Margin               bool   `json:"margin,omitempty" yaml:"margin"`
 	IsolatedMargin       bool   `json:"isolatedMargin,omitempty" yaml:"isolatedMargin,omitempty"`
 	IsolatedMarginSymbol string `json:"isolatedMarginSymbol,omitempty" yaml:"isolatedMarginSymbol,omitempty"`
@@ -246,6 +250,11 @@ func (session *ExchangeSession) Init(ctx context.Context, environ *Environment) 
 		if len(session.PrivateChannels) > 0 {
 			if setter, ok := session.UserDataStream.(types.PrivateChannelSetter); ok {
 				setter.SetPrivateChannels(session.PrivateChannels)
+			}
+		}
+		if len(session.PrivateChannelSymbols) > 0 {
+			if setter, ok := session.UserDataStream.(types.PrivateChannelSymbolSetter); ok {
+				setter.SetPrivateChannelSymbols(session.PrivateChannelSymbols)
 			}
 		}
 

--- a/pkg/exchange/bitget/bitgetapi/v2/get_history_orders_request.go
+++ b/pkg/exchange/bitget/bitgetapi/v2/get_history_orders_request.go
@@ -51,8 +51,8 @@ type OrderDetail struct {
 	// The value is json string, so we unmarshal it after unmarshal OrderDetail
 	FeeDetailRaw string                     `json:"feeDetail"`
 	OrderSource  string                     `json:"orderSource"`
-	CTime        types.MillisecondTimestamp `json:"cTime"`
-	UTime        types.MillisecondTimestamp `json:"uTime"`
+	CreatedTime  types.MillisecondTimestamp `json:"cTime"`
+	UpdatedTime  types.MillisecondTimestamp `json:"uTime"`
 
 	FeeDetail FeeDetail
 }

--- a/pkg/exchange/bitget/bitgetapi/v2/get_history_orders_request_test.go
+++ b/pkg/exchange/bitget/bitgetapi/v2/get_history_orders_request_test.go
@@ -53,8 +53,8 @@ func TestOrderDetail_UnmarshalJSON(t *testing.T) {
 			EnterPointSource: "API",
 			FeeDetailRaw:     "",
 			OrderSource:      "normal",
-			CTime:            types.NewMillisecondTimestampFromInt(1699021576683),
-			UTime:            types.NewMillisecondTimestampFromInt(1699021649099),
+			CreatedTime:      types.NewMillisecondTimestampFromInt(1699021576683),
+			UpdatedTime:      types.NewMillisecondTimestampFromInt(1699021649099),
 			FeeDetail:        FeeDetail{},
 		}, od)
 	})
@@ -98,8 +98,8 @@ func TestOrderDetail_UnmarshalJSON(t *testing.T) {
 			EnterPointSource: "API",
 			FeeDetailRaw:     `{"newFees":{"c":0,"d":0,"deduction":false,"r":-0.0070005,"t":-0.0070005,"totalDeductionFee":0},"USDT":{"deduction":false,"feeCoinCode":"USDT","totalDeductionFee":0,"totalFee":-0.007000500000}}`,
 			OrderSource:      "normal",
-			CTime:            types.NewMillisecondTimestampFromInt(1699020564659),
-			UTime:            types.NewMillisecondTimestampFromInt(1699020564688),
+			CreatedTime:      types.NewMillisecondTimestampFromInt(1699020564659),
+			UpdatedTime:      types.NewMillisecondTimestampFromInt(1699020564688),
 			FeeDetail: FeeDetail{
 				NewFees: struct {
 					DeductedByCoupon     fixedpoint.Value `json:"c"`

--- a/pkg/exchange/bitget/bitgetapi/v2/get_trade_fills.go
+++ b/pkg/exchange/bitget/bitgetapi/v2/get_trade_fills.go
@@ -36,19 +36,19 @@ type TradeFee struct {
 }
 
 type Trade struct {
-	UserId     types.StrInt64             `json:"userId"`
-	Symbol     string                     `json:"symbol"`
-	OrderId    types.StrInt64             `json:"orderId"`
-	TradeId    types.StrInt64             `json:"tradeId"`
-	OrderType  OrderType                  `json:"orderType"`
-	Side       SideType                   `json:"side"`
-	PriceAvg   fixedpoint.Value           `json:"priceAvg"`
-	Size       fixedpoint.Value           `json:"size"`
-	Amount     fixedpoint.Value           `json:"amount"`
-	FeeDetail  TradeFee                   `json:"feeDetail"`
-	TradeScope TradeScope                 `json:"tradeScope"`
-	CTime      types.MillisecondTimestamp `json:"cTime"`
-	UTime      types.MillisecondTimestamp `json:"uTime"`
+	UserId      types.StrInt64             `json:"userId"`
+	Symbol      string                     `json:"symbol"`
+	OrderId     types.StrInt64             `json:"orderId"`
+	TradeId     types.StrInt64             `json:"tradeId"`
+	OrderType   OrderType                  `json:"orderType"`
+	Side        SideType                   `json:"side"`
+	PriceAvg    fixedpoint.Value           `json:"priceAvg"`
+	Size        fixedpoint.Value           `json:"size"`
+	Amount      fixedpoint.Value           `json:"amount"`
+	FeeDetail   TradeFee                   `json:"feeDetail"`
+	TradeScope  TradeScope                 `json:"tradeScope"`
+	CreatedTime types.MillisecondTimestamp `json:"cTime"`
+	UpdatedTime types.MillisecondTimestamp `json:"uTime"`
 }
 
 //go:generate GetRequest -url "/api/v2/spot/trade/fills" -type GetTradeFillsRequest -responseDataType []Trade

--- a/pkg/exchange/bitget/bitgetapi/v2/get_unfilled_orders_request.go
+++ b/pkg/exchange/bitget/bitgetapi/v2/get_unfilled_orders_request.go
@@ -27,8 +27,8 @@ type UnfilledOrder struct {
 	QuoteVolume      fixedpoint.Value           `json:"quoteVolume"`
 	EnterPointSource string                     `json:"enterPointSource"`
 	OrderSource      string                     `json:"orderSource"`
-	CTime            types.MillisecondTimestamp `json:"cTime"`
-	UTime            types.MillisecondTimestamp `json:"uTime"`
+	CreatedTime      types.MillisecondTimestamp `json:"cTime"`
+	UpdatedTime      types.MillisecondTimestamp `json:"uTime"`
 }
 
 //go:generate GetRequest -url "/api/v2/spot/trade/unfilled-orders" -type GetUnfilledOrdersRequest -responseDataType []UnfilledOrder

--- a/pkg/exchange/bitget/convert.go
+++ b/pkg/exchange/bitget/convert.go
@@ -158,7 +158,7 @@ func toGlobalTrade(trade v2.Trade) (*types.Trade, error) {
 		Side:          side,
 		IsBuyer:       side == types.SideTypeBuy,
 		IsMaker:       isMaker,
-		Time:          types.Time(trade.CTime),
+		Time:          types.Time(trade.CreatedTime),
 		Fee:           trade.FeeDetail.TotalFee.Abs(),
 		FeeCurrency:   trade.FeeDetail.FeeCoin,
 		FeeDiscounted: isDiscount,
@@ -211,8 +211,8 @@ func unfilledOrderToGlobalOrder(order v2.UnfilledOrder) (*types.Order, error) {
 		Status:           status,
 		ExecutedQuantity: order.BaseVolume,
 		IsWorking:        order.Status.IsWorking(),
-		CreationTime:     types.Time(order.CTime.Time()),
-		UpdateTime:       types.Time(order.UTime.Time()),
+		CreationTime:     types.Time(order.CreatedTime.Time()),
+		UpdateTime:       types.Time(order.UpdatedTime.Time()),
 	}, nil
 }
 
@@ -262,8 +262,8 @@ func toGlobalOrder(order v2.OrderDetail) (*types.Order, error) {
 		Status:           status,
 		ExecutedQuantity: order.BaseVolume,
 		IsWorking:        order.Status.IsWorking(),
-		CreationTime:     types.Time(order.CTime.Time()),
-		UpdateTime:       types.Time(order.UTime.Time()),
+		CreationTime:     types.Time(order.CreatedTime.Time()),
+		UpdateTime:       types.Time(order.UpdatedTime.Time()),
 	}, nil
 }
 
@@ -443,8 +443,8 @@ func (o *Order) toGlobalOrder() (types.Order, error) {
 		Status:           status,
 		ExecutedQuantity: o.AccBaseVolume,
 		IsWorking:        o.Status.IsWorking(),
-		CreationTime:     types.Time(o.CTime.Time()),
-		UpdateTime:       types.Time(o.UTime.Time()),
+		CreationTime:     types.Time(o.CreatedTime.Time()),
+		UpdateTime:       types.Time(o.UpdatedTime.Time()),
 	}, nil
 }
 

--- a/pkg/exchange/bitget/convert_test.go
+++ b/pkg/exchange/bitget/convert_test.go
@@ -222,8 +222,8 @@ func Test_unfilledOrderToGlobalOrder(t *testing.T) {
 			QuoteVolume:      fixedpoint.NewFromFloat(0),
 			EnterPointSource: "API",
 			OrderSource:      "normal",
-			CTime:            types.NewMillisecondTimestampFromInt(1660704288118),
-			UTime:            types.NewMillisecondTimestampFromInt(1660704288118),
+			CreatedTime:      types.NewMillisecondTimestampFromInt(1660704288118),
+			UpdatedTime:      types.NewMillisecondTimestampFromInt(1660704288118),
 		}
 	)
 
@@ -296,8 +296,8 @@ func Test_toGlobalOrder(t *testing.T) {
 			EnterPointSource: "API",
 			FeeDetailRaw:     `{\"newFees\":{\"c\":0,\"d\":0,\"deduction\":false,\"r\":-0.0070005,\"t\":-0.0070005,\"totalDeductionFee\":0},\"USDT\":{\"deduction\":false,\"feeCoinCode\":\"USDT\",\"totalDeductionFee\":0,\"totalFee\":-0.007000500000}}`,
 			OrderSource:      "normal",
-			CTime:            types.NewMillisecondTimestampFromInt(1660704288118),
-			UTime:            types.NewMillisecondTimestampFromInt(1660704288118),
+			CreatedTime:      types.NewMillisecondTimestampFromInt(1660704288118),
+			UpdatedTime:      types.NewMillisecondTimestampFromInt(1660704288118),
 		}
 
 		expOrder = &types.Order{
@@ -558,9 +558,9 @@ func Test_toGlobalTrade(t *testing.T) {
 			TotalDeductionFee: fixedpoint.Zero,
 			TotalFee:          fixedpoint.NewFromFloat(-0.0070005),
 		},
-		TradeScope: v2.TradeTaker,
-		CTime:      types.NewMillisecondTimestampFromInt(1699020564676),
-		UTime:      types.NewMillisecondTimestampFromInt(1699020564687),
+		TradeScope:  v2.TradeTaker,
+		CreatedTime: types.NewMillisecondTimestampFromInt(1699020564676),
+		UpdatedTime: types.NewMillisecondTimestampFromInt(1699020564687),
 	}
 
 	res, err := toGlobalTrade(trade)
@@ -597,7 +597,7 @@ func Test_toGlobalBalanceMap(t *testing.T) {
 			Frozen:         fixedpoint.NewFromFloat(0.6),
 			Locked:         fixedpoint.NewFromFloat(0.7),
 			LimitAvailable: fixedpoint.Zero,
-			UTime:          types.NewMillisecondTimestampFromInt(1699020564676),
+			UpdatedTime:    types.NewMillisecondTimestampFromInt(1699020564676),
 		},
 	}))
 }
@@ -773,8 +773,8 @@ func TestOrder_toGlobalOrder(t *testing.T) {
 		AccBaseVolume:    fixedpoint.NewFromFloat(33.6558),
 		PriceAvg:         fixedpoint.NewFromFloat(0.49016),
 		Status:           v2.OrderStatusPartialFilled,
-		CTime:            types.NewMillisecondTimestampFromInt(1699881902217),
-		UTime:            types.NewMillisecondTimestampFromInt(1699881902248),
+		CreatedTime:      types.NewMillisecondTimestampFromInt(1699881902217),
+		UpdatedTime:      types.NewMillisecondTimestampFromInt(1699881902248),
 		FeeDetail:        nil,
 		EnterPointSource: "API",
 	}
@@ -829,8 +829,8 @@ func TestOrder_toGlobalOrder(t *testing.T) {
 			Status:           types.OrderStatusPartiallyFilled,
 			ExecutedQuantity: newO.AccBaseVolume,
 			IsWorking:        newO.Status.IsWorking(),
-			CreationTime:     types.Time(newO.CTime),
-			UpdateTime:       types.Time(newO.UTime),
+			CreationTime:     types.Time(newO.CreatedTime),
+			UpdateTime:       types.Time(newO.UpdatedTime),
 		}, res)
 	})
 
@@ -886,8 +886,8 @@ func TestOrder_toGlobalOrder(t *testing.T) {
 			Status:           types.OrderStatusPartiallyFilled,
 			ExecutedQuantity: newO.AccBaseVolume,
 			IsWorking:        newO.Status.IsWorking(),
-			CreationTime:     types.Time(newO.CTime),
-			UpdateTime:       types.Time(newO.UTime),
+			CreationTime:     types.Time(newO.CreatedTime),
+			UpdateTime:       types.Time(newO.UpdatedTime),
 		}, res)
 	})
 
@@ -944,8 +944,8 @@ func TestOrder_toGlobalOrder(t *testing.T) {
 			Status:           types.OrderStatusPartiallyFilled,
 			ExecutedQuantity: newO.AccBaseVolume,
 			IsWorking:        newO.Status.IsWorking(),
-			CreationTime:     types.Time(newO.CTime),
-			UpdateTime:       types.Time(newO.UTime),
+			CreationTime:     types.Time(newO.CreatedTime),
+			UpdateTime:       types.Time(newO.UpdatedTime),
 		}, res)
 	})
 
@@ -1002,8 +1002,8 @@ func TestOrder_toGlobalOrder(t *testing.T) {
 			Status:           types.OrderStatusPartiallyFilled,
 			ExecutedQuantity: newO.AccBaseVolume,
 			IsWorking:        newO.Status.IsWorking(),
-			CreationTime:     types.Time(newO.CTime),
-			UpdateTime:       types.Time(newO.UTime),
+			CreationTime:     types.Time(newO.CreatedTime),
+			UpdateTime:       types.Time(newO.UpdatedTime),
 		}, res)
 	})
 
@@ -1088,8 +1088,8 @@ func TestOrder_toGlobalTrade(t *testing.T) {
 		AccBaseVolume:    fixedpoint.NewFromFloat(33.6558),
 		PriceAvg:         fixedpoint.NewFromFloat(0.49016),
 		Status:           v2.OrderStatusPartialFilled,
-		CTime:            types.NewMillisecondTimestampFromInt(1699881902217),
-		UTime:            types.NewMillisecondTimestampFromInt(1699881902248),
+		CreatedTime:      types.NewMillisecondTimestampFromInt(1699881902217),
+		UpdatedTime:      types.NewMillisecondTimestampFromInt(1699881902248),
 		FeeDetail:        nil,
 		EnterPointSource: "API",
 	}

--- a/pkg/exchange/bitget/exchange.go
+++ b/pkg/exchange/bitget/exchange.go
@@ -394,7 +394,7 @@ func (e *Exchange) QueryOpenOrders(ctx context.Context, symbol string) (orders [
 	return orders, nil
 }
 
-// QueryClosedOrders queries closed order by time range(`CTime`) and id. The order of the response is in descending order.
+// QueryClosedOrders queries closed order by time range(`CreatedTime`) and id. The order of the response is in descending order.
 // If you need to retrieve all data, please utilize the function pkg/exchange/batch.ClosedOrderBatchQuery.
 //
 // ** Since is inclusive, Until is exclusive. If you use a time range to query, you must provide both a start time and an end time. **
@@ -495,7 +495,7 @@ func (e *Exchange) CancelOrders(ctx context.Context, orders ...types.Order) (err
 }
 
 // QueryTrades queries fill trades. The trade of the response is in descending order. The time-based query are typically
-// using (`CTime`) as the search criteria.
+// using (`CreatedTime`) as the search criteria.
 // If you need to retrieve all data, please utilize the function pkg/exchange/batch.TradeBatchQuery.
 //
 // ** StartTime is inclusive, EndTime is exclusive. If you use the EndTime, the StartTime is required. **

--- a/pkg/exchange/bitget/stream_callbacks.go
+++ b/pkg/exchange/bitget/stream_callbacks.go
@@ -43,3 +43,13 @@ func (s *Stream) EmitAccountEvent(e AccountEvent) {
 		cb(e)
 	}
 }
+
+func (s *Stream) OnOrderTradeEvent(cb func(e OrderTradeEvent)) {
+	s.orderTradeEventCallbacks = append(s.orderTradeEventCallbacks, cb)
+}
+
+func (s *Stream) EmitOrderTradeEvent(e OrderTradeEvent) {
+	for _, cb := range s.orderTradeEventCallbacks {
+		cb(e)
+	}
+}

--- a/pkg/exchange/bitget/stream_test.go
+++ b/pkg/exchange/bitget/stream_test.go
@@ -134,6 +134,12 @@ func TestStream(t *testing.T) {
 		s.OnBalanceUpdate(func(balances types.BalanceMap) {
 			t.Log("get update", balances)
 		})
+		s.OnOrderUpdate(func(order types.Order) {
+			t.Log("order update", order)
+		})
+		s.OnTradeUpdate(func(trade types.Trade) {
+			t.Log("trade update", trade)
+		})
 
 		c := make(chan struct{})
 		<-c

--- a/pkg/exchange/bitget/types.go
+++ b/pkg/exchange/bitget/types.go
@@ -452,7 +452,7 @@ type Balance struct {
 	Locked fixedpoint.Value `json:"locked"`
 	// Restricted availability For spot copy trading
 	LimitAvailable fixedpoint.Value           `json:"limitAvailable"`
-	UTime          types.MillisecondTimestamp `json:"uTime"`
+	UpdatedTime    types.MillisecondTimestamp `json:"uTime"`
 }
 
 type AccountEvent struct {
@@ -495,8 +495,8 @@ type Order struct {
 	AccBaseVolume fixedpoint.Value           `json:"accBaseVolume"`
 	PriceAvg      fixedpoint.Value           `json:"priceAvg"`
 	Status        v2.OrderStatus             `json:"status"`
-	CTime         types.MillisecondTimestamp `json:"cTime"`
-	UTime         types.MillisecondTimestamp `json:"uTime"`
+	CreatedTime   types.MillisecondTimestamp `json:"cTime"`
+	UpdatedTime   types.MillisecondTimestamp `json:"uTime"`
 	FeeDetail     []struct {
 		FeeCoin string `json:"feeCoin"`
 		Fee     string `json:"fee"`

--- a/pkg/exchange/bitget/types.go
+++ b/pkg/exchange/bitget/types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	v2 "github.com/c9s/bbgo/pkg/exchange/bitget/bitgetapi/v2"
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
 )
@@ -29,6 +30,7 @@ const (
 	// ChannelOrderBook15 top 15 order book of "books" that begins from bid1/ask1
 	ChannelOrderBook15 ChannelType = "books15"
 	ChannelTrade       ChannelType = "trade"
+	ChannelOrders      ChannelType = "orders"
 )
 
 type WsArg struct {
@@ -455,6 +457,66 @@ type Balance struct {
 
 type AccountEvent struct {
 	Balances []Balance
+
+	// internal use
+	actionType ActionType
+	instId     string
+}
+
+type Trade struct {
+	// Latest filled price
+	FillPrice fixedpoint.Value `json:"fillPrice"`
+	TradeId   types.StrInt64   `json:"tradeId"`
+	// Number of latest filled orders
+	BaseVolume fixedpoint.Value           `json:"baseVolume"`
+	FillTime   types.MillisecondTimestamp `json:"fillTime"`
+	// Transaction fee of the latest transaction, negative value
+	FillFee fixedpoint.Value `json:"fillFee"`
+	// Currency of transaction fee of the latest transaction
+	FillFeeCoin string `json:"fillFeeCoin"`
+	// Direction of liquidity of the latest transaction
+	TradeScope string `json:"tradeScope"`
+}
+
+type Order struct {
+	Trade
+
+	InstId string `json:"instId"`
+	// OrderId are always numeric. It's confirmed with official customer service. https://t.me/bitgetOpenapi/24172
+	OrderId       types.StrInt64 `json:"orderId"`
+	ClientOrderId string         `json:"clientOid"`
+	// Size is base coin when orderType=limit; quote coin when orderType=market
+	Size fixedpoint.Value `json:"size"`
+	// Buy amount, returned when buying at market price
+	Notional      fixedpoint.Value           `json:"notional"`
+	OrderType     v2.OrderType               `json:"orderType"`
+	Force         v2.OrderForce              `json:"force"`
+	Side          v2.SideType                `json:"side"`
+	AccBaseVolume fixedpoint.Value           `json:"accBaseVolume"`
+	PriceAvg      fixedpoint.Value           `json:"priceAvg"`
+	Status        v2.OrderStatus             `json:"status"`
+	CTime         types.MillisecondTimestamp `json:"cTime"`
+	UTime         types.MillisecondTimestamp `json:"uTime"`
+	FeeDetail     []struct {
+		FeeCoin string `json:"feeCoin"`
+		Fee     string `json:"fee"`
+	} `json:"feeDetail"`
+	EnterPointSource string `json:"enterPointSource"`
+}
+
+func (o *Order) isMaker() (bool, error) {
+	switch o.TradeScope {
+	case "T":
+		return false, nil
+	case "M":
+		return true, nil
+	default:
+		return false, fmt.Errorf("unexpected trade scope: %s", o.TradeScope)
+	}
+}
+
+type OrderTradeEvent struct {
+	Orders []Order
 
 	// internal use
 	actionType ActionType

--- a/pkg/types/stream.go
+++ b/pkg/types/stream.go
@@ -46,6 +46,10 @@ type PrivateChannelSetter interface {
 	SetPrivateChannels(channels []string)
 }
 
+type PrivateChannelSymbolSetter interface {
+	SetPrivateChannelSymbols(symbols []string)
+}
+
 type Unsubscriber interface {
 	// Unsubscribe unsubscribes the all subscriptions.
 	Unsubscribe()


### PR DESCRIPTION
https://www.bitget.com/api-doc/spot/websocket/private/Order-Channel

# order, trade data

## market sell
### order
```
//stream_test.go:153: order update ORDER bitget | UUID 1107940456212631553 (1107940456212631553) | BGBUSDT | MARKET SELL | 0/285 @ 0 | NEW | Nov 13 12:45:09.976 -> Nov 13 12:45:09.976
//stream_test.go:153: order update ORDER bitget | UUID 1107940456212631553 (1107940456212631553) | BGBUSDT | MARKET SELL | 22.5835/285 @ 0.48706 | PARTIALLY_FILLED | Nov 13 12:45:09.976 -> Nov 13 12:45:10.006
//stream_test.go:153: order update ORDER bitget | UUID 1107940456212631553 (1107940456212631553) | BGBUSDT | MARKET SELL | 45.1675/285 @ 0.48706 | PARTIALLY_FILLED | Nov 13 12:45:09.976 -> Nov 13 12:45:10.007
//stream_test.go:153: order update ORDER bitget | UUID 1107940456212631553 (1107940456212631553) | BGBUSDT | MARKET SELL | 67.7519/285 @ 0.48706 | PARTIALLY_FILLED | Nov 13 12:45:09.976 -> Nov 13 12:45:10.007
//stream_test.go:153: order update ORDER bitget | UUID 1107940456212631553 (1107940456212631553) | BGBUSDT | MARKET SELL | 285/285 @ 0.48705 | PARTIALLY_FILLED | Nov 13 12:45:09.976 -> Nov 13 12:45:10.007
//stream_test.go:153: order update ORDER bitget | UUID 1107940456212631553 (1107940456212631553) | BGBUSDT | MARKET SELL | 285/285 @ 0.48705 | FILLED | Nov 13 12:45:09.976 -> Nov 13 12:45:10.008
```
### trade
```
//stream_test.go:156: trade update TRADE bitget BGBUSDT SELL 22.5835 @ 0.48706 | AMOUNT 10.99951951 | FEE 0.01099951 USDT | OrderID 1107940456212631553 | TID 1107940456278728704 | Nov 13 20:45:09.992
//stream_test.go:156: trade update TRADE bitget BGBUSDT SELL 22.584 @ 0.48706 | AMOUNT 10.99976304 | FEE 0.01099976 USDT | OrderID 1107940456212631553 | TID 1107940456278728706 | Nov 13 20:45:09.992
//stream_test.go:156: trade update TRADE bitget BGBUSDT SELL 22.5844 @ 0.48706 | AMOUNT 10.99995786 | FEE 0.01099995 USDT | OrderID 1107940456212631553 | TID 1107940456278728708 | Nov 13 20:45:09.992
//stream_test.go:156: trade update TRADE bitget BGBUSDT SELL 217.2481 @ 0.48705 | AMOUNT 105.8106871 | FEE 0.10581068 USDT | OrderID 1107940456212631553 | TID 1107940456278728710 | Nov 13 20:45:09.992
```
## market buy
### order
```
//    stream_test.go:153: order update ORDER bitget | UUID 1107950489998626816 (1107950489998626816) | BGBUSDT | MARKET BUY  | 0/0 @ 0 | NEW | Nov 13 13:25:02.217 -> Nov 13 13:25:02.217
//    stream_test.go:153: order update ORDER bitget | UUID 1107950489998626816 (1107950489998626816) | BGBUSDT | MARKET BUY  | 33.6558/79.56585604 @ 0.49016 | PARTIALLY_FILLED | Nov 13 13:25:02.217 -> Nov 13 13:25:02.248
//    stream_test.go:153: order update ORDER bitget | UUID 1107950489998626816 (1107950489998626816) | BGBUSDT | MARKET BUY  | 55.0972/79.55124936 @ 0.49019 | PARTIALLY_FILLED | Nov 13 13:25:02.217 -> Nov 13 13:25:02.249
//    stream_test.go:153: order update ORDER bitget | UUID 1107950489998626816 (1107950489998626816) | BGBUSDT | MARKET BUY  | 77.5393/79.53827014 @ 0.49023 | PARTIALLY_FILLED | Nov 13 13:25:02.217 -> Nov 13 13:25:02.249
//    stream_test.go:153: order update ORDER bitget | UUID 1107950489998626816 (1107950489998626816) | BGBUSDT | MARKET BUY  | 79.5534/79.53827014 @ 0.49023 | PARTIALLY_FILLED | Nov 13 13:25:02.217 -> Nov 13 13:25:02.250
//    stream_test.go:153: order update ORDER bitget | UUID 1107950489998626816 (1107950489998626816) | BGBUSDT | MARKET BUY  | 79.5534/79.5534 @ 0.49023 | FILLED | Nov 13 13:25:02.217 -> Nov 13 13:25:02.250
```
### trade
```
//    stream_test.go:156: trade update TRADE bitget BGBUSDT  BUY 33.6558 @ 0.49016 | AMOUNT 16.49672692 | FEE 0.0336558 BGB | OrderID 1107950489998626816 | TID 1107950490073112582 | Nov 13 21:25:02.235
//    stream_test.go:156: trade update TRADE bitget BGBUSDT  BUY 21.4414 @ 0.49025 | AMOUNT 10.51164635 | FEE 0.0214414 BGB | OrderID 1107950489998626816 | TID 1107950490073112584 | Nov 13 21:25:02.235
//    stream_test.go:156: trade update TRADE bitget BGBUSDT  BUY 22.4421 @ 0.49033 | AMOUNT 11.00403489 | FEE 0.0224421 BGB | OrderID 1107950489998626816 | TID 1107950490073112586 | Nov 13 21:25:02.235
//    stream_test.go:156: trade update TRADE bitget BGBUSDT  BUY 2.0141 @ 0.49033 | AMOUNT 0.98757365 | FEE 0.0020141 BGB | OrderID 1107950489998626816 | TID 1107950490073112588 | Nov 13 21:25:02.235
```

## limit sell
### order
```
//    stream_test.go:153: order update ORDER bitget | UUID 1107936497259417600 (1107936497259417600) | BGBUSDT | LIMIT SELL | 0/280 @ 0 | NEW | Nov 13 12:29:26.088 -> Nov 13 12:29:26.088
//    stream_test.go:153: order update ORDER bitget | UUID 1107936497259417600 (1107936497259417600) | BGBUSDT | LIMIT SELL | 1.2254/280 @ 0.4871 | PARTIALLY_FILLED | Nov 13 12:29:26.088 -> Nov 13 12:29:51.901
//    stream_test.go:153: order update ORDER bitget | UUID 1107936497259417600 (1107936497259417600) | BGBUSDT | LIMIT SELL | 105.2616/280 @ 0.4871 | PARTIALLY_FILLED | Nov 13 12:29:26.088 -> Nov 13 12:31:26.695
//    stream_test.go:153: order update ORDER bitget | UUID 1107936497259417600 (1107936497259417600) | BGBUSDT | LIMIT SELL | 146.3209/280 @ 0.4871 | PARTIALLY_FILLED | Nov 13 12:29:26.088 -> Nov 13 12:31:38.746
//    stream_test.go:153: order update ORDER bitget | UUID 1107936497259417600 (1107936497259417600) | BGBUSDT | LIMIT SELL | 280/280 @ 0.4871 | PARTIALLY_FILLED | Nov 13 12:29:26.088 -> Nov 13 12:33:31.715
//    stream_test.go:153: order update ORDER bitget | UUID 1107936497259417600 (1107936497259417600) | BGBUSDT | LIMIT SELL | 280/280 @ 0.4871 | FILLED | Nov 13 12:29:26.088 -> Nov 13 12:33:31.715
```
### trade
```
//    stream_test.go:156: trade update TRADE bitget BGBUSDT SELL 1.2254 @ 0.4871 | AMOUNT 0.59689234 | FEE 0.00059689 USDT | OrderID 1107936497259417600 | TID 1107936605475643483 | Nov 13 20:29:51.889
//    stream_test.go:156: trade update TRADE bitget BGBUSDT SELL 104.0362 @ 0.4871 | AMOUNT 50.67603301 | FEE 0.05067603 USDT | OrderID 1107936497259417600 | TID 1107937003070496897 | Nov 13 20:31:26.683
//    stream_test.go:156: trade update TRADE bitget BGBUSDT SELL 41.0593 @ 0.4871 | AMOUNT 19.99998502 | FEE 0.01999998 USDT | OrderID 1107936497259417600 | TID 1107937053540556809 | Nov 13 20:31:38.716
//    stream_test.go:156: trade update TRADE bitget BGBUSDT SELL 133.6791 @ 0.4871 | AMOUNT 65.11508961 | FEE 0.06511508 USDT | OrderID 1107936497259417600 | TID 1107937527433994241 | Nov 13 20:33:31.700
```
## limit buy
### order
```
//    stream_test.go:153: order update ORDER bitget | UUID 1107955329902481408 (1107955329902481408) | BGBUSDT | LIMIT BUY  | 0/24.999 @ 0 | NEW | Nov 13 13:44:16.140 -> Nov 13 13:44:16.140
//    stream_test.go:153: order update ORDER bitget | UUID 1107955329902481408 (1107955329902481408) | BGBUSDT | LIMIT BUY  | 15.9404/24.999 @ 0.49998 | PARTIALLY_FILLED | Nov 13 13:44:16.140 -> Nov 13 13:44:33.285
//    stream_test.go:153: order update ORDER bitget | UUID 1107955329902481408 (1107955329902481408) | BGBUSDT 
| LIMIT BUY  | 15.9404/24.999 @ 0.49998 | CANCELED | Nov 13 13:44:16.140 -> Nov 13 13:46:02.998
```

### trade
```
//    stream_test.go:156: trade update TRADE bitget BGBUSDT  BUY 15.9404 @ 0.49998 | AMOUNT 7.96988119 | FEE 
0.0159404 BGB | OrderID 1107955329902481408 | TID 1107955401758285828 | Nov 13 21:44:33.272
```