### PR TITLE
FIX: move Initialize() call out, call it before the LoadState

### DIFF
--- a/cmd/bbgo-webview/main.go
+++ b/cmd/bbgo-webview/main.go
@@ -109,6 +109,11 @@ func main() {
 				return
 			}
 
+			if err := trader.Initialize(ctx); err != nil {
+				log.WithError(err).Error("failed to initialize strategies")
+				return
+			}
+
 			if err := trader.LoadState(ctx); err != nil {
 				log.WithError(err).Error("failed to load strategy states")
 				return

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -163,6 +163,10 @@ func runConfig(basectx context.Context, cmd *cobra.Command, userConfig *bbgo.Con
 		return err
 	}
 
+	if err := trader.Initialize(tradingCtx); err != nil {
+		return err
+	}
+
 	if err := trader.LoadState(tradingCtx); err != nil {
 		return err
 	}


### PR DESCRIPTION
The new generation of strategies introduces the use of `common.Strategy`, which is embedded as a struct to simplify the strategy implementation. This approach reduces the amount of code required for writing strategies. During the transition from YAML configuration to runtime instance, whenever any configuration field of `common.Strategy` is set, it initializes the `common.Strategy` structure to enable persistence. In other words, `s.Strategy == &common.Strategy` is established by the JSON unmarshal process. Conversely, if it's not set, `s.Strategy` becomes `nil`, preventing persistence from being loaded.

Inside the `Run()` function, we directly assign `s.Strategy = &common.Strategy{}`. This overwrites the object that was previously loaded from persistence, causing the strategy to start with zeroed data when it stops. Initially, the intention was to move `s.Strategy = &common.Strategy{}` inside the `Initialize()` method of the strategy. However, this phase still occurs after `LoadState`, resulting in persistence being cleared.

The original stages of the strategy launch were as follows:
1. `trader.Configure`: Mount strategies.
2. `trader.LoadState`: Load persistence.
3. `Run`: Execute `Strategy Initialize()`, `Defaults()`, and `Run()`.

The modified stages are as follows:
1. `trader.Configure`: Mount strategies.
2. `trader.Initialize`: Call strategy `Initialize()`.
3. `trader.LoadState`: Load persistence.
4. `Run`: Execute strategy `Defaults()` and `Run()`.