### PR TITLE
FIX: [rebalance] fix position map and profit stats map

### DIFF
--- a/pkg/strategy/rebalance/multi_market_strategy.go
+++ b/pkg/strategy/rebalance/multi_market_strategy.go
@@ -11,8 +11,8 @@ type MultiMarketStrategy struct {
 	Environ *bbgo.Environment
 	Session *bbgo.ExchangeSession
 
-	PositionMap      PositionMap    `persistence:"positionMap"`
-	ProfitStatsMap   ProfitStatsMap `persistence:"profitStatsMap"`
+	PositionMap      PositionMap    `persistence:"position_map"`
+	ProfitStatsMap   ProfitStatsMap `persistence:"profit_stats_map"`
 	OrderExecutorMap GeneralOrderExecutorMap
 
 	parent, ctx context.Context

--- a/pkg/strategy/rebalance/strategy.go
+++ b/pkg/strategy/rebalance/strategy.go
@@ -54,6 +54,10 @@ func (s *Strategy) Defaults() error {
 }
 
 func (s *Strategy) Initialize() error {
+	if s.MultiMarketStrategy == nil {
+		s.MultiMarketStrategy = &MultiMarketStrategy{}
+	}
+
 	for currency := range s.TargetWeights {
 		if currency == s.QuoteCurrency {
 			continue
@@ -105,7 +109,6 @@ func (s *Strategy) Run(ctx context.Context, _ bbgo.OrderExecutor, session *bbgo.
 		s.markets[symbol] = market
 	}
 
-	s.MultiMarketStrategy = &MultiMarketStrategy{}
 	s.MultiMarketStrategy.Initialize(ctx, s.Environment, session, s.markets, ID)
 
 	s.activeOrderBook = bbgo.NewActiveOrderBook("")

--- a/pkg/strategy/rebalance/strategy.go
+++ b/pkg/strategy/rebalance/strategy.go
@@ -137,7 +137,7 @@ func (s *Strategy) Run(ctx context.Context, _ bbgo.OrderExecutor, session *bbgo.
 
 func (s *Strategy) rebalance(ctx context.Context) {
 	// cancel active orders before rebalance
-	if err := s.Session.Exchange.CancelOrders(ctx, s.activeOrderBook.Orders()...); err != nil {
+	if err := s.activeOrderBook.GracefulCancel(ctx, s.Session.Exchange); err != nil {
 		log.WithError(err).Errorf("failed to cancel orders")
 	}
 

--- a/pkg/strategy/rebalance/strategy.go
+++ b/pkg/strategy/rebalance/strategy.go
@@ -113,6 +113,9 @@ func (s *Strategy) Run(ctx context.Context, _ bbgo.OrderExecutor, session *bbgo.
 
 	s.activeOrderBook = bbgo.NewActiveOrderBook("")
 	s.activeOrderBook.BindStream(session.UserDataStream)
+	s.activeOrderBook.OnFilled(func(order types.Order) {
+		s.rebalance(ctx)
+	})
 
 	session.UserDataStream.OnStart(func() {
 		if s.OnStart {


### PR DESCRIPTION
- fix position map and profit stats map
- graceful cancel orders to avoid `Cannot lock funds` error
- rebalance on order filled