### PR TITLE
DOCS: fix frontend path

### DIFF
--- a/doc/build-from-source.md
+++ b/doc/build-from-source.md
@@ -97,7 +97,7 @@ go run ./cmd/bbgo run
 You can also use the makefile to build bbgo:
 
 ```shell
-cd frontend && yarn install
+cd apps/frontend && yarn install
 make bbgo
 ```
 


### PR DESCRIPTION
`frontend` got moved to `apps/frontend` in this [commit](https://github.com/c9s/bbgo/commit/46d8d28b)