### PR TITLE
FIX: [telegram] prevent sending error to telegram for the case of no opened position

### DIFF
--- a/pkg/bbgo/interact.go
+++ b/pkg/bbgo/interact.go
@@ -147,7 +147,7 @@ func (it *CoreInteraction) Commands(i *interact.Interact) {
 		position := reader.CurrentPosition()
 		if position == nil || position.Base.IsZero() {
 			reply.Message(fmt.Sprintf("Strategy %q has no opened position", signature))
-			return fmt.Errorf("strategy %T has no opened position", strategy)
+			return nil
 		}
 
 		reply.Send("Your current position:")


### PR DESCRIPTION
Executing the Telegram command /position to request information about open positions results in an error message when there are no open positions. The state of having no open positions should not be treated as an error.