### PR TITLE
FIX: [okx] fix trade id

### DIFF
--- a/pkg/exchange/okex/convert.go
+++ b/pkg/exchange/okex/convert.go
@@ -150,12 +150,9 @@ func toGlobalTrades(orderDetails []okexapi.OrderDetails) ([]types.Trade, error) 
 }
 
 func tradeToGlobal(trade okexapi.Trade) types.Trade {
-	// ** We use the bill id as the trade id, because okx uses billId to perform pagination. **
-	billID := trade.BillId
-
 	side := toGlobalSide(trade.Side)
 	return types.Trade{
-		ID:            uint64(billID),
+		ID:            uint64(trade.TradeId),
 		OrderID:       uint64(trade.OrderId),
 		Exchange:      types.ExchangeOKEx,
 		Price:         trade.FillPrice,

--- a/pkg/exchange/okex/convert_test.go
+++ b/pkg/exchange/okex/convert_test.go
@@ -115,7 +115,7 @@ func Test_tradeToGlobal(t *testing.T) {
 
 	t.Run("succeeds with sell/taker", func(t *testing.T) {
 		assert.Equal(tradeToGlobal(res), types.Trade{
-			ID:            uint64(665951654138736652),
+			ID:            uint64(724072849),
 			OrderID:       uint64(665951654130348158),
 			Exchange:      types.ExchangeOKEx,
 			Price:         fixedpoint.NewFromFloat(46446.4),
@@ -135,7 +135,7 @@ func Test_tradeToGlobal(t *testing.T) {
 		newRes := res
 		newRes.Side = okexapi.SideTypeBuy
 		assert.Equal(tradeToGlobal(newRes), types.Trade{
-			ID:            uint64(665951654138736652),
+			ID:            uint64(724072849),
 			OrderID:       uint64(665951654130348158),
 			Exchange:      types.ExchangeOKEx,
 			Price:         fixedpoint.NewFromFloat(46446.4),
@@ -155,7 +155,7 @@ func Test_tradeToGlobal(t *testing.T) {
 		newRes := res
 		newRes.ExecutionType = okexapi.LiquidityTypeMaker
 		assert.Equal(tradeToGlobal(newRes), types.Trade{
-			ID:            uint64(665951654138736652),
+			ID:            uint64(724072849),
 			OrderID:       uint64(665951654130348158),
 			Exchange:      types.ExchangeOKEx,
 			Price:         fixedpoint.NewFromFloat(46446.4),
@@ -176,7 +176,7 @@ func Test_tradeToGlobal(t *testing.T) {
 		newRes.Side = okexapi.SideTypeBuy
 		newRes.ExecutionType = okexapi.LiquidityTypeMaker
 		assert.Equal(tradeToGlobal(newRes), types.Trade{
-			ID:            uint64(665951654138736652),
+			ID:            uint64(724072849),
 			OrderID:       uint64(665951654130348158),
 			Exchange:      types.ExchangeOKEx,
 			Price:         fixedpoint.NewFromFloat(46446.4),


### PR DESCRIPTION
In the past, I used the bill ID as the trade ID because OKX only supports querying trades by [bill ID](https://www.okx.com/docs-v5/en/#order-book-trading-trade-get-transaction-details-last-3-months). However, the bill ID is not supported on websocket events.

I updated the implementation, handling the bill ID as a filter in the loop instead of getting the ID from outside, even if you use batch.query.