### PR TITLE
FIX: [bitget] support market order on bitget unfilled order conversion

### DIFF
--- a/pkg/exchange/bitget/convert_test.go
+++ b/pkg/exchange/bitget/convert_test.go
@@ -227,7 +227,7 @@ func Test_unfilledOrderToGlobalOrder(t *testing.T) {
 		}
 	)
 
-	t.Run("succeeds", func(t *testing.T) {
+	t.Run("succeeds with limit order", func(t *testing.T) {
 		order, err := unfilledOrderToGlobalOrder(unfilledOrder)
 		assert.NoError(err)
 		assert.Equal(&types.Order{
@@ -245,6 +245,67 @@ func Test_unfilledOrderToGlobalOrder(t *testing.T) {
 			UUID:             strconv.FormatInt(int64(orderId), 10),
 			Status:           types.OrderStatusNew,
 			ExecutedQuantity: fixedpoint.NewFromFloat(0),
+			IsWorking:        true,
+			CreationTime:     types.Time(types.NewMillisecondTimestampFromInt(1660704288118).Time()),
+			UpdateTime:       types.Time(types.NewMillisecondTimestampFromInt(1660704288118).Time()),
+		}, order)
+	})
+
+	t.Run("succeeds with market buy order", func(t *testing.T) {
+		unfilledOrder2 := unfilledOrder
+		unfilledOrder2.OrderType = v2.OrderTypeMarket
+		unfilledOrder2.Side = v2.SideTypeBuy
+		unfilledOrder2.Size = unfilledOrder2.PriceAvg.Mul(unfilledOrder2.Size)
+		unfilledOrder2.PriceAvg = fixedpoint.Zero
+		unfilledOrder2.Status = v2.OrderStatusNew
+
+		order, err := unfilledOrderToGlobalOrder(unfilledOrder2)
+		assert.NoError(err)
+		assert.Equal(&types.Order{
+			SubmitOrder: types.SubmitOrder{
+				ClientOrderID: "74b86af3-6098-479c-acac-bfb074c067f3",
+				Symbol:        "BTCUSDT",
+				Side:          types.SideTypeBuy,
+				Type:          types.OrderTypeMarket,
+				Quantity:      fixedpoint.Zero,
+				Price:         fixedpoint.Zero,
+				TimeInForce:   types.TimeInForceGTC,
+			},
+			Exchange:         types.ExchangeBitget,
+			OrderID:          uint64(orderId),
+			UUID:             strconv.FormatInt(int64(orderId), 10),
+			Status:           types.OrderStatusNew,
+			ExecutedQuantity: fixedpoint.Zero,
+			IsWorking:        true,
+			CreationTime:     types.Time(types.NewMillisecondTimestampFromInt(1660704288118).Time()),
+			UpdateTime:       types.Time(types.NewMillisecondTimestampFromInt(1660704288118).Time()),
+		}, order)
+	})
+
+	t.Run("succeeds with market sell order", func(t *testing.T) {
+		unfilledOrder2 := unfilledOrder
+		unfilledOrder2.OrderType = v2.OrderTypeMarket
+		unfilledOrder2.Side = v2.SideTypeSell
+		unfilledOrder2.PriceAvg = fixedpoint.Zero
+		unfilledOrder2.Status = v2.OrderStatusNew
+
+		order, err := unfilledOrderToGlobalOrder(unfilledOrder2)
+		assert.NoError(err)
+		assert.Equal(&types.Order{
+			SubmitOrder: types.SubmitOrder{
+				ClientOrderID: "74b86af3-6098-479c-acac-bfb074c067f3",
+				Symbol:        "BTCUSDT",
+				Side:          types.SideTypeSell,
+				Type:          types.OrderTypeMarket,
+				Quantity:      fixedpoint.NewFromInt(5),
+				Price:         fixedpoint.Zero,
+				TimeInForce:   types.TimeInForceGTC,
+			},
+			Exchange:         types.ExchangeBitget,
+			OrderID:          uint64(orderId),
+			UUID:             strconv.FormatInt(int64(orderId), 10),
+			Status:           types.OrderStatusNew,
+			ExecutedQuantity: fixedpoint.Zero,
 			IsWorking:        true,
 			CreationTime:     types.Time(types.NewMillisecondTimestampFromInt(1660704288118).Time()),
 			UpdateTime:       types.Time(types.NewMillisecondTimestampFromInt(1660704288118).Time()),

--- a/pkg/exchange/bitget/exchange.go
+++ b/pkg/exchange/bitget/exchange.go
@@ -362,10 +362,12 @@ func (e *Exchange) SubmitOrder(ctx context.Context, order types.SubmitOrder) (cr
 	debugf("unfilled order response for order#%s: %+v", orderId, ordersResp)
 
 	if len(ordersResp) == 1 {
+		// 2023/11/05 The market order will be executed immediately, so we cannot retrieve it through the NewGetUnfilledOrdersRequest API.
+		// Try to get the order from the NewGetHistoryOrdersRequest API.
+		// 2024/03/06 After placing a Market Order, we can retrieve it through the unfilledOrder API, so we still need to
+		// handle the Market Order status.
 		return unfilledOrderToGlobalOrder(ordersResp[0])
 	} else if len(ordersResp) == 0 {
-		// The market order will be executed immediately, so we cannot retrieve it through the NewGetUnfilledOrdersRequest API.
-		// Try to get the order from the NewGetHistoryOrdersRequest API.
 		ordersResp, err := e.v2client.NewGetHistoryOrdersRequest().OrderId(orderId).Do(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to query history order by order id: %s, err: %w", orderId, err)


### PR DESCRIPTION
2023/11/05 The market order will be executed immediately, so this check is used to handle corner cases.
2024/03/06 After placing a Market Order, we can retrieve it through the unfilledOrder API, so we still need to
 handle the Market Order status.