### PR TITLE
MINOR: add inserted_at column to trades

### DIFF
--- a/migrations/mysql/20240531163411_trades_created.sql
+++ b/migrations/mysql/20240531163411_trades_created.sql
@@ -1,0 +1,14 @@
+-- +up
+-- +begin
+ALTER TABLE `trades` ADD COLUMN `inserted_at` DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL AFTER `traded_at`;
+-- +end
+
+-- +begin
+UPDATE `trades` SET `inserted_at`=`traded_at`;
+-- +end
+
+-- +down
+
+-- +begin
+ALTER TABLE `trades` DROP COLUMN `inserted_at`;
+-- +end

--- a/migrations/sqlite3/20240531163411_trades_created.sql
+++ b/migrations/sqlite3/20240531163411_trades_created.sql
@@ -1,0 +1,23 @@
+-- +up
+-- +begin
+ALTER TABLE trades ADD COLUMN inserted_at TEXT;
+
+UPDATE trades SET inserted_at = traded_at;
+
+CREATE TRIGGER set_inserted_at
+AFTER INSERT ON trades
+FOR EACH ROW
+BEGIN
+    UPDATE trades
+    SET inserted_at = datetime('now')
+    WHERE rowid = NEW.rowid;
+END;
+
+-- +end
+
+-- +down
+
+-- +begin
+DROP TRIGGER set_inserted_at;
+ALTER TABLE trades DROP COLUMN inserted_at;
+-- +end

--- a/pkg/types/trade.go
+++ b/pkg/types/trade.go
@@ -96,7 +96,7 @@ type Trade struct {
 	// PnL is the profit and loss value of the executed trade
 	PnL sql.NullFloat64 `json:"pnl" db:"pnl"`
 
-	InsertedAt Time `db:"inserted_at"`
+	InsertedAt Time `json:"insertedAt" db:"inserted_at"`
 }
 
 func (trade Trade) CsvHeader() []string {

--- a/pkg/types/trade.go
+++ b/pkg/types/trade.go
@@ -95,6 +95,8 @@ type Trade struct {
 
 	// PnL is the profit and loss value of the executed trade
 	PnL sql.NullFloat64 `json:"pnl" db:"pnl"`
+
+	InsertedAt Time `db:"inserted_at"`
 }
 
 func (trade Trade) CsvHeader() []string {


### PR DESCRIPTION
A trade may be missed initially and fetched after it has occurred, so we add inserted_at column.