### PR TITLE
fix float64 series use mean or stdev function result is zero

### DIFF
--- a/pkg/types/series_float64.go
+++ b/pkg/types/series_float64.go
@@ -13,7 +13,7 @@ type Float64Series struct {
 func NewFloat64Series(v ...float64) *Float64Series {
 	s := &Float64Series{}
 	s.Slice = v
-	s.SeriesBase.Series = s.Slice
+	s.SeriesBase.Series = &s.Slice
 	return s
 }
 

--- a/pkg/types/series_float64_test.go
+++ b/pkg/types/series_float64_test.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSeriesBaseFuncWithPushData(t *testing.T) {
+	series := NewFloat64Series(0.5, 1.0)
+	series.Push(2.5)
+	series.Push(3.0)
+	series.Push(4.0)
+	mean := series.Mean(5)
+	assert.Equal(t, 2.2, mean)
+	stdev := series.Stdev(5)
+	assert.Equal(t, 1.2884098726725126, stdev)
+}


### PR DESCRIPTION
```
series := types.NewFloat64Series()
	series.PushAndEmit(2)
	series.PushAndEmit(4)
	series.PushAndEmit(6)
	series.PushAndEmit(8)
	series.PushAndEmit(10)

	t.Log(series.SeriesBase.Length())
	t.Log(series.Mean(3))
	t.Log(series.Stdev(3))
}
```
The result is zero.