### PR TITLE
FIX: update timeInForce for binance margin order

### DIFF
--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -1005,16 +1005,13 @@ func (e *Exchange) submitMarginOrder(ctx context.Context, order types.SubmitOrde
 		}
 	}
 
-	// could be IOC or FOK
-	switch order.Type {
-	case types.OrderTypeLimit, types.OrderTypeStopLimit:
-		req.TimeInForce(binance.TimeInForceTypeGTC)
-	case types.OrderTypeLimitMaker:
-		// do not set TimeInForce for LimitMaker
-	default:
-		if len(order.TimeInForce) > 0 {
-			// TODO: check the TimeInForce value
-			req.TimeInForce(binance.TimeInForceType(order.TimeInForce))
+	if len(order.TimeInForce) > 0 {
+		// TODO: check the TimeInForce value
+		req.TimeInForce(binance.TimeInForceType(order.TimeInForce))
+	} else {
+		switch order.Type {
+		case types.OrderTypeLimit, types.OrderTypeStopLimit:
+			req.TimeInForce(binance.TimeInForceTypeGTC)
 		}
 	}
 


### PR DESCRIPTION
update binance margin order to support IOC and FOK, same behavior with spot order