### PR TITLE
FIX: fix shutdownCancelProfitOrders json tag

### DIFF
--- a/pkg/strategy/bollgrid/strategy.go
+++ b/pkg/strategy/bollgrid/strategy.go
@@ -77,7 +77,7 @@ type Strategy struct {
 	// boll is the BOLLINGER indicator we used for predicting the price.
 	boll *indicator.BOLL
 
-	CancelProfitOrdersOnShutdown bool `json: "shutdownCancelProfitOrders"`
+	CancelProfitOrdersOnShutdown bool `json:"shutdownCancelProfitOrders"`
 }
 
 func (s *Strategy) ID() string {


### PR DESCRIPTION
fix bad syntax for struct tag value

In fact, the previous json tag cannot be parsed correctly