### PR TITLE
FIX: fix OnNew event must be called before OnFilled

### DIFF
--- a/pkg/bbgo/activeorderbook.go
+++ b/pkg/bbgo/activeorderbook.go
@@ -359,7 +359,6 @@ func (b *ActiveOrderBook) Add(orders ...types.Order) {
 		}
 
 		b.add(order)
-		b.EmitNew(order)
 	}
 }
 
@@ -424,6 +423,7 @@ func (b *ActiveOrderBook) add(order types.Order) {
 
 		b.orders.Add(order)
 		b.pendingOrderUpdates.Remove(pendingOrder.OrderID)
+		b.EmitNew(order)
 
 		// when using add(order), it's usually a new maker order on the order book.
 		// so, when it's not status=new, we should trigger order update handler
@@ -434,6 +434,7 @@ func (b *ActiveOrderBook) add(order types.Order) {
 
 	} else {
 		b.orders.Add(order)
+		b.EmitNew(order)
 	}
 }
 


### PR DESCRIPTION
For some special case like IOC order is filled immediately, current code caused OnFilled event is called before OnNew event.
In order to fix it, I update the position of b.EmitNew(order) to guarantee OnNew event is always called before OnFilled event.