### PR TITLE
FIX: depth buffer can skip old event if event.FinalUpdateID <= buffer…

### DIFF
--- a/pkg/depth/buffer.go
+++ b/pkg/depth/buffer.go
@@ -158,7 +158,7 @@ func (b *Buffer) fetchAndPush() error {
 	var pushUpdates []Update
 	for _, u := range b.buffer {
 		// skip old events
-		if u.FirstUpdateID < finalUpdateID+1 {
+		if u.FinalUpdateID <= finalUpdateID {
 			continue
 		}
 


### PR DESCRIPTION
….FinalUpdateID