### PR TITLE
fix: misuse of unbuffered os.Signal channel as argument to signal.Notify

### DIFF
--- a/pkg/cmd/hoptimize.go
+++ b/pkg/cmd/hoptimize.go
@@ -94,11 +94,12 @@ var hoptimizeCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
 		go func() {
-			c := make(chan os.Signal)
-			signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-			<-c
-			log.Info("Early stop by manual cancelation.")
+			<-sigs
+			log.Info("Early stop by manual cancelation")
 			cancel()
 		}()
 


### PR DESCRIPTION
signal channel should not be used elsewhere. Reported by go vet.
refer: https://github.com/golang/go/issue/45043