### PR TITLE
minor: [bybit] refine order histories error msg

### DIFF
--- a/pkg/exchange/bybit/exchange.go
+++ b/pkg/exchange/bybit/exchange.go
@@ -229,6 +229,9 @@ func (e *Exchange) QueryOrder(ctx context.Context, q types.OrderQuery) (*types.O
 	if err != nil {
 		return nil, fmt.Errorf("failed to query order, queryConfig: %+v, err: %w", q, err)
 	}
+	if len(res.List) == 0 {
+		return nil, fmt.Errorf("order not found, queryConfig: %+v", q)
+	}
 	if len(res.List) != 1 {
 		return nil, fmt.Errorf("unexpected order histories length: %d, queryConfig: %+v", len(res.List), q)
 	}

--- a/pkg/exchange/bybit/exchange.go
+++ b/pkg/exchange/bybit/exchange.go
@@ -230,7 +230,7 @@ func (e *Exchange) QueryOrder(ctx context.Context, q types.OrderQuery) (*types.O
 		return nil, fmt.Errorf("failed to query order, queryConfig: %+v, err: %w", q, err)
 	}
 	if len(res.List) != 1 {
-		return nil, fmt.Errorf("unexpected order length, queryConfig: %+v", q)
+		return nil, fmt.Errorf("unexpected order histories length: %d, queryConfig: %+v", len(res.List), q)
 	}
 
 	return toGlobalOrder(res.List[0])


### PR DESCRIPTION
When placing IOC order, we are not able to get order from order history api immediately. We should raise a special error to client.