### PR TITLE
fix: [binance] remove client order id prefix

### DIFF
--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -1125,19 +1125,11 @@ func newSpotClientOrderID(originalID string) (clientOrderID string) {
 		return ""
 	}
 
-	prefix := "x-" + spotBrokerID
-	prefixLen := len(prefix)
-
 	if originalID != "" {
-		// try to keep the whole original client order ID if user specifies it.
-		if prefixLen+len(originalID) > 32 {
-			return originalID
-		}
-
-		clientOrderID = prefix + originalID
-		return clientOrderID
+		return originalID
 	}
 
+	prefix := "x-" + spotBrokerID
 	clientOrderID = uuid.New().String()
 	clientOrderID = prefix + clientOrderID
 	if len(clientOrderID) > 32 {

--- a/pkg/exchange/binance/exchange_test.go
+++ b/pkg/exchange/binance/exchange_test.go
@@ -15,7 +15,7 @@ func Test_newClientOrderID(t *testing.T) {
 	strings.HasPrefix(cID, "x-"+spotBrokerID)
 
 	cID = newSpotClientOrderID("myid1")
-	assert.Equal(t, cID, "x-"+spotBrokerID+"myid1")
+	assert.Equal(t, "myid1", cID)
 }
 
 func Test_new(t *testing.T) {


### PR DESCRIPTION
We should always use user specified client order id.