### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/pkg/bbgo/session.go
+++ b/pkg/bbgo/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"time"
 
@@ -25,7 +26,6 @@ import (
 	exchange2 "github.com/c9s/bbgo/pkg/exchange"
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
-	"github.com/c9s/bbgo/pkg/util"
 )
 
 const defaultMaxSessionTradeBufferSize = 3500
@@ -846,7 +846,7 @@ func (session *ExchangeSession) FindPossibleAssetSymbols() (symbols []string, er
 
 	for _, market := range session.Markets() {
 		// ignore the markets that are not fiat currency markets
-		if !util.StringSliceContains(fiatAssets, market.QuoteCurrency) {
+		if !slices.Contains(fiatAssets, market.QuoteCurrency) {
 			continue
 		}
 

--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -5,15 +5,6 @@ import (
 	"unicode/utf8"
 )
 
-func StringSliceContains(slice []string, needle string) bool {
-	for _, s := range slice {
-		if s == needle {
-			return true
-		}
-	}
-
-	return false
-}
 
 func MaskKey(key string) string {
 	if len(key) == 0 {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.