### PR TITLE
FIX: [exchange] add missing market info fields for Coinbase Exchange

### DIFF
--- a/pkg/exchange/coinbase/convert.go
+++ b/pkg/exchange/coinbase/convert.go
@@ -50,6 +50,11 @@ func toGlobalMarket(cbMarket *api.MarketInfo) types.Market {
 		QuoteCurrency:   cbMarket.QuoteCurrency,
 		BaseCurrency:    cbMarket.BaseCurrency,
 		MinNotional:     cbMarket.MinMarketFunds,
+		MinAmount:       cbMarket.MinMarketFunds,
+		TickSize:        cbMarket.QuoteIncrement,
+		StepSize:        cbMarket.BaseIncrement,
+		MinPrice:        fixedpoint.Zero,
+		MaxPrice:        fixedpoint.Zero,
 	}
 }
 

--- a/pkg/exchange/coinbase/exchage.go
+++ b/pkg/exchange/coinbase/exchage.go
@@ -279,7 +279,8 @@ func (e *Exchange) QueryMarkets(ctx context.Context) (types.MarketMap, error) {
 		}
 		marketInfo, err := e.queryMarketDetails(ctx, m)
 		if err != nil {
-			log.WithError(err).Errorf("failed to query market: %v", m.ID)
+			log.WithError(err).Warnf("failed to query market info for product: %v, skipped", m.ID)
+			continue
 		}
 		marketMap[toGlobalSymbol(m.ID)] = *marketInfo
 	}


### PR DESCRIPTION
Add missing fields for `types.Market`:
- `MinAmount` -> filled with `min_market_funds`
- `TickSize` -> filled with `quote_increment`
- `StepSize` -> filled with `base_increment`
- `MinPrice` -> optional, filled with `0`
- `MaxPrice` -> optional, filled with `0`
- `MinQuantity` -> derived by ticker price and `min_market_funds`
- `MaxQuantity` -> optional, filled with dummy value