### PR TITLE
FIX: [exchange] [coinbase] fill in dummy values for min/max quantity

### DIFF
--- a/pkg/exchange/coinbase/convert.go
+++ b/pkg/exchange/coinbase/convert.go
@@ -43,13 +43,14 @@ func toGlobalTrade(cbTrade *api.Trade) types.Trade {
 //
 // According to the markets list, the PPP is the max slippage percentage:
 // - https://exchange.coinbase.com/markets
-func toGlobalMarket(cbMarket *api.MarketInfo, cbTicker *api.Ticker) types.Market {
+func toGlobalMarket(cbMarket *api.MarketInfo) types.Market {
 	pricePrecision := int(math.Log10(fixedpoint.One.Div(cbMarket.QuoteIncrement).Float64()))
 	volumnPrecision := int(math.Log10(fixedpoint.One.Div(cbMarket.BaseIncrement).Float64()))
+
+	// NOTE: Coinbase does not appose a min quantity, but a min notional.
+	// So we set the min quantity to the base increment. Or it may require more API calls
+	// to calculate the excact min quantity, which is costy.
 	minQuantity := cbMarket.BaseIncrement
-	if cbTicker != nil {
-		minQuantity = cbMarket.MinMarketFunds.Div(cbTicker.Price)
-	}
 	// TODO: estimate max quantity by PPP
 	// fill a dummy value for now.
 	maxQuantity := minQuantity.Mul(fixedpoint.NewFromFloat(1.5))

--- a/pkg/exchange/coinbase/exchange_test.go
+++ b/pkg/exchange/coinbase/exchange_test.go
@@ -36,7 +36,8 @@ func Test_Symbols(t *testing.T) {
 
 func Test_OrdersAPI(t *testing.T) {
 	ex := getExchangeOrSkip(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
 
 	// should fail on unsupported symbol
 	order, err := ex.SubmitOrder(
@@ -103,21 +104,26 @@ func Test_OrdersAPI(t *testing.T) {
 
 func Test_QueryAccount(t *testing.T) {
 	ex := getExchangeOrSkip(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
 	_, err := ex.QueryAccount(ctx)
 	assert.NoError(t, err)
 }
 
 func Test_QueryAccountBalances(t *testing.T) {
 	ex := getExchangeOrSkip(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
 	_, err := ex.QueryAccountBalances(ctx)
 	assert.NoError(t, err)
 }
 
 func Test_QueryOpenOrders(t *testing.T) {
 	ex := getExchangeOrSkip(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
 
 	symbols := []string{"BTCUSD", "ETHUSD", "ETHBTC"}
 	for _, k := range symbols {
@@ -128,14 +134,18 @@ func Test_QueryOpenOrders(t *testing.T) {
 
 func Test_QueryMarkets(t *testing.T) {
 	ex := getExchangeOrSkip(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
 	_, err := ex.QueryMarkets(ctx)
 	assert.NoError(t, err)
 }
 
 func Test_QueryTicker(t *testing.T) {
 	ex := getExchangeOrSkip(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
 	ticker, err := ex.QueryTicker(ctx, "BTCUSD")
 	assert.NoError(t, err)
 	assert.NotNil(t, ticker)
@@ -143,7 +153,9 @@ func Test_QueryTicker(t *testing.T) {
 
 func Test_QueryTickers(t *testing.T) {
 	ex := getExchangeOrSkip(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
 	symbols := []string{"BTCUSD", "ETHUSD", "ETHBTC"}
 	tickers, err := ex.QueryTickers(ctx, symbols...)
 	assert.NoError(t, err)
@@ -152,7 +164,9 @@ func Test_QueryTickers(t *testing.T) {
 
 func Test_QueryKLines(t *testing.T) {
 	ex := getExchangeOrSkip(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
 	// should fail on unsupported interval
 	_, err := ex.QueryKLines(ctx, "BTCUSD", types.Interval12h, types.KLineQueryOptions{})
 	assert.Error(t, err)
@@ -178,7 +192,8 @@ func Test_QueryKLines(t *testing.T) {
 
 func Test_QueryOrderTrades(t *testing.T) {
 	ex := getExchangeOrSkip(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
 
 	trades, err := ex.QueryOrderTrades(ctx, types.OrderQuery{Symbol: "ETHUSD"})
 	assert.NoError(t, err)


### PR DESCRIPTION
Fix timeout issue for QueryMarkets.

Fill dummy values for min/max quantity because:
1. Coinbase does not appose quantity limit on orders (but min notional)
2. there are other helper functions in bbgo which can adjust the order size to meet the min notional.