### PR TITLE
FIX: [exchange] (coinbase) fix balance update

### DIFF
--- a/pkg/exchange/coinbase/convert.go
+++ b/pkg/exchange/coinbase/convert.go
@@ -112,7 +112,7 @@ func toGlobalTicker(cbTicker *api.Ticker) types.Ticker {
 func toGlobalBalance(cur string, cbBalance *api.Balance) types.Balance {
 	balance := types.NewZeroBalance(cur)
 	balance.Available = cbBalance.Available
-	balance.Locked = cbBalance.Balance.Sub(cbBalance.Available)
+	balance.Locked = cbBalance.Hold
 	balance.NetAsset = cbBalance.Balance
 	return balance
 }

--- a/pkg/exchange/coinbase/exchage.go
+++ b/pkg/exchange/coinbase/exchage.go
@@ -104,7 +104,8 @@ func (e *Exchange) QueryAccountBalances(ctx context.Context) (types.BalanceMap, 
 	balances := make(types.BalanceMap)
 	for _, cbBalance := range accounts {
 		cur := strings.ToUpper(cbBalance.Currency)
-		balances[cur] = toGlobalBalance(cur, &cbBalance)
+		tb := balances[cur]
+		balances[cur] = tb.Add(toGlobalBalance(cur, &cbBalance))
 	}
 	return balances, nil
 }


### PR DESCRIPTION
1. According to the doc of websocket feed of Coinbase, the `Hold` field is the `Locked` field
    - See: https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#balance-channel
2. Fix bug: there may be multiple trading accounts for one user, should use `.Add` method to accumulate the balance. 