### PR TITLE
FEAT: [coinbase] implement stream message handlers

### DIFF
--- a/pkg/exchange/coinbase/stream.go
+++ b/pkg/exchange/coinbase/stream.go
@@ -68,6 +68,8 @@ func NewStream(
 	s.OnBalanceMessage(s.handleBalanceMessage)
 	s.OnReceivedMessage(s.handleReceivedMessage)
 	s.OnOpenMessage(s.handleOpenMessage)
+	s.OnDoneMessage(s.handleDoneMessage)
+	s.OnChangeMessage(s.handleChangeMessage)
 
 	// public handlers
 	s.OnConnect(s.handleConnect)

--- a/pkg/exchange/coinbase/stream.go
+++ b/pkg/exchange/coinbase/stream.go
@@ -68,8 +68,6 @@ func NewStream(
 	s.OnBalanceMessage(s.handleBalanceMessage)
 	s.OnReceivedMessage(s.handleReceivedMessage)
 	s.OnOpenMessage(s.handleOpenMessage)
-	s.OnDoneMessage(s.handleDoneMessage)
-	s.OnChangeMessage(s.handleChangeMessage)
 
 	// public handlers
 	s.OnConnect(s.handleConnect)
@@ -144,10 +142,3 @@ func (s *Stream) generateSignature() (string, string) {
 
 	return signature, ts
 }
-<<<<<<< HEAD
-
-func (s *Stream) handleConnect() {
-	// TODO: dummy, will add connection logic later
-}
-=======
->>>>>>> 24b0cff7 (🔧 feat(coinbase): implement stream message handlers for various events and enhance connection logic)

--- a/pkg/exchange/coinbase/stream.go
+++ b/pkg/exchange/coinbase/stream.go
@@ -60,8 +60,18 @@ func NewStream(
 	s.SetDispatcher(s.dispatchEvent)
 	s.SetEndpointCreator(createEndpoint)
 
+	// private handlers
+	s.OnTickerMessage(s.handleTickerMessage)
+	s.OnMatchMessage(s.handleMatchMessage)
+	s.OnOrderbookSnapshotMessage(s.handleOrderBookSnapshotMessage)
+	s.OnOrderbookUpdateMessage(s.handleOrderbookUpdateMessage)
+	s.OnBalanceMessage(s.handleBalanceMessage)
+	s.OnReceivedMessage(s.handleReceivedMessage)
+	s.OnOpenMessage(s.handleOpenMessage)
+
 	// public handlers
 	s.OnConnect(s.handleConnect)
+	s.OnDisconnect(s.handleDisconnect)
 	return &s
 }
 
@@ -132,7 +142,10 @@ func (s *Stream) generateSignature() (string, string) {
 
 	return signature, ts
 }
+<<<<<<< HEAD
 
 func (s *Stream) handleConnect() {
 	// TODO: dummy, will add connection logic later
 }
+=======
+>>>>>>> 24b0cff7 (🔧 feat(coinbase): implement stream message handlers for various events and enhance connection logic)

--- a/pkg/exchange/coinbase/stream_handlers.go
+++ b/pkg/exchange/coinbase/stream_handlers.go
@@ -277,7 +277,7 @@ func (s *Stream) handleDoneMessage(msg *DoneMessage) {
 		return
 	}
 	isWorking := true
-	if msg.Reason == "cancelled" {
+	if msg.Reason == "canceled" {
 		isWorking = false
 	}
 	orderUpdate := types.Order{

--- a/pkg/exchange/coinbase/stream_handlers.go
+++ b/pkg/exchange/coinbase/stream_handlers.go
@@ -16,8 +16,7 @@ type channelType struct {
 }
 
 func (c channelType) String() string {
-	return fmt.Sprintf(`(Name:       %s,
-ProductIDs: %s)`, c.Name, c.ProductIDs)
+	return fmt.Sprintf("(channelType Name:%s, ProductIDs: %s)", c.Name, c.ProductIDs)
 }
 
 type authMsg struct {
@@ -28,10 +27,7 @@ type authMsg struct {
 }
 
 func (msg authMsg) String() string {
-	return fmt.Sprintf(`(Signature:  %s,
-Key:        ****,
-Passphrase: ****,
-Timestamp:  %s)`, msg.Signature, msg.Timestamp)
+	return fmt.Sprintf("(authMsg Signature:%s, Timestamp:%s)", msg.Signature, msg.Timestamp)
 }
 
 type subscribeMsgType1 struct {
@@ -42,9 +38,7 @@ type subscribeMsgType1 struct {
 }
 
 func (msg subscribeMsgType1) String() string {
-	return fmt.Sprintf(`(Type:     %s,
-Channels: %s,
-%s)`, msg.Type, msg.Channels, msg.authMsg.String())
+	return fmt.Sprintf("(subscribeMsg Type:%s, Channels: %s, %s)", msg.Type, msg.Channels, msg.authMsg.String())
 }
 
 type subscribeMsgType2 struct {
@@ -57,11 +51,14 @@ type subscribeMsgType2 struct {
 }
 
 func (msg subscribeMsgType2) String() string {
-	return fmt.Sprintf(`(Type:       %s,
-Channels:   %s,
-ProductIDs: %s,
-AccountIDs: %s,
-%s`, msg.Type, msg.Channels, msg.ProductIDs, msg.AccountIDs, msg.authMsg.String())
+	return fmt.Sprintf(
+		"(Type:%s, Channels:%s, ProductIDs:%s, AccountIDs:%s, %s",
+		msg.Type,
+		msg.Channels,
+		msg.ProductIDs,
+		msg.AccountIDs,
+		msg.authMsg.String(),
+	)
 }
 
 func (s *Stream) handleConnect() {
@@ -154,7 +151,7 @@ func (s *Stream) handleConnect() {
 		balances, err := s.exchange.QueryAccountBalances(ctx)
 		if err != nil {
 			log.WithError(err).Warn("failed to query account balances, the balance snapshot is initialized with empty balances")
-			return
+			balances = make(types.BalanceMap)
 		}
 		s.EmitBalanceSnapshot(balances)
 	}()

--- a/pkg/exchange/coinbase/stream_handlers.go
+++ b/pkg/exchange/coinbase/stream_handlers.go
@@ -2,6 +2,7 @@ package coinbase
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -14,11 +15,23 @@ type channelType struct {
 	ProductIDs []string `json:"product_ids,omitempty"`
 }
 
+func (c channelType) String() string {
+	return fmt.Sprintf(`(Name:       %s,
+ProductIDs: %s)`, c.Name, c.ProductIDs)
+}
+
 type authMsg struct {
 	Signature  string `json:"signature,omitempty"`
 	Key        string `json:"key,omitempty"`
 	Passphrase string `json:"passphrase,omitempty"`
 	Timestamp  string `json:"timestamp,omitempty"`
+}
+
+func (msg authMsg) String() string {
+	return fmt.Sprintf(`(Signature:  %s,
+Key:        ****,
+Passphrase: ****,
+Timestamp:  %s)`, msg.Signature, msg.Timestamp)
 }
 
 type subscribeMsgType1 struct {
@@ -28,6 +41,12 @@ type subscribeMsgType1 struct {
 	authMsg
 }
 
+func (msg subscribeMsgType1) String() string {
+	return fmt.Sprintf(`(Type:     %s,
+Channels: %s,
+%s)`, msg.Type, msg.Channels, msg.authMsg.String())
+}
+
 type subscribeMsgType2 struct {
 	Type       string   `json:"type"`
 	Channels   []string `json:"channels"`
@@ -35,6 +54,14 @@ type subscribeMsgType2 struct {
 	AccountIDs []string `json:"account_ids,omitempty"` // for balance channel
 
 	authMsg
+}
+
+func (msg subscribeMsgType2) String() string {
+	return fmt.Sprintf(`(Type:       %s,
+Channels:   %s,
+ProductIDs: %s,
+AccountIDs: %s,
+%s`, msg.Type, msg.Channels, msg.ProductIDs, msg.AccountIDs, msg.authMsg.String())
 }
 
 func (s *Stream) handleConnect() {
@@ -112,9 +139,9 @@ func (s *Stream) handleConnect() {
 	for _, subCmd := range subCmds {
 		err := s.Conn.WriteJSON(subCmd)
 		if err != nil {
-			log.WithError(err).Errorf("subscription error: %v", subCmd)
+			log.WithError(err).Errorf("subscription error: %s", subCmd)
 		} else {
-			log.Infof("subscribed to %v", subCmd)
+			log.Infof("subscribed to %s", subCmd)
 		}
 	}
 

--- a/pkg/exchange/coinbase/stream_handlers.go
+++ b/pkg/exchange/coinbase/stream_handlers.go
@@ -1,0 +1,298 @@
+package coinbase
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+type channelType struct {
+	Name       string   `json:"name"`
+	ProductIDs []string `json:"product_ids,omitempty"`
+}
+
+type authMsg struct {
+	Signature  string `json:"signature,omitempty"`
+	Key        string `json:"key,omitempty"`
+	Passphrase string `json:"passphrase,omitempty"`
+	Timestamp  string `json:"timestamp,omitempty"`
+}
+
+type subscribeMsgType1 struct {
+	Type     string        `json:"type"`
+	Channels []channelType `json:"channels"`
+
+	authMsg
+}
+
+type subscribeMsgType2 struct {
+	Type       string   `json:"type"`
+	Channels   []string `json:"channels"`
+	ProductIDs []string `json:"product_ids,omitempty"`
+	AccountIDs []string `json:"account_ids,omitempty"` // for balance channel
+
+	authMsg
+}
+
+func (s *Stream) handleConnect() {
+	// subscribe to channels
+	if len(s.Subscriptions) == 0 {
+		return
+	}
+
+	subProductsMap := make(map[string][]string)
+	for _, sub := range s.Subscriptions {
+		strChannel := string(sub.Channel)
+		// rfqMatchChannel allow empty symbol
+		if sub.Channel != rfqMatchChannel && len(sub.Symbol) == 0 {
+			continue
+		}
+		subProductsMap[strChannel] = append(subProductsMap[strChannel], sub.Symbol)
+	}
+	var subCmds []any
+	signature, ts := s.generateSignature()
+	for channel, productIDs := range subProductsMap {
+		var subType string
+		switch channel {
+		case "rfq_matches":
+			subType = "subscriptions"
+		default:
+			subType = "subscribe"
+		}
+		var subCmd any
+		switch channel {
+		case "ticker", "ticker_batch", "level2", "level2_batch":
+			subCmd = subscribeMsgType2{
+				Type:       subType,
+				Channels:   []string{channel},
+				ProductIDs: productIDs,
+				authMsg: authMsg{
+					Signature:  signature,
+					Key:        s.apiKey,
+					Passphrase: s.passphrase,
+					Timestamp:  ts,
+				},
+			}
+		case "balance":
+			subCmd = subscribeMsgType2{
+				Type:       subType,
+				Channels:   []string{channel},
+				AccountIDs: productIDs,
+
+				authMsg: authMsg{
+					Signature:  signature,
+					Key:        s.apiKey,
+					Passphrase: s.passphrase,
+					Timestamp:  ts,
+				},
+			}
+		default:
+			subCmd = subscribeMsgType1{
+				Type: subType,
+				Channels: []channelType{
+					{
+						Name:       channel,
+						ProductIDs: productIDs,
+					},
+				},
+
+				authMsg: authMsg{
+					Signature:  signature,
+					Key:        s.apiKey,
+					Passphrase: s.passphrase,
+					Timestamp:  ts,
+				},
+			}
+		}
+		subCmds = append(subCmds, subCmd)
+	}
+	for _, subCmd := range subCmds {
+		err := s.Conn.WriteJSON(subCmd)
+		if err != nil {
+			log.WithError(err).Errorf("subscription error: %v", subCmd)
+		} else {
+			log.Infof("subscribed to %v", subCmd)
+		}
+	}
+
+	// emit balance snapshot on connection
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+
+		// query account balances
+		balances, err := s.exchange.QueryAccountBalances(ctx)
+		if err != nil {
+			log.WithError(err).Warn("failed to query account balances, the balance snapshot is initialized with empty balances")
+			return
+		}
+		s.EmitBalanceSnapshot(balances)
+	}()
+}
+
+func (s *Stream) handleDisconnect() {
+	// clear sequence numbers
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.lastSequenceMsgMap = make(map[MessageType]SequenceNumberType)
+}
+
+// order book, trade
+func (s *Stream) handleTickerMessage(msg *TickerMessage) {
+	// ignore outdated messages
+	if !s.checkAndUpdateSequenceNumber(msg.Type, msg.Sequence) {
+		return
+	}
+	trade := msg.Trade()
+	s.EmitTradeUpdate(trade)
+}
+
+func (s *Stream) handleMatchMessage(msg *MatchMessage) {
+	// ignore outdated messages
+	if !s.checkAndUpdateSequenceNumber(msg.Type, msg.Sequence) {
+		return
+	}
+	trade := msg.Trade()
+	s.EmitTradeUpdate(trade)
+}
+
+func (s *Stream) handleOrderBookSnapshotMessage(msg *OrderBookSnapshotMessage) {
+	symbol := toGlobalSymbol(msg.ProductID)
+	var bids types.PriceVolumeSlice
+	for _, b := range msg.Bids {
+		if len(b) != 2 {
+			continue
+		}
+		bids = append(bids, types.PriceVolume{
+			Price:  b[0],
+			Volume: b[1],
+		})
+	}
+	var asks types.PriceVolumeSlice
+	for _, a := range msg.Asks {
+		if len(a) != 2 {
+			continue
+		}
+		asks = append(asks, types.PriceVolume{
+			Price:  a[0],
+			Volume: a[1],
+		})
+	}
+	book := types.SliceOrderBook{
+		Symbol: symbol,
+		Bids:   bids,
+		Asks:   asks,
+		Time:   time.Now(),
+	}
+	s.EmitBookSnapshot(book)
+}
+
+func (s *Stream) handleOrderbookUpdateMessage(msg *OrderBookUpdateMessage) {
+	var bids types.PriceVolumeSlice
+	var asks types.PriceVolumeSlice
+	for _, c := range msg.Changes {
+		if len(c) != 3 {
+			continue
+		}
+		side := c[0]
+		price := fixedpoint.MustNewFromString(c[1])
+		volume := fixedpoint.MustNewFromString(c[2])
+		if volume.IsZero() {
+			// 0 volume means the price can be removed.
+			continue
+		}
+		switch side {
+		case "buy":
+			bids = append(bids, types.PriceVolume{
+				Price:  price,
+				Volume: volume,
+			})
+		case "sell":
+			asks = append(asks, types.PriceVolume{
+				Price:  price,
+				Volume: volume,
+			})
+		default:
+			log.Warnf("unknown order book update side: %s", side)
+		}
+	}
+	if len(bids) > 0 || len(asks) > 0 {
+		book := types.SliceOrderBook{
+			Symbol: toGlobalSymbol(msg.ProductID),
+			Bids:   bids,
+			Asks:   asks,
+			Time:   msg.Time,
+		}
+		s.EmitBookUpdate(book)
+	}
+
+}
+
+// order update
+func (s *Stream) handleReceivedMessage(msg *ReceivedMessage) {
+	if !s.checkAndUpdateSequenceNumber(msg.Type, msg.Sequence) {
+		return
+	}
+
+	order := types.Order{
+		SubmitOrder: types.SubmitOrder{
+			Symbol:   toGlobalSymbol(msg.ProductID),
+			Side:     toGlobalSide(msg.Side),
+			Price:    msg.Price,
+			Quantity: msg.Size,
+			Type:     types.OrderType(strings.ToUpper(msg.OrderType)),
+		},
+		Exchange:   types.ExchangeCoinBase,
+		UpdateTime: types.Time(msg.Time),
+		IsWorking:  true,
+	}
+	s.EmitOrderUpdate(order)
+}
+
+func (s *Stream) handleOpenMessage(msg *OpenMessage) {
+	if !s.checkAndUpdateSequenceNumber(msg.Type, msg.Sequence) {
+		return
+	}
+	order := types.Order{
+		SubmitOrder: types.SubmitOrder{
+			Symbol:   toGlobalSymbol(msg.ProductID),
+			Side:     toGlobalSide(msg.Side),
+			Price:    msg.Price,
+			Quantity: msg.RemainingSize,
+		},
+		UUID:       msg.OrderID,
+		Exchange:   types.ExchangeCoinBase,
+		IsWorking:  true,
+		UpdateTime: types.Time(msg.Time),
+	}
+	s.EmitOrderUpdate(order)
+}
+
+// balance update
+func (s *Stream) handleBalanceMessage(msg *BalanceMessage) {
+	balanceUpdte := make(types.BalanceMap)
+	balanceUpdte[msg.Currency] = types.Balance{
+		Currency:  msg.Currency,
+		Available: msg.Available,
+		Locked:    msg.Holds,
+		NetAsset:  msg.Available.Add(msg.Holds),
+	}
+	s.EmitBalanceUpdate(balanceUpdte)
+}
+
+// helpers
+func (s *Stream) checkAndUpdateSequenceNumber(msgType MessageType, currentSeqNum SequenceNumberType) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	latestSeq := s.lastSequenceMsgMap[msgType]
+	if latestSeq >= currentSeqNum {
+		return false
+	}
+	s.lastSequenceMsgMap[msgType] = currentSeqNum
+	return true
+}

--- a/pkg/exchange/coinbase/stream_messages.go
+++ b/pkg/exchange/coinbase/stream_messages.go
@@ -213,7 +213,7 @@ type DoneMessage struct {
 	Price         fixedpoint.Value `json:"price"`
 	OrderID       string           `json:"order_id"`
 	Reason        string           `json:"reason"` // filled, canceled
-	Side          string           `json:"side"`
+	Side          api.SideType     `json:"side"`
 	RemainingSize fixedpoint.Value `json:"remaining_size"`
 	CancelReason  string           `json:"cancel_reason,omitempty"` // non-empty if reason is canceled
 }

--- a/pkg/exchange/coinbase/stream_test.go
+++ b/pkg/exchange/coinbase/stream_test.go
@@ -1,0 +1,47 @@
+package coinbase
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SubCmdString(t *testing.T) {
+	var subCmd interface{}
+	subCmd = subscribeMsgType1{
+		Type: "subscribe",
+		Channels: []channelType{
+			{
+				Name:       "ticker",
+				ProductIDs: []string{"BTC-USD"},
+			},
+		},
+		authMsg: authMsg{
+			Signature:  "signature",
+			Key:        "<secret_key!>",
+			Passphrase: "<secret_passphrase!>",
+			Timestamp:  "timestamp",
+		},
+	}
+	outStr := fmt.Sprintf("%s", subCmd)
+	assert.False(t, strings.Contains(outStr, "<secret_key!>"))
+	assert.False(t, strings.Contains(outStr, "<secret_passphrase!>"))
+
+	subCmd = subscribeMsgType2{
+		Type:       "subscribe",
+		Channels:   []string{},
+		ProductIDs: []string{},
+		AccountIDs: []string{},
+		authMsg: authMsg{
+			Signature:  "signature",
+			Key:        "<secret_key!>",
+			Passphrase: "<secret_passphrase!>",
+			Timestamp:  "timestamp",
+		},
+	}
+	outStr = fmt.Sprintf("%s", subCmd)
+	assert.False(t, strings.Contains(outStr, "<secret_key!>"))
+	assert.False(t, strings.Contains(outStr, "<secret_passphrase!>"))
+}

--- a/pkg/exchange/coinbase/stream_test.go
+++ b/pkg/exchange/coinbase/stream_test.go
@@ -17,6 +17,10 @@ func Test_SubCmdString(t *testing.T) {
 				Name:       "ticker",
 				ProductIDs: []string{"BTC-USD"},
 			},
+			{
+				Name:       "matches",
+				ProductIDs: []string{"BTC-USD"},
+			},
 		},
 		authMsg: authMsg{
 			Signature:  "signature",


### PR DESCRIPTION
In this PR:
1. Implement handlers to bridge Coinbase events to standard events
2. Modify on-connection handler: publish balance snapshot event on connection.