### PR TITLE
FIX: [coinbase] submit order logic

### DIFF
--- a/pkg/exchange/coinbase/api/v1/create_order_request.go
+++ b/pkg/exchange/coinbase/api/v1/create_order_request.go
@@ -42,20 +42,22 @@ type CreateOrderResponse struct {
 type CreateOrderRequest struct {
 	client requestgen.AuthenticatedAPIClient
 
-	profileID     *string           `param:"profile_id"`
-	orderType     string            `param:"type,required" validValues:"limit,market,stop"`
-	side          string            `param:"side,required" validValues:"buy,sell"`
-	productID     string            `param:"product_id,required"`
-	stp           *string           `param:"stp" validValues:"dc,co,cn,cb"`
-	stop          *string           `param:"stop" validValues:"loss,entry"`
-	stopPrice     *fixedpoint.Value `param:"stop_price"`
-	price         *fixedpoint.Value `param:"price"`
-	size          *fixedpoint.Value `param:"size"`
-	funds         *fixedpoint.Value `param:"funds"`
-	timeInForce   *string           `param:"time_in_force" validValues:"GTC,GCC,IOC,FOK"`
-	cancelAfter   *string           `param:"cancel_after" validValues:"min,hour,day"`
-	postOnly      *bool             `param:"post_only"`
-	clientOrderID *string           `param:"client_oid"`
+	profileID      *string           `param:"profile_id"`
+	orderType      string            `param:"type,required" validValues:"limit,market,stop"`
+	side           string            `param:"side,required" validValues:"buy,sell"`
+	productID      string            `param:"product_id,required"`
+	stp            *string           `param:"stp" validValues:"dc,co,cn,cb"`
+	stop           *string           `param:"stop" validValues:"loss,entry"`
+	stopPrice      *fixedpoint.Value `param:"stop_price"`
+	price          *fixedpoint.Value `param:"price"`
+	size           *fixedpoint.Value `param:"size"`
+	funds          *fixedpoint.Value `param:"funds"`
+	timeInForce    *string           `param:"time_in_force" validValues:"GTC,GCC,IOC,FOK"`
+	cancelAfter    *string           `param:"cancel_after" validValues:"min,hour,day"`
+	postOnly       *bool             `param:"post_only"`
+	clientOrderID  *string           `param:"client_oid"`
+	maxFloor       *string           `param:"max_floor"`
+	stopLimitPrice *fixedpoint.Value `param:"stop_limit_price"`
 }
 
 func (client *RestAPIClient) NewCreateOrderRequest() *CreateOrderRequest {

--- a/pkg/exchange/coinbase/api/v1/create_order_request.go
+++ b/pkg/exchange/coinbase/api/v1/create_order_request.go
@@ -50,7 +50,7 @@ type CreateOrderRequest struct {
 	stop          *string           `param:"stop" validValues:"loss,entry"`
 	stopPrice     *fixedpoint.Value `param:"stop_price"`
 	price         *fixedpoint.Value `param:"price"`
-	size          string            `param:"size,required"` // don't use fixedpoint.Value because it's required and it will lead to an error in requestgen.
+	size          *fixedpoint.Value `param:"size"`
 	funds         *fixedpoint.Value `param:"funds"`
 	timeInForce   *string           `param:"time_in_force" validValues:"GTC,GCC,IOC,FOK"`
 	cancelAfter   *string           `param:"cancel_after" validValues:"min,hour,day"`

--- a/pkg/exchange/coinbase/api/v1/create_order_request_requestgen.go
+++ b/pkg/exchange/coinbase/api/v1/create_order_request_requestgen.go
@@ -82,6 +82,16 @@ func (c *CreateOrderRequest) ClientOrderID(clientOrderID string) *CreateOrderReq
 	return c
 }
 
+func (c *CreateOrderRequest) MaxFloor(maxFloor string) *CreateOrderRequest {
+	c.maxFloor = &maxFloor
+	return c
+}
+
+func (c *CreateOrderRequest) StopLimitPrice(stopLimitPrice fixedpoint.Value) *CreateOrderRequest {
+	c.stopLimitPrice = &stopLimitPrice
+	return c
+}
+
 // GetQueryParameters builds and checks the query parameters and returns url.Values
 func (c *CreateOrderRequest) GetQueryParameters() (url.Values, error) {
 	var params = map[string]interface{}{}
@@ -282,6 +292,22 @@ func (c *CreateOrderRequest) GetParameters() (map[string]interface{}, error) {
 
 		// assign parameter of clientOrderID
 		params["client_oid"] = clientOrderID
+	} else {
+	}
+	// check maxFloor field -> json key max_floor
+	if c.maxFloor != nil {
+		maxFloor := *c.maxFloor
+
+		// assign parameter of maxFloor
+		params["max_floor"] = maxFloor
+	} else {
+	}
+	// check stopLimitPrice field -> json key stop_limit_price
+	if c.stopLimitPrice != nil {
+		stopLimitPrice := *c.stopLimitPrice
+
+		// assign parameter of stopLimitPrice
+		params["stop_limit_price"] = stopLimitPrice
 	} else {
 	}
 

--- a/pkg/exchange/coinbase/api/v1/create_order_request_requestgen.go
+++ b/pkg/exchange/coinbase/api/v1/create_order_request_requestgen.go
@@ -52,8 +52,8 @@ func (c *CreateOrderRequest) Price(price fixedpoint.Value) *CreateOrderRequest {
 	return c
 }
 
-func (c *CreateOrderRequest) Size(size string) *CreateOrderRequest {
-	c.size = size
+func (c *CreateOrderRequest) Size(size fixedpoint.Value) *CreateOrderRequest {
+	c.size = &size
 	return c
 }
 
@@ -215,16 +215,13 @@ func (c *CreateOrderRequest) GetParameters() (map[string]interface{}, error) {
 	} else {
 	}
 	// check size field -> json key size
-	size := c.size
+	if c.size != nil {
+		size := *c.size
 
-	// TEMPLATE check-required
-	if len(size) == 0 {
-		return nil, fmt.Errorf("size is required, empty string given")
+		// assign parameter of size
+		params["size"] = size
+	} else {
 	}
-	// END TEMPLATE check-required
-
-	// assign parameter of size
-	params["size"] = size
 	// check funds field -> json key funds
 	if c.funds != nil {
 		funds := *c.funds

--- a/pkg/exchange/coinbase/exchage.go
+++ b/pkg/exchange/coinbase/exchage.go
@@ -167,7 +167,12 @@ func (e *Exchange) SubmitOrder(ctx context.Context, order types.SubmitOrder) (cr
 	case types.OrderTypeMarket:
 		switch order.Side {
 		case types.SideTypeBuy:
-			funds := order.Price.Mul(order.Quantity)
+			// buy with market price
+			ticker, err := e.QueryTicker(ctx, order.Market.Symbol)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to get ticker for market order: %v", order.Market.Symbol)
+			}
+			funds := ticker.Buy.Mul(order.Quantity)
 			req.Funds(funds)
 		case types.SideTypeSell:
 			req.Size(order.Quantity)

--- a/pkg/exchange/coinbase/exchage.go
+++ b/pkg/exchange/coinbase/exchage.go
@@ -177,6 +177,7 @@ func (e *Exchange) SubmitOrder(ctx context.Context, order types.SubmitOrder) (cr
 	case types.OrderTypeStopLimit:
 		req.StopPrice(order.StopPrice)
 		req.Price(order.Price)
+		req.StopLimitPrice(order.Price)
 		req.Size(order.Quantity)
 	default:
 		return nil, fmt.Errorf("unsupported order type: %v", order.Type)


### PR DESCRIPTION
- bug fix
    - `size` is not required for all order
    - use `price * quantity` as `funds`, which is required parameter for market order on Coinbase Exchange.
    - update stop-limit order logic: using stop order on Coinbase Exchange. 
        - as a result, we only support long position on stop-limit order.