### PR TITLE
FIX: [coinbase] fix stream handlers and order placing logics

### DIFF
--- a/pkg/exchange/coinbase/api/v1/constants.go
+++ b/pkg/exchange/coinbase/api/v1/constants.go
@@ -34,13 +34,13 @@ const (
 type OrderStatus string
 
 const (
-	OrderStatusOpen     OrderStatus = "open"
+	OrderStatusReceived OrderStatus = "received"
 	OrderStatusPending  OrderStatus = "pending"
+	OrderStatusOpen     OrderStatus = "open"
 	OrderStatusRejected OrderStatus = "rejected"
 	OrderStatusDone     OrderStatus = "done"
-	OrderStatusActive   OrderStatus = "active"
-	OrderStatusReceived OrderStatus = "received"
-	OrderStatusAll      OrderStatus = "all"
+	OrderStatusActive   OrderStatus = "active" // query only status
+	OrderStatusAll      OrderStatus = "all"    // query only status
 )
 
 type OrderType string

--- a/pkg/exchange/coinbase/api/v1/get_orders_request.go
+++ b/pkg/exchange/coinbase/api/v1/get_orders_request.go
@@ -1,23 +1,12 @@
 package coinbase
 
 import (
-	"strings"
 	"time"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
 	"github.com/c9s/requestgen"
 )
-
-func (s *OrderStatus) GlobalOrderStatus() types.OrderStatus {
-	switch *s {
-	case OrderStatusRejected:
-		return types.OrderStatusRejected
-	case OrderStatusOpen, OrderStatusPending, OrderStatusDone, OrderStatusActive, OrderStatusReceived, OrderStatusAll:
-		return types.OrderStatus(strings.ToUpper(string(*s)))
-	}
-	return types.OrderStatus(strings.ToUpper(string(*s)))
-}
 
 type Order struct {
 	Type      string           `json:"type"`

--- a/pkg/exchange/coinbase/convert.go
+++ b/pkg/exchange/coinbase/convert.go
@@ -3,6 +3,7 @@ package coinbase
 import (
 	"hash/fnv"
 	"math"
+	"strings"
 	"time"
 
 	api "github.com/c9s/bbgo/pkg/exchange/coinbase/api/v1"
@@ -18,6 +19,25 @@ func toGlobalSide(cbSide api.SideType) types.SideType {
 		return types.SideTypeSell
 	}
 	return types.SideTypeNone
+}
+
+func toGlobalOrderStatus(order *api.Order) types.OrderStatus {
+	switch order.Status {
+	case api.OrderStatusRejected:
+		return types.OrderStatusRejected
+	case api.OrderStatusReceived, api.OrderStatusOpen, api.OrderStatusPending:
+		return types.OrderStatusNew
+	case api.OrderStatusDone:
+		switch order.DoneReason {
+		case "filled":
+			return types.OrderStatusFilled
+		case "canceled":
+			return types.OrderStatusCanceled
+		case "rejected":
+			return types.OrderStatusRejected
+		}
+	}
+	return types.OrderStatus(strings.ToUpper(string(order.Status)))
 }
 
 func toGlobalOrder(cbOrder *api.Order) types.Order {
@@ -44,7 +64,7 @@ func toGlobalOrder(cbOrder *api.Order) types.Order {
 			TimeInForce:   types.TimeInForce(cbOrder.TimeInForce),
 		},
 		Exchange:       types.ExchangeCoinBase,
-		Status:         cbOrder.Status.GlobalOrderStatus(),
+		Status:         toGlobalOrderStatus(cbOrder),
 		UUID:           cbOrder.ID,
 		OrderID:        FNV64a(cbOrder.ID),
 		OriginalStatus: string(cbOrder.Status),

--- a/pkg/exchange/coinbase/parse.go
+++ b/pkg/exchange/coinbase/parse.go
@@ -85,7 +85,7 @@ func parseMessage(data []byte) (interface{}, error) {
 		}
 		return &changeMsg, nil
 	case "active":
-		var activeMsg ActiveMessage
+		var activeMsg ActivateMessage
 		err = json.Unmarshal(data, &activeMsg)
 		if err != nil {
 			return nil, err

--- a/pkg/exchange/coinbase/parse_test.go
+++ b/pkg/exchange/coinbase/parse_test.go
@@ -384,7 +384,7 @@ func Test_ParseActive(t *testing.T) {
 `)
 	msg, err := parseMessage(data)
 	assert.NoError(t, err)
-	assert.IsType(t, &ActiveMessage{}, msg)
+	assert.IsType(t, &ActivateMessage{}, msg)
 }
 
 func Test_ParseBalance(t *testing.T) {

--- a/pkg/exchange/coinbase/stream.go
+++ b/pkg/exchange/coinbase/stream.go
@@ -34,7 +34,7 @@ type Stream struct {
 	doneMessageCallbacks              []func(m *DoneMessage)
 	matchMessageCallbacks             []func(m *MatchMessage)
 	changeMessageCallbacks            []func(m *ChangeMessage)
-	activeMessageCallbacks            []func(m *ActiveMessage)
+	activateMessageCallbacks          []func(m *ActivateMessage)
 	balanceMessageCallbacks           []func(m *BalanceMessage)
 	orderbookSnapshotMessageCallbacks []func(m *OrderBookSnapshotMessage)
 	orderbookUpdateMessageCallbacks   []func(m *OrderBookUpdateMessage)
@@ -95,8 +95,8 @@ func (s *Stream) dispatchEvent(e interface{}) {
 		s.EmitMatchMessage(e)
 	case *ChangeMessage:
 		s.EmitChangeMessage(e)
-	case *ActiveMessage:
-		s.EmitActiveMessage(e)
+	case *ActivateMessage:
+		s.EmitActivateMessage(e)
 	case *BalanceMessage:
 		s.EmitBalanceMessage(e)
 	case *OrderBookSnapshotMessage:

--- a/pkg/exchange/coinbase/stream_callbacks.go
+++ b/pkg/exchange/coinbase/stream_callbacks.go
@@ -94,12 +94,12 @@ func (s *Stream) EmitChangeMessage(m *ChangeMessage) {
 	}
 }
 
-func (s *Stream) OnActiveMessage(cb func(m *ActiveMessage)) {
-	s.activeMessageCallbacks = append(s.activeMessageCallbacks, cb)
+func (s *Stream) OnActivateMessage(cb func(m *ActivateMessage)) {
+	s.activateMessageCallbacks = append(s.activateMessageCallbacks, cb)
 }
 
-func (s *Stream) EmitActiveMessage(m *ActiveMessage) {
-	for _, cb := range s.activeMessageCallbacks {
+func (s *Stream) EmitActivateMessage(m *ActivateMessage) {
+	for _, cb := range s.activateMessageCallbacks {
 		cb(m)
 	}
 }

--- a/pkg/exchange/coinbase/stream_messages.go
+++ b/pkg/exchange/coinbase/stream_messages.go
@@ -319,7 +319,7 @@ func (m *ChangeMessage) IsModifyOrder() bool {
 	return m.Reason == "modify_order"
 }
 
-type ActiveMessage struct {
+type ActivateMessage struct {
 	messageBaseType
 
 	ProductID string           `json:"product_id"`


### PR DESCRIPTION
The purpose of this PR is to:
1. minor refactoring, moving type conversion logics from api modules to application module
2. renaming `ActiveMessage` as `ActivateMessage` to be aligned with Coinbase documentation.

These are preliminary works for the upcoming PR #1928.