### PR TITLE
FIX: [coinbase] refactoring and fix order-related streaming event handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,13 @@
 {
     "go.testEnvFile": "${workspaceFolder}/.env.local",
+    "go.testFlags": [
+        "-race",
+        "-count",
+        "3",
+        "-coverprofile",
+        "${workspaceFolder}/coverage.out",
+        "-covermode",
+        "atomic"
+    ],
+    "go.testTimeout": "10m"
 }

--- a/pkg/exchange/coinbase/exchage.go
+++ b/pkg/exchange/coinbase/exchage.go
@@ -125,9 +125,14 @@ func (e *Exchange) QueryAccountBalances(ctx context.Context) (types.BalanceMap, 
 
 // ExchangeTradeService
 // For the stop-limit order, we only support the long position
+// For the market order, though Coinbase supports both funds and size, we only support size in order to simplify the stream handler logic
+// We do not support limit order with funds.
 func (e *Exchange) SubmitOrder(ctx context.Context, order types.SubmitOrder) (createdOrder *types.Order, err error) {
 	if len(order.Market.Symbol) == 0 {
 		return nil, fmt.Errorf("order.Market.Symbol is required: %+v", order)
+	}
+	if order.Quantity.IsZero() {
+		return nil, fmt.Errorf("order.Quantity is required: %+v", order)
 	}
 	req := e.client.NewCreateOrderRequest().ProductID(toLocalSymbol(order.Market.Symbol))
 
@@ -162,28 +167,21 @@ func (e *Exchange) SubmitOrder(ctx context.Context, order types.SubmitOrder) (cr
 	// set price and quanity
 	switch order.Type {
 	case types.OrderTypeLimit:
-		req.Price(order.Price)
+		if order.Price.IsZero() || order.Quantity.IsZero() {
+			return nil, fmt.Errorf("order.Price and order.Quantity are required for limit order: %+v", order)
+		}
 		req.Size(order.Quantity)
+		req.Price(order.Price)
 	case types.OrderTypeMarket:
-		switch order.Side {
-		case types.SideTypeBuy:
-			// buy with market price
-			ticker, err := e.QueryTicker(ctx, order.Market.Symbol)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get ticker for market order: %v", order.Market.Symbol)
-			}
-			funds := ticker.Buy.Mul(order.Quantity)
-			req.Funds(funds)
-		case types.SideTypeSell:
-			req.Size(order.Quantity)
-		default:
-			return nil, fmt.Errorf("unsupported side for market order: %v", order.Side)
+		req.Size(order.Quantity)
+		if !order.Price.IsZero() {
+			log.Warning("the price is ignored for market order")
 		}
 	case types.OrderTypeStopLimit:
+		req.Size(order.Quantity)
 		req.StopPrice(order.StopPrice)
 		req.Price(order.Price)
 		req.StopLimitPrice(order.Price)
-		req.Size(order.Quantity)
 	default:
 		return nil, fmt.Errorf("unsupported order type: %v", order.Type)
 	}
@@ -246,7 +244,11 @@ func (e *Exchange) queryOrdersByPagination(ctx context.Context, symbol string, s
 	sorting := "desc"
 	localSymbol := toLocalSymbol(symbol)
 	getOrdersReq := e.client.NewGetOrdersRequest()
-	getOrdersReq.ProductID(localSymbol).Status(status).SortedBy(sortedBy).Sorting(sorting).Limit(PaginationLimit)
+	getOrdersReq.Status(status).SortedBy(sortedBy).Sorting(sorting).Limit(PaginationLimit)
+	// query all orders if symbol is empty
+	if len(localSymbol) > 0 {
+		getOrdersReq.ProductID(localSymbol)
+	}
 	cbOrders, err := getOrdersReq.Do(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get orders")

--- a/pkg/exchange/coinbase/exchage.go
+++ b/pkg/exchange/coinbase/exchage.go
@@ -1,5 +1,7 @@
 package coinbase
 
+// TODO: support "funds" for submitting orders
+
 import (
 	"context"
 	"fmt"

--- a/pkg/exchange/coinbase/parse.go
+++ b/pkg/exchange/coinbase/parse.go
@@ -14,6 +14,13 @@ func parseMessage(data []byte) (interface{}, error) {
 	}
 
 	switch baseMsg.Type {
+	case "subscriptions":
+		var subMsg SubscriptionsMessage
+		err = json.Unmarshal(data, &subMsg)
+		if err != nil {
+			return nil, err
+		}
+		return &subMsg, nil
 	case "heartbeat":
 		var heartbeatMsg HeartbeatMessage
 		err = json.Unmarshal(data, &heartbeatMsg)

--- a/pkg/exchange/coinbase/parse.go
+++ b/pkg/exchange/coinbase/parse.go
@@ -14,6 +14,13 @@ func parseMessage(data []byte) (interface{}, error) {
 	}
 
 	switch baseMsg.Type {
+	case "error":
+		var errMsg ErrorMessage
+		err = json.Unmarshal(data, &errMsg)
+		if err != nil {
+			return nil, err
+		}
+		return &errMsg, nil
 	case "subscriptions":
 		var subMsg SubscriptionsMessage
 		err = json.Unmarshal(data, &subMsg)

--- a/pkg/exchange/coinbase/parse.go
+++ b/pkg/exchange/coinbase/parse.go
@@ -91,7 +91,7 @@ func parseMessage(data []byte) (interface{}, error) {
 			return nil, err
 		}
 		return &changeMsg, nil
-	case "active":
+	case "activate":
 		var activeMsg ActivateMessage
 		err = json.Unmarshal(data, &activeMsg)
 		if err != nil {

--- a/pkg/exchange/coinbase/parse_test.go
+++ b/pkg/exchange/coinbase/parse_test.go
@@ -6,6 +6,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_ParseInvalidMessage(t *testing.T) {
+	data := []byte(`{"type": "invalid_type"}`)
+	msg, err := parseMessage(data)
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+
+	data = []byte(`{}`)
+	msg, err = parseMessage(data)
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+
+	data = []byte(`{ // broken json`)
+	msg, err = parseMessage(data)
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+}
+
 func Test_ParseHeartbeat(t *testing.T) {
 	data := []byte(`
 {

--- a/pkg/exchange/coinbase/parse_test.go
+++ b/pkg/exchange/coinbase/parse_test.go
@@ -387,10 +387,10 @@ func Test_ParseChange(t *testing.T) {
 	assert.True(t, changeMsg.IsModifyOrder())
 }
 
-func Test_ParseActive(t *testing.T) {
+func Test_ParseActivate(t *testing.T) {
 	data := []byte(`
 {
-  "type": "active",
+  "type": "activate",
   "time": "2014-11-07T08:19:27.028459Z",
   "product_id": "BTC-USD",
   "sequence": 10,

--- a/pkg/exchange/coinbase/stream.go
+++ b/pkg/exchange/coinbase/stream.go
@@ -41,6 +41,7 @@ type Stream struct {
 	orderbookSnapshotMessageCallbacks []func(m *OrderBookSnapshotMessage)
 	orderbookUpdateMessageCallbacks   []func(m *OrderBookUpdateMessage)
 
+	authEnabled        bool
 	lockSeqNumMap      sync.Mutex // lock to protect lastSequenceMsgMap
 	lastSequenceMsgMap map[string]SequenceNumberType
 
@@ -60,6 +61,7 @@ func NewStream(
 		apiKey:         apiKey,
 		passphrase:     passphrase,
 		secretKey:      secretKey,
+		authEnabled:    len(apiKey) > 0 && len(passphrase) > 0 && len(secretKey) > 0,
 	}
 	s.SetParser(parseMessage)
 	s.SetDispatcher(s.dispatchEvent)
@@ -77,7 +79,7 @@ func NewStream(
 	s.OnOpenMessage(s.handleOpenMessage)
 	s.OnDoneMessage(s.handleDoneMessage)
 	s.OnChangeMessage(s.handleChangeMessage)
-	s.OnActivateMessage(s.handleActiveMessage)
+	s.OnActivateMessage(s.handleActivateMessage)
 
 	// public handlers
 	s.OnConnect(s.handleConnect)

--- a/pkg/exchange/coinbase/stream.go
+++ b/pkg/exchange/coinbase/stream.go
@@ -43,7 +43,7 @@ type Stream struct {
 	orderbookUpdateMessageCallbacks   []func(m *OrderBookUpdateMessage)
 
 	lockSeqNumMap      sync.Mutex // lock to protect lastSequenceMsgMap
-	lastSequenceMsgMap map[MessageType]SequenceNumberType
+	lastSequenceMsgMap map[string]SequenceNumberType
 
 	lockWorkingOrderMap sync.Mutex // lock to protect lastOrderMap
 	workingOrdersMap    map[string]types.Order

--- a/pkg/exchange/coinbase/stream.go
+++ b/pkg/exchange/coinbase/stream.go
@@ -15,7 +15,6 @@ import (
 
 // https://docs.cdp.coinbase.com/exchange/docs/websocket-overview
 const wsFeedUrl = "wss://ws-feed.exchange.coinbase.com" // ws feeds available without auth
-const rfqMatchChannel = "rfq_matches"
 
 //go:generate callbackgen -type Stream
 type Stream struct {

--- a/pkg/exchange/coinbase/stream.go
+++ b/pkg/exchange/coinbase/stream.go
@@ -77,6 +77,7 @@ func NewStream(
 	s.SetHeartBeat(ping)
 
 	// private handlers
+	s.OnErrorMessage(logErrorMessage)
 	s.OnSubscriptions(logSubscriptions)
 	s.OnTickerMessage(s.handleTickerMessage)
 	s.OnMatchMessage(s.handleMatchMessage)
@@ -102,6 +103,13 @@ func logSubscriptions(m *SubscriptionsMessage) {
 	for _, channel := range m.Channels {
 		logStream.Infof("Confirmed subscription to channel: %s (product ids: %s)", channel.Name, channel.ProductIDs)
 	}
+}
+
+func logErrorMessage(m *ErrorMessage) {
+	if m == nil {
+		return
+	}
+	logStream.Errorf("Get error message: %s", m.Reason)
 }
 
 func (s *Stream) dispatchEvent(e interface{}) {

--- a/pkg/exchange/coinbase/stream_callbacks.go
+++ b/pkg/exchange/coinbase/stream_callbacks.go
@@ -4,6 +4,16 @@ package coinbase
 
 import ()
 
+func (s *Stream) OnSubscriptions(cb func(m *SubscriptionsMessage)) {
+	s.subscriptionsCallbacks = append(s.subscriptionsCallbacks, cb)
+}
+
+func (s *Stream) EmitSubscriptions(m *SubscriptionsMessage) {
+	for _, cb := range s.subscriptionsCallbacks {
+		cb(m)
+	}
+}
+
 func (s *Stream) OnStatusMessage(cb func(m *StatusMessage)) {
 	s.statusMessageCallbacks = append(s.statusMessageCallbacks, cb)
 }

--- a/pkg/exchange/coinbase/stream_callbacks.go
+++ b/pkg/exchange/coinbase/stream_callbacks.go
@@ -4,6 +4,16 @@ package coinbase
 
 import ()
 
+func (s *Stream) OnErrorMessage(cb func(m *ErrorMessage)) {
+	s.errorMessageCallbacks = append(s.errorMessageCallbacks, cb)
+}
+
+func (s *Stream) EmitErrorMessage(m *ErrorMessage) {
+	for _, cb := range s.errorMessageCallbacks {
+		cb(m)
+	}
+}
+
 func (s *Stream) OnSubscriptions(cb func(m *SubscriptionsMessage)) {
 	s.subscriptionsCallbacks = append(s.subscriptionsCallbacks, cb)
 }

--- a/pkg/exchange/coinbase/stream_handlers.go
+++ b/pkg/exchange/coinbase/stream_handlers.go
@@ -10,9 +10,24 @@ import (
 	"github.com/c9s/bbgo/pkg/types"
 )
 
+type ChannelName = string
+
+const (
+	rfqMatchChannel    ChannelName = "rfq_matches"
+	statusChannel      ChannelName = "status"
+	auctionChannel     ChannelName = "auctionfeed"
+	matchesChannel     ChannelName = "matches"
+	tickerChannel      ChannelName = "ticker"
+	tickerBatchChannel ChannelName = "ticker_batch"
+	level2Channel      ChannelName = "level2"
+	level2BatchChannel ChannelName = "level2_batch"
+	fullChannel        ChannelName = "full"
+	balanceChannel     ChannelName = "balance"
+)
+
 type channelType struct {
-	Name       string   `json:"name"`
-	ProductIDs []string `json:"product_ids,omitempty"`
+	Name       ChannelName `json:"name"`
+	ProductIDs []string    `json:"product_ids,omitempty"`
 }
 
 func (c channelType) String() string {
@@ -71,7 +86,7 @@ func (s *Stream) handleConnect() {
 	for _, sub := range s.Subscriptions {
 		strChannel := string(sub.Channel)
 		// rfqMatchChannel allow empty symbol
-		if sub.Channel != rfqMatchChannel && sub.Channel != "status" && len(sub.Symbol) == 0 {
+		if strChannel != rfqMatchChannel && strChannel != "status" && len(sub.Symbol) == 0 {
 			continue
 		}
 		subProductsMap[strChannel] = append(subProductsMap[strChannel], sub.Symbol)
@@ -88,7 +103,7 @@ func (s *Stream) handleConnect() {
 		}
 		var subCmd any
 		switch channel {
-		case "status":
+		case statusChannel:
 			subCmd = subscribeMsgType1{
 				Type: subType,
 				Channels: []channelType{
@@ -97,7 +112,7 @@ func (s *Stream) handleConnect() {
 					},
 				},
 			}
-		case "auctionfeed", "matches", rfqMatchChannel:
+		case auctionChannel, matchesChannel, rfqMatchChannel:
 			subCmd = subscribeMsgType1{
 				Type: subType,
 				Channels: []channelType{
@@ -107,13 +122,13 @@ func (s *Stream) handleConnect() {
 					},
 				},
 			}
-		case "ticker", "ticker_batch":
+		case tickerChannel, tickerBatchChannel:
 			subCmd = subscribeMsgType2{
 				Type:       subType,
 				Channels:   []string{channel},
 				ProductIDs: productIDs,
 			}
-		case "full":
+		case fullChannel:
 			subCmd = subscribeMsgType2{
 				Type:       subType,
 				Channels:   []string{channel},
@@ -125,7 +140,7 @@ func (s *Stream) handleConnect() {
 					Timestamp:  ts,
 				},
 			}
-		case "level2", "level2_batch":
+		case level2Channel, level2BatchChannel:
 			subCmd = subscribeMsgType2{
 				Type:       subType,
 				Channels:   []string{channel},
@@ -138,7 +153,7 @@ func (s *Stream) handleConnect() {
 					Timestamp:  ts,
 				},
 			}
-		case "balance":
+		case balanceChannel:
 			subCmd = subscribeMsgType2{
 				Type:       subType,
 				Channels:   []string{channel},

--- a/pkg/exchange/coinbase/stream_handlers.go
+++ b/pkg/exchange/coinbase/stream_handlers.go
@@ -251,9 +251,6 @@ func (s *Stream) handleConnect() {
 }
 
 func (s *Stream) handleDisconnect() {
-	s.lockWorkingOrderMap.Lock()
-	defer s.lockWorkingOrderMap.Unlock()
-
 	// clear sequence numbers
 	s.clearSequenceNumber()
 	s.clearWorkingOrders()

--- a/pkg/exchange/coinbase/stream_handlers.go
+++ b/pkg/exchange/coinbase/stream_handlers.go
@@ -325,7 +325,7 @@ func (s *Stream) handleReceivedMessage(msg *ReceivedMessage) {
 			Symbol: toGlobalSymbol(msg.ProductID),
 			Side:   toGlobalSide(msg.Side),
 		},
-		Status:     types.OrderStatusReceived,
+		Status:     types.OrderStatusNew,
 		UUID:       msg.OrderID,
 		Exchange:   types.ExchangeCoinBase,
 		UpdateTime: types.Time(msg.Time),

--- a/pkg/exchange/coinbase/stream_messages.go
+++ b/pkg/exchange/coinbase/stream_messages.go
@@ -35,6 +35,12 @@ func (s *seqenceMessageType) QuoteCurrency() string {
 }
 
 // Websocket message types
+type SubscriptionsMessage struct {
+	messageBaseType
+
+	Channels []channelType `json:"channels"`
+}
+
 // heartbeat channel
 type HeartbeatMessage struct {
 	seqenceMessageType

--- a/pkg/exchange/coinbase/stream_messages.go
+++ b/pkg/exchange/coinbase/stream_messages.go
@@ -41,6 +41,12 @@ type SubscriptionsMessage struct {
 	Channels []channelType `json:"channels"`
 }
 
+type ErrorMessage struct {
+	messageBaseType
+
+	Reason string `json:"reason"`
+}
+
 // heartbeat channel
 type HeartbeatMessage struct {
 	seqenceMessageType

--- a/pkg/exchange/coinbase/stream_test.go
+++ b/pkg/exchange/coinbase/stream_test.go
@@ -214,7 +214,7 @@ func TestBalance(t *testing.T) {
 	accountsStr := os.Getenv("COINBASE_ACCOUNT_IDS")
 	accounts := strings.Split(accountsStr, ",")
 
-	c := make(chan bool)
+	c := make(chan struct{})
 
 	t.Run("Run Balance", func(t *testing.T) {
 		stream := getTestStreamOrSkip(t)
@@ -229,7 +229,7 @@ func TestBalance(t *testing.T) {
 			triggered = true
 			assert.NotNil(t, m)
 			t.Logf("get balance message: %v", *m)
-			c <- true
+			c <- struct{}{}
 		})
 		err := stream.Connect(context.Background())
 		assert.NoError(t, err)

--- a/pkg/exchange/coinbase/stream_test.go
+++ b/pkg/exchange/coinbase/stream_test.go
@@ -70,7 +70,7 @@ func TestStreamBasic(t *testing.T) {
 			}
 			triggered = true
 			assert.NotNil(t, m)
-			t.Log("get status message")
+			// t.Log("get status message")
 			c <- *m
 		})
 		err := stream.Connect(context.Background())
@@ -91,7 +91,7 @@ func TestStreamBasic(t *testing.T) {
 			}
 			triggered = true
 			assert.NotNil(t, m)
-			t.Logf("get ticker message: %v", *m)
+			// t.Logf("get ticker message: %v", *m)
 			c <- *m
 		})
 		err := stream.Connect(context.Background())
@@ -112,7 +112,7 @@ func TestStreamBasic(t *testing.T) {
 			}
 			triggered = true
 			assert.NotNil(t, m)
-			t.Logf("get match message: %v", *m)
+			// t.Logf("get match message: %v", *m)
 			c <- *m
 		})
 		err := stream.Connect(context.Background())
@@ -136,32 +136,32 @@ func TestStreamFull(t *testing.T) {
 		// TODO: test full order life cycle
 		// received -> open -> change* -> match? -> done
 		stream.OnReceivedMessage(func(m *ReceivedMessage) {
-			t.Log("get received message")
+			// t.Log("get received message")
 			assert.NotNil(t, m)
 			c <- true
 		})
 		stream.OnOpenMessage(func(m *OpenMessage) {
-			t.Log("get open message")
+			// t.Log("get open message")
 			assert.NotNil(t, m)
 			c <- true
 		})
 		stream.OnDoneMessage(func(m *DoneMessage) {
-			t.Log("get done message")
+			// t.Log("get done message")
 			assert.NotNil(t, m)
 			c <- true
 		})
 		stream.OnMatchMessage(func(m *MatchMessage) {
-			t.Log("get match message")
+			// t.Log("get match message")
 			assert.NotNil(t, m)
 			c <- true
 		})
 		stream.OnChangeMessage(func(m *ChangeMessage) {
-			t.Log("get change message")
+			// t.Log("get change message")
 			assert.NotNil(t, m)
 			c <- true
 		})
 		stream.OnActivateMessage(func(m *ActivateMessage) {
-			t.Log("get activate message")
+			// t.Log("get activate message")
 			assert.NotNil(t, m)
 			c <- true
 		})
@@ -183,12 +183,12 @@ func TestLevel2(t *testing.T) {
 			stream.Subscribe("level2", productID, types.SubscribeOptions{})
 		}
 		stream.OnOrderbookSnapshotMessage(func(m *OrderBookSnapshotMessage) {
-			t.Log("get orderbook snapshot message")
+			// t.Log("get orderbook snapshot message")
 			assert.NotNil(t, m)
 			c <- "snapshot"
 		})
 		stream.OnOrderbookUpdateMessage(func(m *OrderBookUpdateMessage) {
-			t.Log("get orderbook update message")
+			// t.Log("get orderbook update message")
 			assert.NotNil(t, m)
 			c <- "update"
 		})
@@ -228,7 +228,7 @@ func TestBalance(t *testing.T) {
 			}
 			triggered = true
 			assert.NotNil(t, m)
-			t.Logf("get balance message: %v", *m)
+			// t.Logf("get balance message: %v", *m)
 			c <- struct{}{}
 		})
 		err := stream.Connect(context.Background())

--- a/pkg/exchange/coinbase/stream_test.go
+++ b/pkg/exchange/coinbase/stream_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/c9s/bbgo/pkg/testutil"
 	"github.com/c9s/bbgo/pkg/types"
@@ -56,132 +57,144 @@ func Test_SubCmdString(t *testing.T) {
 }
 
 func TestStreamBasic(t *testing.T) {
-	c := make(chan any)
 	productIDs := []string{"BTC-USD", "ETH-USD"}
-	var msg any
 
 	t.Run("Test Status", func(t *testing.T) {
 		stream := getTestStreamOrSkip(t)
+		chanStatus := make(chan StatusMessage)
+
 		stream.Subscribe("status", "", types.SubscribeOptions{})
-		triggered := false
 		stream.OnStatusMessage(func(m *StatusMessage) {
-			if triggered {
-				return
-			}
-			triggered = true
 			assert.NotNil(t, m)
 			// t.Log("get status message")
-			c <- *m
+			chanStatus <- *m
 		})
+
 		err := stream.Connect(context.Background())
 		assert.NoError(t, err)
+		select {
+		case msg := <-chanStatus:
+			assert.IsType(t, StatusMessage{}, msg)
+		case <-time.After(time.Second * 10):
+			t.Fatal("No message from status channel after 10 seconds")
+		}
 	})
-	msg = <-c
-	assert.IsType(t, StatusMessage{}, msg)
 
 	t.Run("Test Ticker", func(t *testing.T) {
 		stream := getTestStreamOrSkip(t)
+		chanTicker := make(chan TickerMessage)
+
 		for _, productID := range productIDs {
 			stream.Subscribe("ticker", productID, types.SubscribeOptions{})
 		}
-		triggered := false
 		stream.OnTickerMessage(func(m *TickerMessage) {
-			if triggered {
-				return
-			}
-			triggered = true
 			assert.NotNil(t, m)
 			// t.Logf("get ticker message: %v", *m)
-			c <- *m
+			chanTicker <- *m
 		})
+
 		err := stream.Connect(context.Background())
 		assert.NoError(t, err)
+		select {
+		case msg := <-chanTicker:
+			assert.IsType(t, TickerMessage{}, msg)
+		case <-time.After(time.Second * 10):
+			t.Fatal("No message from ticker channel after 10 seconds")
+		}
 	})
-	msg = <-c
-	assert.IsType(t, TickerMessage{}, msg)
 
 	t.Run("Test Match", func(t *testing.T) {
 		stream := getTestStreamOrSkip(t)
+		chanMatch := make(chan MatchMessage)
+
 		for _, productID := range productIDs {
 			stream.Subscribe("matches", productID, types.SubscribeOptions{})
 		}
-		triggered := false
 		stream.OnMatchMessage(func(m *MatchMessage) {
-			if triggered {
-				return
-			}
-			triggered = true
 			assert.NotNil(t, m)
 			// t.Logf("get match message: %v", *m)
-			c <- *m
+			chanMatch <- *m
 		})
+
 		err := stream.Connect(context.Background())
 		assert.NoError(t, err)
+		// wait for 5 seconds to receive match message
+		time.Sleep(time.Second * 5)
+		select {
+		case msg := <-chanMatch:
+			assert.IsType(t, MatchMessage{}, msg)
+		case <-time.After(time.Second * 10):
+			t.Fatal("No message from match channel after 10 seconds")
+		}
 	})
-	msg = <-c
-	assert.IsType(t, MatchMessage{}, msg)
 
 	// TODO: test Rfq message
 }
 
 func TestStreamFull(t *testing.T) {
-	c := make(chan bool)
-	productIDs := []string{"BTC-USD", "ETH-USD"}
-
 	t.Run("Run Full", func(t *testing.T) {
+		productIDs := []string{"BTC-USD", "ETH-USD"}
+		c := make(chan struct{}, 10)
 		stream := getTestStreamOrSkip(t)
 		for _, productID := range productIDs {
 			stream.Subscribe("full", productID, types.SubscribeOptions{})
 		}
-		// TODO: test full order life cycle
-		// received -> open+ -> change* -> match? -> done
+
+		// received -> open* -> change* -> match? -> done
 		stream.OnReceivedMessage(func(m *ReceivedMessage) {
 			// t.Log("get received message")
 			assert.NotNil(t, m)
-			c <- true
+			c <- struct{}{}
 		})
 		stream.OnOpenMessage(func(m *OpenMessage) {
 			// t.Log("get open message")
 			assert.NotNil(t, m)
-			c <- true
+			c <- struct{}{}
 		})
 		stream.OnDoneMessage(func(m *DoneMessage) {
 			// t.Log("get done message")
 			assert.NotNil(t, m)
-			c <- true
+			c <- struct{}{}
 		})
 		stream.OnMatchMessage(func(m *MatchMessage) {
 			// t.Log("get match message")
 			assert.NotNil(t, m)
-			c <- true
+			c <- struct{}{}
 		})
 		stream.OnChangeMessage(func(m *ChangeMessage) {
 			// t.Log("get change message")
 			assert.NotNil(t, m)
-			c <- true
+			c <- struct{}{}
 		})
 		stream.OnActivateMessage(func(m *ActivateMessage) {
 			// t.Log("get activate message")
 			assert.NotNil(t, m)
-			c <- true
+			c <- struct{}{}
 		})
+
 		err := stream.Connect(context.Background())
 		assert.NoError(t, err)
+		select {
+		case <-c:
+		case <-time.After(time.Second * 10):
+			t.Fatal("No message from full channel after 10 seconds")
+		}
 	})
-	<-c
+
 }
 
 func TestLevel2(t *testing.T) {
-	c := make(chan string)
-	productIDs := []string{"BTC-USD"}
-
-	getSnapshot := false
-	getUpdate := false
 	t.Run("Run Level2", func(t *testing.T) {
 		stream := getTestStreamOrSkip(t)
+		c := make(chan string, 2)
+		productIDs := []string{"BTC-USD"}
+		getSnapshot := false
+		getUpdate := false
+
 		for _, productID := range productIDs {
 			stream.Subscribe("level2", productID, types.SubscribeOptions{})
 		}
+
 		stream.OnOrderbookSnapshotMessage(func(m *OrderBookSnapshotMessage) {
 			// t.Log("get orderbook snapshot message")
 			assert.NotNil(t, m)
@@ -192,49 +205,53 @@ func TestLevel2(t *testing.T) {
 			assert.NotNil(t, m)
 			c <- "update"
 		})
+
 		err := stream.Connect(context.Background())
 		assert.NoError(t, err)
-	})
-	for {
-		select {
-		case msg := <-c:
-			if msg == "snapshot" {
-				getSnapshot = true
-			} else if msg == "update" {
-				getUpdate = true
+		for {
+			select {
+			case msg := <-c:
+				if msg == "snapshot" {
+					getSnapshot = true
+				} else if msg == "update" {
+					getUpdate = true
+				}
+			case <-time.After(time.Second * 10):
+				t.Fatal("No message from level2 channel after 10 seconds")
+			default:
+				// do nothing
+			}
+			if getSnapshot && getUpdate {
+				break
 			}
 		}
-		if getSnapshot && getUpdate {
-			break
-		}
-	}
+	})
 }
 
 func TestBalance(t *testing.T) {
-	accountsStr := os.Getenv("COINBASE_ACCOUNT_IDS")
-	accounts := strings.Split(accountsStr, ",")
-
-	c := make(chan struct{})
 
 	t.Run("Run Balance", func(t *testing.T) {
+		accountsStr := os.Getenv("COINBASE_ACCOUNT_IDS")
+		accounts := strings.Split(accountsStr, ",")
+
+		c := make(chan struct{}, 1)
 		stream := getTestStreamOrSkip(t)
 		for _, accountID := range accounts {
 			stream.Subscribe("balance", accountID, types.SubscribeOptions{})
 		}
-		triggered := false
 		stream.OnBalanceMessage(func(m *BalanceMessage) {
-			if triggered {
-				return
-			}
-			triggered = true
 			assert.NotNil(t, m)
 			// t.Logf("get balance message: %v", *m)
 			c <- struct{}{}
 		})
 		err := stream.Connect(context.Background())
 		assert.NoError(t, err)
+		select {
+		case <-c:
+		case <-time.After(time.Second * 10):
+			t.Fatal("No message from balance channel after 10 seconds")
+		}
 	})
-	<-c
 }
 
 func getTestStreamOrSkip(t *testing.T) *Stream {

--- a/pkg/exchange/coinbase/stream_test.go
+++ b/pkg/exchange/coinbase/stream_test.go
@@ -1,10 +1,15 @@
 package coinbase
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/c9s/bbgo/pkg/testutil"
+	"github.com/c9s/bbgo/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,4 +53,200 @@ func Test_SubCmdString(t *testing.T) {
 	outStr = fmt.Sprintf("%s", subCmd)
 	assert.False(t, strings.Contains(outStr, "<secret_key!>"))
 	assert.False(t, strings.Contains(outStr, "<secret_passphrase!>"))
+}
+
+func TestStreamBasic(t *testing.T) {
+	c := make(chan any)
+	productIDs := []string{"BTC-USD", "ETH-USD"}
+	var msg any
+
+	t.Run("Test Status", func(t *testing.T) {
+		stream := getTestStreamOrSkip(t)
+		stream.Subscribe("status", "", types.SubscribeOptions{})
+		triggered := false
+		stream.OnStatusMessage(func(m *StatusMessage) {
+			if triggered {
+				return
+			}
+			triggered = true
+			assert.NotNil(t, m)
+			t.Log("get status message")
+			c <- *m
+		})
+		err := stream.Connect(context.Background())
+		assert.NoError(t, err)
+	})
+	msg = <-c
+	assert.IsType(t, StatusMessage{}, msg)
+
+	t.Run("Test Ticker", func(t *testing.T) {
+		stream := getTestStreamOrSkip(t)
+		for _, productID := range productIDs {
+			stream.Subscribe("ticker", productID, types.SubscribeOptions{})
+		}
+		triggered := false
+		stream.OnTickerMessage(func(m *TickerMessage) {
+			if triggered {
+				return
+			}
+			triggered = true
+			assert.NotNil(t, m)
+			t.Logf("get ticker message: %v", *m)
+			c <- *m
+		})
+		err := stream.Connect(context.Background())
+		assert.NoError(t, err)
+	})
+	msg = <-c
+	assert.IsType(t, TickerMessage{}, msg)
+
+	t.Run("Test Match", func(t *testing.T) {
+		stream := getTestStreamOrSkip(t)
+		for _, productID := range productIDs {
+			stream.Subscribe("matches", productID, types.SubscribeOptions{})
+		}
+		triggered := false
+		stream.OnMatchMessage(func(m *MatchMessage) {
+			if triggered {
+				return
+			}
+			triggered = true
+			assert.NotNil(t, m)
+			t.Logf("get match message: %v", *m)
+			c <- *m
+		})
+		err := stream.Connect(context.Background())
+		assert.NoError(t, err)
+	})
+	msg = <-c
+	assert.IsType(t, MatchMessage{}, msg)
+
+	// TODO: test Rfq message
+}
+
+func TestStreamFull(t *testing.T) {
+	c := make(chan bool)
+	productIDs := []string{"BTC-USD", "ETH-USD"}
+
+	t.Run("Run Full", func(t *testing.T) {
+		stream := getTestStreamOrSkip(t)
+		for _, productID := range productIDs {
+			stream.Subscribe("full", productID, types.SubscribeOptions{})
+		}
+		// TODO: test full order life cycle
+		// received -> open -> change* -> match? -> done
+		stream.OnReceivedMessage(func(m *ReceivedMessage) {
+			t.Log("get received message")
+			assert.NotNil(t, m)
+			c <- true
+		})
+		stream.OnOpenMessage(func(m *OpenMessage) {
+			t.Log("get open message")
+			assert.NotNil(t, m)
+			c <- true
+		})
+		stream.OnDoneMessage(func(m *DoneMessage) {
+			t.Log("get done message")
+			assert.NotNil(t, m)
+			c <- true
+		})
+		stream.OnMatchMessage(func(m *MatchMessage) {
+			t.Log("get match message")
+			assert.NotNil(t, m)
+			c <- true
+		})
+		stream.OnChangeMessage(func(m *ChangeMessage) {
+			t.Log("get change message")
+			assert.NotNil(t, m)
+			c <- true
+		})
+		stream.OnActivateMessage(func(m *ActivateMessage) {
+			t.Log("get activate message")
+			assert.NotNil(t, m)
+			c <- true
+		})
+		err := stream.Connect(context.Background())
+		assert.NoError(t, err)
+	})
+	<-c
+}
+
+func TestLevel2(t *testing.T) {
+	c := make(chan string)
+	productIDs := []string{"BTC-USD"}
+
+	getSnapshot := false
+	getUpdate := false
+	t.Run("Run Level2", func(t *testing.T) {
+		stream := getTestStreamOrSkip(t)
+		for _, productID := range productIDs {
+			stream.Subscribe("level2", productID, types.SubscribeOptions{})
+		}
+		stream.OnOrderbookSnapshotMessage(func(m *OrderBookSnapshotMessage) {
+			t.Log("get orderbook snapshot message")
+			assert.NotNil(t, m)
+			c <- "snapshot"
+		})
+		stream.OnOrderbookUpdateMessage(func(m *OrderBookUpdateMessage) {
+			t.Log("get orderbook update message")
+			assert.NotNil(t, m)
+			c <- "update"
+		})
+		err := stream.Connect(context.Background())
+		assert.NoError(t, err)
+	})
+	for {
+		select {
+		case msg := <-c:
+			if msg == "snapshot" {
+				getSnapshot = true
+			} else if msg == "update" {
+				getUpdate = true
+			}
+		}
+		if getSnapshot && getUpdate {
+			break
+		}
+	}
+}
+
+func TestBalance(t *testing.T) {
+	accountsStr := os.Getenv("COINBASE_ACCOUNT_IDS")
+	accounts := strings.Split(accountsStr, ",")
+
+	c := make(chan bool)
+
+	t.Run("Run Balance", func(t *testing.T) {
+		stream := getTestStreamOrSkip(t)
+		for _, accountID := range accounts {
+			stream.Subscribe("balance", accountID, types.SubscribeOptions{})
+		}
+		triggered := false
+		stream.OnBalanceMessage(func(m *BalanceMessage) {
+			if triggered {
+				return
+			}
+			triggered = true
+			assert.NotNil(t, m)
+			t.Logf("get balance message: %v", *m)
+			c <- true
+		})
+		err := stream.Connect(context.Background())
+		assert.NoError(t, err)
+	})
+	<-c
+}
+
+func getTestStreamOrSkip(t *testing.T) *Stream {
+	if isCI, _ := strconv.ParseBool(os.Getenv("CI")); isCI {
+		t.Skip("skip test for CI")
+	}
+
+	key, secret, passphrase, ok := testutil.IntegrationTestWithPassphraseConfigured(t, "COINBASE")
+	if !ok {
+		t.Skip("COINBASE_* env vars not set")
+	}
+	exchange := New(key, secret, passphrase, 0)
+	stream := NewStream(exchange, key, passphrase, secret)
+	return stream
 }

--- a/pkg/exchange/coinbase/stream_test.go
+++ b/pkg/exchange/coinbase/stream_test.go
@@ -78,6 +78,8 @@ func TestStreamBasic(t *testing.T) {
 		case <-time.After(time.Second * 10):
 			t.Fatal("No message from status channel after 10 seconds")
 		}
+		err = stream.Close()
+		assert.NoError(t, err)
 	})
 
 	t.Run("Test Ticker", func(t *testing.T) {
@@ -101,6 +103,8 @@ func TestStreamBasic(t *testing.T) {
 		case <-time.After(time.Second * 10):
 			t.Fatal("No message from ticker channel after 10 seconds")
 		}
+		err = stream.Close()
+		assert.NoError(t, err)
 	})
 
 	t.Run("Test Match", func(t *testing.T) {
@@ -126,6 +130,8 @@ func TestStreamBasic(t *testing.T) {
 		case <-time.After(time.Second * 10):
 			t.Fatal("No message from match channel after 10 seconds")
 		}
+		err = stream.Close()
+		assert.NoError(t, err)
 	})
 
 	// TODO: test Rfq message
@@ -179,6 +185,8 @@ func TestStreamFull(t *testing.T) {
 		case <-time.After(time.Second * 10):
 			t.Fatal("No message from full channel after 10 seconds")
 		}
+		err = stream.Close()
+		assert.NoError(t, err)
 	})
 
 }
@@ -225,6 +233,8 @@ func TestLevel2(t *testing.T) {
 				break
 			}
 		}
+		err = stream.Close()
+		assert.NoError(t, err)
 	})
 }
 
@@ -251,6 +261,8 @@ func TestBalance(t *testing.T) {
 		case <-time.After(time.Second * 10):
 			t.Fatal("No message from balance channel after 10 seconds")
 		}
+		err = stream.Close()
+		assert.NoError(t, err)
 	})
 }
 

--- a/pkg/exchange/coinbase/stream_test.go
+++ b/pkg/exchange/coinbase/stream_test.go
@@ -134,7 +134,7 @@ func TestStreamFull(t *testing.T) {
 			stream.Subscribe("full", productID, types.SubscribeOptions{})
 		}
 		// TODO: test full order life cycle
-		// received -> open -> change* -> match? -> done
+		// received -> open+ -> change* -> match? -> done
 		stream.OnReceivedMessage(func(m *ReceivedMessage) {
 			// t.Log("get received message")
 			assert.NotNil(t, m)

--- a/pkg/exchange/coinbase/stream_test.go
+++ b/pkg/exchange/coinbase/stream_test.go
@@ -40,7 +40,7 @@ func Test_SubCmdString(t *testing.T) {
 
 	subCmd = subscribeMsgType2{
 		Type:       "subscribe",
-		Channels:   []string{},
+		Channels:   []types.Channel{},
 		ProductIDs: []string{},
 		AccountIDs: []string{},
 		authMsg: authMsg{


### PR DESCRIPTION
1. update `.SubmitOrder` logic, to simplify the streaming handlers logic
    - Do not support `limit order with funds`
    - Only support stop limit order (via `stop` order on Coinbase Exchange) at long position .
2. By `1.`, update order-related event handlers accordingly.