### PR TITLE
FIX: [sync service] inconsistency of the query conditions on existing trades

### DIFF
--- a/pkg/service/sync_task.go
+++ b/pkg/service/sync_task.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"reflect"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/Masterminds/squirrel"
+	"github.com/c9s/bbgo/pkg/types"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -73,7 +75,10 @@ func (sel SyncTask) execute(
 
 	logrus.Debugf("loaded %d %T records", recordSliceRef.Len(), sel.Type)
 
-	ids := buildIdMap(sel, recordSliceRef)
+	ids, err := buildIdMap(ctx, db, sel, recordSliceRef)
+	if err != nil {
+		return err
+	}
 
 	if err := sortRecordsAscending(sel, recordSliceRef); err != nil {
 		return err
@@ -201,13 +206,65 @@ func sortRecordsAscending(sel SyncTask, recordSlice reflect.Value) error {
 	return nil
 }
 
-func buildIdMap(sel SyncTask, recordSliceRef reflect.Value) map[string]struct{} {
+func buildIdMap(ctx context.Context, db *sqlx.DB, sel SyncTask, recordSliceRef reflect.Value) (map[string]struct{}, error) {
 	ids := map[string]struct{}{}
-	for i := 0; i < recordSliceRef.Len(); i++ {
+	refLen := recordSliceRef.Len()
+	for i := 0; i < refLen; i++ {
 		entryRef := recordSliceRef.Index(i)
 		id := sel.ID(entryRef.Interface())
 		ids[id] = struct{}{}
 	}
+	if refLen == 0 {
+		return ids, nil
+	}
+	switch sel.Type.(type) {
+	case types.Trade:
+		err := patchSelfTrade(ctx, db, sel, recordSliceRef, &ids)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	return ids
+	return ids, nil
+}
+
+func patchSelfTrade(ctx context.Context, db *sqlx.DB, sel SyncTask, recordSliceRef reflect.Value, ids *map[string]struct{}) error {
+	// address the issue if the last record is a self-trade
+	// this patch will make sure both the buy and self side of the self-trade are in the ids map
+	last := recordSliceRef.Index(recordSliceRef.Len() - 1)
+	idRef := last.FieldByName("ID")
+	lastTradeId := strconv.FormatUint(idRef.Uint(), 10)
+	query := squirrel.Select("*").
+		From("trades").
+		Where(squirrel.Eq{"id": lastTradeId})
+	sql, args, err := query.ToSql()
+	if err != nil {
+		logrus.Warnf("can not build sql for self-trade records: %s", err)
+		return nil
+	}
+	rows, err := db.QueryxContext(ctx, sql, args...)
+	if err != nil {
+		logrus.Warnf("can not query self-trade records: %s", err)
+		return nil
+	}
+	defer rows.Close()
+
+	records, err := scanRowsOfType(rows, sel.Type)
+	if err != nil {
+		return err
+	}
+	recordsRef := reflect.ValueOf(records)
+	if recordsRef.Kind() == reflect.Ptr {
+		recordsRef = recordsRef.Elem()
+	}
+	len := recordsRef.Len()
+	for i := 0; i < len; i++ {
+		id := sel.ID(recordsRef.Index(i).Interface())
+		if _, exists := (*ids)[id]; exists {
+			continue
+		}
+		(*ids)[id] = struct{}{}
+	}
+
+	return nil
 }

--- a/pkg/service/sync_task.go
+++ b/pkg/service/sync_task.go
@@ -78,7 +78,7 @@ func (sel SyncTask) execute(
 	ids := buildIdMap(sel, recordSliceRef)
 	switch sel.Type.(type) {
 	case types.Trade:
-		if err := patchSelfTrade(ctx, db, sel, recordSliceRef, &ids); err != nil {
+		if err := patchSelfTrade(ctx, db, sel, recordSliceRef, ids); err != nil {
 			return err
 		}
 	}
@@ -219,7 +219,7 @@ func buildIdMap(sel SyncTask, recordSliceRef reflect.Value) map[string]struct{} 
 	return ids
 }
 
-func patchSelfTrade(ctx context.Context, db *sqlx.DB, sel SyncTask, recordSliceRef reflect.Value, ids *map[string]struct{}) error {
+func patchSelfTrade(ctx context.Context, db *sqlx.DB, sel SyncTask, recordSliceRef reflect.Value, ids map[string]struct{}) error {
 	// address the issue if the last record is a self-trade
 	// this patch will make sure both the buy and sell side of the self-trade are in the ids map
 	last := recordSliceRef.Index(recordSliceRef.Len() - 1)
@@ -251,10 +251,10 @@ func patchSelfTrade(ctx context.Context, db *sqlx.DB, sel SyncTask, recordSliceR
 	len := recordsRef.Len()
 	for i := 0; i < len; i++ {
 		id := sel.ID(recordsRef.Index(i).Interface())
-		if _, exists := (*ids)[id]; exists {
+		if _, exists := ids[id]; exists {
 			continue
 		}
-		(*ids)[id] = struct{}{}
+		ids[id] = struct{}{}
 	}
 
 	return nil


### PR DESCRIPTION
The query on existing trade records from the DB was based on trade id and limit.
Whereas, the query via the exchange API is based on timestamp and trade id.
The inconsistency on the query conditions may cause error on corner cases.
There are chances the ids map may fail to filter out existing trade records and resulting in duplicate key error while inserting.

In this PR, I add an extra query for the record with the last trade id.
And I update the ids map accordingly so that self-trade records on both side will be included.
