### PR TITLE
FIX: [coinbase] skip last match event to prevent potential duplicate trades

### DIFF
--- a/pkg/exchange/coinbase/stream_handlers.go
+++ b/pkg/exchange/coinbase/stream_handlers.go
@@ -267,6 +267,10 @@ func (s *Stream) handleTickerMessage(msg *TickerMessage) {
 }
 
 func (s *Stream) handleMatchMessage(msg *MatchMessage) {
+	if msg.Type == "last_match" {
+		// TODO: fetch missing trades from the REST API and emit them
+		return
+	}
 	// ignore outdated messages
 	if !s.checkAndUpdateSequenceNumber(msg.Type, msg.ProductID, msg.Sequence) {
 		return


### PR DESCRIPTION
Skip `last_match` event.
Though it may miss trades from the last disconnection, it can prevent duplicate insert to the DB.