### PR TITLE
FIX: [okx] fix the before id bug

### DIFF
--- a/pkg/exchange/okex/exchange.go
+++ b/pkg/exchange/okex/exchange.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/multierr"
@@ -778,7 +779,17 @@ func (e *Exchange) QueryTrades(ctx context.Context, symbol string, options *type
 	}
 
 	lessThan3Day := timeNow.Sub(newStartTime) <= threeDaysHistoricalPeriod
-	logger.Infof("QueryTrades: symbol=%s, limit=%d, start=%s, end=%s, lastTradeId=%d, less3Day=%t, margin=%t", symbol, limit, newStartTime, endTime, options.LastTradeID, lessThan3Day, e.MarginSettings.IsMargin)
+
+	logger = logger.WithFields(logrus.Fields{
+		"symbol":        symbol,
+		"limit":         limit,
+		"start_time":    newStartTime,
+		"end_time":      endTime,
+		"last_trade_id": options.LastTradeID,
+		"less_3day":     lessThan3Day,
+		"margin":        e.MarginSettings.IsMargin,
+		"req_id":        uuid.New().String(),
+	})
 
 	if lessThan3Day {
 		c := e.client.NewGetThreeDaysTransactionHistoryRequest().
@@ -792,7 +803,11 @@ func (e *Exchange) QueryTrades(ctx context.Context, symbol string, options *type
 		}
 
 		return getTrades(ctx, logger, limit, func(ctx context.Context, billId string) ([]okexapi.Trade, error) {
-			c.Before(billId)
+			if billId != "" && billId != "0" {
+				// the `after` will get the data after the billId
+				// so DON'T fill the billId if it's 0
+				c.After(billId)
+			}
 			return c.Do(ctx)
 		})
 	}
@@ -808,19 +823,23 @@ func (e *Exchange) QueryTrades(ctx context.Context, symbol string, options *type
 	}
 
 	return getTrades(ctx, logger, limit, func(ctx context.Context, billId string) ([]okexapi.Trade, error) {
-		c.Before(billId)
+		if billId != "" && billId != "0" {
+			// the `after` will get the data after the billId
+			// so DON'T fill the billId if it's 0
+			c.After(billId)
+		}
 		return c.Do(ctx)
 	})
 }
 
 func getTrades(
-	ctx context.Context, log *logrus.Entry, limit int64, doFunc func(ctx context.Context, billId string) ([]okexapi.Trade, error),
+	ctx context.Context, logger *logrus.Entry, limit int64, doFunc func(ctx context.Context, billId string) ([]okexapi.Trade, error),
 ) (trades []types.Trade, err error) {
 	billId := "0"
 	for {
 		response, err := doFunc(ctx, billId)
 		if err != nil {
-			log.WithError(err).Warn("failed to query trades")
+			logger.WithError(err).Warn("failed to query trades")
 			return nil, fmt.Errorf("failed to query trades, err: %w", err)
 		}
 
@@ -829,18 +848,18 @@ func getTrades(
 		}
 
 		tradeLen := int64(len(response))
-		log.Infof("getTrades: billId=%s, tradeLen=%d, limit=%d", billId, tradeLen, limit)
 		// a defensive programming to ensure the length of order response is expected.
 		if tradeLen > limit {
-			log.WithError(err).Warnf("getTrades: trade length %d exceeds limit %d", tradeLen, limit)
+			logger.WithError(err).Warnf("getTrades: trade length %d exceeds limit %d", tradeLen, limit)
 			return nil, fmt.Errorf("unexpected trade length %d", tradeLen)
 		}
 
 		if tradeLen < limit {
-			log.Warnf("getTrades: trade length %d less than limit %d", tradeLen, limit)
+			logger.Warnf("getTrades: trade length %d less than limit %d", tradeLen, limit)
 			break
 		}
-		// use Before filter to get all data.
+
+		// use After filter to get all data.
 		billId = response[tradeLen-1].BillId.String()
 	}
 	return trades, nil

--- a/pkg/exchange/okex/exchange_test.go
+++ b/pkg/exchange/okex/exchange_test.go
@@ -126,19 +126,17 @@ func TestExchange_QueryTrades(t *testing.T) {
 
 			transport.GET(threeDayUrl, func(req *http.Request) (*http.Response, error) {
 				query := req.URL.Query()
-				assert.Len(query, 6)
+				assert.Len(query, 5)
 				assert.Contains(query, "begin")
 				assert.Contains(query, "end")
 				assert.Contains(query, "limit")
 				assert.Contains(query, "instId")
 				assert.Contains(query, "instType")
-				assert.Contains(query, "before")
 				assert.Equal(query["begin"], []string{strconv.FormatInt(since.UnixNano()/int64(time.Millisecond), 10)})
 				assert.Equal(query["end"], []string{strconv.FormatInt(until.UnixNano()/int64(time.Millisecond), 10)})
 				assert.Equal(query["limit"], []string{strconv.FormatInt(defaultQueryLimit, 10)})
 				assert.Equal(query["instId"], []string{expLocalBtcSymbol})
 				assert.Equal(query["instType"], []string{string(okexapi.InstrumentTypeSpot)})
-				assert.Equal(query["before"], []string{"0"})
 				return httptesting.BuildResponseString(http.StatusOK, string(historyOrderFile)), nil
 			})
 
@@ -205,9 +203,8 @@ func TestExchange_QueryTrades(t *testing.T) {
 				assert.Equal(query["limit"], []string{strconv.FormatInt(defaultQueryLimit, 10)})
 				assert.Equal(query["instId"], []string{expLocalBtcSymbol})
 				assert.Equal(query["instType"], []string{string(okexapi.InstrumentTypeSpot)})
-				assert.Len(query, 6)
 
-				if query["before"][0] == "0" {
+				if _, found := query["after"]; !found {
 					resp := &okexapi.APIResponse{
 						Code: "0",
 						Data: []byte("[" + strings.Join(tradesStr[0:defaultQueryLimit], ",") + "]"),
@@ -220,7 +217,7 @@ func TestExchange_QueryTrades(t *testing.T) {
 
 				// second time query
 				// last order id, so need to -1
-				assert.Equal(query["before"], []string{strconv.FormatInt(int64(billId+defaultQueryLimit-1), 10)})
+				assert.Equal(query["after"], []string{strconv.FormatInt(int64(billId+defaultQueryLimit-1), 10)})
 
 				resp := okexapi.APIResponse{
 					Code: "0",
@@ -249,19 +246,17 @@ func TestExchange_QueryTrades(t *testing.T) {
 
 			transport.GET(historyUrl, func(req *http.Request) (*http.Response, error) {
 				query := req.URL.Query()
-				assert.Len(query, 6)
+				assert.Len(query, 5)
 				assert.Contains(query, "begin")
 				assert.Contains(query, "end")
 				assert.Contains(query, "limit")
 				assert.Contains(query, "instId")
 				assert.Contains(query, "instType")
-				assert.Contains(query, "before")
 				assert.Equal(query["begin"], []string{strconv.FormatInt(newSince.UnixNano()/int64(time.Millisecond), 10)})
 				assert.Equal(query["end"], []string{strconv.FormatInt(until.UnixNano()/int64(time.Millisecond), 10)})
 				assert.Equal(query["limit"], []string{strconv.FormatInt(defaultQueryLimit, 10)})
 				assert.Equal(query["instId"], []string{expLocalBtcSymbol})
 				assert.Equal(query["instType"], []string{string(okexapi.InstrumentTypeSpot)})
-				assert.Equal(query["before"], []string{"0"})
 				return httptesting.BuildResponseString(http.StatusOK, string(historyOrderFile)), nil
 			})
 
@@ -330,9 +325,8 @@ func TestExchange_QueryTrades(t *testing.T) {
 				assert.Equal(query["limit"], []string{strconv.FormatInt(defaultQueryLimit, 10)})
 				assert.Equal(query["instId"], []string{expLocalBtcSymbol})
 				assert.Equal(query["instType"], []string{string(okexapi.InstrumentTypeSpot)})
-				assert.Len(query, 6)
 
-				if query["before"][0] == "0" {
+				if _, found := query["after"]; !found {
 					resp := &okexapi.APIResponse{
 						Code: "0",
 						Data: []byte("[" + strings.Join(tradesStr[0:defaultQueryLimit], ",") + "]"),
@@ -345,7 +339,7 @@ func TestExchange_QueryTrades(t *testing.T) {
 
 				// second time query
 				// last order id, so need to -1
-				assert.Equal(query["before"], []string{strconv.FormatInt(int64(billId+defaultQueryLimit-1), 10)})
+				assert.Equal(query["after"], []string{strconv.FormatInt(int64(billId+defaultQueryLimit-1), 10)})
 
 				resp := okexapi.APIResponse{
 					Code: "0",
@@ -377,19 +371,16 @@ func TestExchange_QueryTrades(t *testing.T) {
 
 		transport.GET(historyUrl, func(req *http.Request) (*http.Response, error) {
 			query := req.URL.Query()
-			assert.Len(query, 6)
 			assert.Contains(query, "begin")
 			assert.Contains(query, "end")
 			assert.Contains(query, "limit")
 			assert.Contains(query, "instId")
 			assert.Contains(query, "instType")
-			assert.Contains(query, "before")
 			assert.Equal(query["begin"], []string{strconv.FormatInt(expSinceTime.UnixNano()/int64(time.Millisecond), 10)})
 			assert.Equal(query["end"], []string{strconv.FormatInt(until.UnixNano()/int64(time.Millisecond), 10)})
 			assert.Equal(query["limit"], []string{strconv.FormatInt(defaultQueryLimit, 10)})
 			assert.Equal(query["instId"], []string{expLocalBtcSymbol})
 			assert.Equal(query["instType"], []string{string(okexapi.InstrumentTypeSpot)})
-			assert.Equal(query["before"], []string{"0"})
 			return httptesting.BuildResponseString(http.StatusOK, string(historyOrderFile)), nil
 		})
 


### PR DESCRIPTION
由於使用before id 的 pagination 從 desc 變為 asc，先前可利用最後一個 id 直接撈取更大的資料，現在卻需要 N-1 次才能完成，效率大幅降低，且會包含重複的，和先前測試的結果不符。

現在改成使用 After，可直接利用最後一個 id 繼續撈曲剩下的資料回來，而且不會重複