### PR TITLE
FIX: [xgap] adjust mid price (round and truncate by price precision)

### DIFF
--- a/pkg/strategy/grid2/grid.go
+++ b/pkg/strategy/grid2/grid.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strconv"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
+	"github.com/c9s/bbgo/pkg/util"
 )
 
 type PinCalculator func() []Pin
@@ -35,17 +35,6 @@ type Grid struct {
 
 type Pin fixedpoint.Value
 
-// roundAndTruncatePrice rounds the given price at prec-1 and then truncate the price at prec
-func roundAndTruncatePrice(p fixedpoint.Value, prec int) fixedpoint.Value {
-	var pow10 = math.Pow10(prec)
-	pp := math.Round(p.Float64()*pow10*10.0) / 10.0
-	pp = math.Trunc(pp) / pow10
-
-	pps := strconv.FormatFloat(pp, 'f', prec, 64)
-	price := fixedpoint.MustNewFromString(pps)
-	return price
-}
-
 func removeDuplicatedPins(pins []Pin) []Pin {
 	var buckets = map[string]struct{}{}
 	var out []Pin
@@ -71,12 +60,12 @@ func calculateArithmeticPins(lower, upper, spread, tickSize fixedpoint.Value) []
 	var ts = tickSize.Float64()
 	var prec = int(math.Round(math.Log10(ts) * -1.0))
 	for p := lower; p.Compare(upper.Sub(spread)) <= 0; p = p.Add(spread) {
-		price := roundAndTruncatePrice(p, prec)
+		price := util.RoundAndTruncatePrice(p, prec)
 		pins = append(pins, Pin(price))
 	}
 
 	// this makes sure there is no error at the upper price
-	upperPrice := roundAndTruncatePrice(upper, prec)
+	upperPrice := util.RoundAndTruncatePrice(upper, prec)
 	pins = append(pins, Pin(upperPrice))
 
 	return pins

--- a/pkg/strategy/grid2/grid_test.go
+++ b/pkg/strategy/grid2/grid_test.go
@@ -215,40 +215,6 @@ func Test_calculateArithmeticPins(t *testing.T) {
 	}
 }
 
-func Test_filterPrice1(t *testing.T) {
-	type args struct {
-		p    fixedpoint.Value
-		prec int
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "basic",
-			args: args{p: number("31.2222"), prec: 3},
-			want: "31.222",
-		},
-		{
-			name: "roundup",
-			args: args{p: number("31.22295"), prec: 3},
-			want: "31.223",
-		},
-		{
-			name: "roundup2",
-			args: args{p: number("31.22290"), prec: 3},
-			want: "31.222",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rst := roundAndTruncatePrice(tt.args.p, tt.args.prec)
-			assert.Equalf(t, tt.want, rst.String(), "roundAndTruncatePrice(%v, %v)", tt.args.p, tt.args.prec)
-		})
-	}
-}
-
 func Test_removeDuplicatedPins(t *testing.T) {
 	pins := []Pin{
 		Pin(number("31.222")),

--- a/pkg/strategy/xgap/strategy.go
+++ b/pkg/strategy/xgap/strategy.go
@@ -322,7 +322,7 @@ func (s *Strategy) placeOrders(ctx context.Context) {
 		bestAsk.Price.String(), bestBid.Price.String(), midPrice)
 
 	var price = adjustPrice(midPrice, s.tradingMarket.PricePrecision)
-	log.Infof("adjusted price: %s -> %s", midPrice.String(), price.String())
+	log.Infof("adjusted price: %s -> %s (precision: %v)", midPrice.String(), price.String(), s.tradingMarket.PricePrecision)
 
 	var balances = s.tradingSession.GetAccount().Balances()
 

--- a/pkg/strategy/xgap/strategy.go
+++ b/pkg/strategy/xgap/strategy.go
@@ -322,6 +322,8 @@ func (s *Strategy) placeOrders(ctx context.Context) {
 		bestAsk.Price.String(), bestBid.Price.String(), midPrice)
 
 	var price = adjustPrice(midPrice, s.tradingMarket.PricePrecision)
+	log.Infof("adjusted price: %s -> %s", midPrice.String(), price.String())
+
 	var balances = s.tradingSession.GetAccount().Balances()
 
 	baseBalance, ok := balances[s.tradingMarket.BaseCurrency]
@@ -453,6 +455,5 @@ func adjustPrice(price fixedpoint.Value, pricePrecision int) fixedpoint.Value {
 	}
 	rate := math.Pow(10, float64(-pricePrecision))*0.1 + 1
 	priceAdjusted := util.RoundAndTruncatePrice(price.Mul(fixedpoint.NewFromFloat(rate)), pricePrecision)
-	log.Infof("adjusted price: %s -> %s", price.String(), priceAdjusted.String())
 	return priceAdjusted
 }

--- a/pkg/strategy/xgap/strategy.go
+++ b/pkg/strategy/xgap/strategy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/strategy/common"
 	"github.com/c9s/bbgo/pkg/types"
+	"github.com/c9s/bbgo/pkg/util"
 	"github.com/c9s/bbgo/pkg/util/timejitter"
 	"github.com/c9s/bbgo/pkg/util/tradingutil"
 )
@@ -320,8 +321,7 @@ func (s *Strategy) placeOrders(ctx context.Context) {
 		spreadPercentage.Percentage(),
 		bestAsk.Price.String(), bestBid.Price.String(), midPrice)
 
-	var price = midPrice
-
+	var price = adjustPrice(midPrice, s.tradingMarket.PricePrecision)
 	var balances = s.tradingSession.GetAccount().Balances()
 
 	baseBalance, ok := balances[s.tradingMarket.BaseCurrency]
@@ -445,4 +445,14 @@ func quantityJitter2(q, maxJitterQ fixedpoint.Value) fixedpoint.Value {
 	rg := maxJitterQ.Sub(q).Float64()
 	randQuantity := fixedpoint.NewFromFloat(q.Float64() + rg*rand.Float64())
 	return randQuantity
+}
+
+func adjustPrice(price fixedpoint.Value, pricePrecision int) fixedpoint.Value {
+	if pricePrecision <= 0 {
+		return price
+	}
+	rate := math.Pow(10, float64(-pricePrecision))*0.1 + 1
+	priceAdjusted := util.RoundAndTruncatePrice(price.Mul(fixedpoint.NewFromFloat(rate)), pricePrecision)
+	log.Infof("adjusted price: %s -> %s", price.String(), priceAdjusted.String())
+	return priceAdjusted
 }

--- a/pkg/strategy/xgap/strategy.go
+++ b/pkg/strategy/xgap/strategy.go
@@ -453,7 +453,7 @@ func adjustPrice(price fixedpoint.Value, pricePrecision int) fixedpoint.Value {
 	if pricePrecision <= 0 {
 		return price
 	}
-	rate := math.Pow(10, float64(-pricePrecision))*0.1 + 1
-	priceAdjusted := util.RoundAndTruncatePrice(price.Mul(fixedpoint.NewFromFloat(rate)), pricePrecision)
+
+	priceAdjusted := util.RoundAndTruncatePrice(price, pricePrecision)
 	return priceAdjusted
 }

--- a/pkg/strategy/xgap/strategy_test.go
+++ b/pkg/strategy/xgap/strategy_test.go
@@ -1,0 +1,42 @@
+package xgap
+
+import (
+	"testing"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_AdjustPrice(t *testing.T) {
+	type args struct {
+		p    fixedpoint.Value
+		prec int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "basic",
+			args: args{p: fixedpoint.MustNewFromString("0.32179999"), prec: 4},
+			want: "0.3218",
+		},
+		{
+			name: "adjust",
+			args: args{p: fixedpoint.MustNewFromString("0.32148"), prec: 4},
+			want: "0.3214",
+		},
+		{
+			name: "adjust2",
+			args: args{p: fixedpoint.MustNewFromString("0.321600"), prec: 4},
+			want: "0.3216",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rst := adjustPrice(tt.args.p, tt.args.prec)
+			assert.Equalf(t, tt.want, rst.String(), "AdjustPrice(%v, %v)", tt.args.p, tt.args.prec)
+		})
+	}
+}

--- a/pkg/strategy/xgap/strategy_test.go
+++ b/pkg/strategy/xgap/strategy_test.go
@@ -32,11 +32,16 @@ func Test_AdjustPrice(t *testing.T) {
 			args: args{p: fixedpoint.MustNewFromString("0.321600"), prec: 4},
 			want: "0.3216",
 		},
+		{
+			name: "negPrecision",
+			args: args{p: fixedpoint.MustNewFromString("0.3213333"), prec: -1},
+			want: "0.3213333",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rst := adjustPrice(tt.args.p, tt.args.prec)
-			assert.Equalf(t, tt.want, rst.String(), "AdjustPrice(%v, %v)", tt.args.p, tt.args.prec)
+			assert.Equalf(t, tt.want, rst.String(), "adjustPrice(%v, %v)", tt.args.p, tt.args.prec)
 		})
 	}
 }

--- a/pkg/util/round_precision.go
+++ b/pkg/util/round_precision.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+)
+
+// RoundAndTruncatePrice rounds the given price at prec-1 and then truncate the price at prec
+func RoundAndTruncatePrice(p fixedpoint.Value, prec int) fixedpoint.Value {
+	var pow10 = math.Pow10(prec)
+	pp := math.Round(p.Float64()*pow10*10.0) / 10.0
+	pp = math.Trunc(pp) / pow10
+
+	pps := strconv.FormatFloat(pp, 'f', prec, 64)
+	price := fixedpoint.MustNewFromString(pps)
+	return price
+}

--- a/pkg/util/round_precision_test.go
+++ b/pkg/util/round_precision_test.go
@@ -4,25 +4,11 @@ import (
 	"testing"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/testing/testhelper"
 	"github.com/stretchr/testify/assert"
 )
 
-func number(a interface{}) fixedpoint.Value {
-	switch v := a.(type) {
-	case string:
-		return fixedpoint.MustNewFromString(v)
-	case int:
-		return fixedpoint.NewFromInt(int64(v))
-	case int64:
-		return fixedpoint.NewFromInt(int64(v))
-	case float64:
-		return fixedpoint.NewFromFloat(v)
-	}
-
-	return fixedpoint.Zero
-}
-
-func Test_RoundPrice(t *testing.T) {
+func Test_RoundAndTruncatePrice(t *testing.T) {
 	type args struct {
 		p    fixedpoint.Value
 		prec int
@@ -34,17 +20,17 @@ func Test_RoundPrice(t *testing.T) {
 	}{
 		{
 			name: "basic",
-			args: args{p: number("31.2222"), prec: 3},
+			args: args{p: testhelper.Number("31.2222"), prec: 3},
 			want: "31.222",
 		},
 		{
 			name: "roundup",
-			args: args{p: number("31.22295"), prec: 3},
+			args: args{p: testhelper.Number("31.22295"), prec: 3},
 			want: "31.223",
 		},
 		{
 			name: "roundup2",
-			args: args{p: number("31.22290"), prec: 3},
+			args: args{p: testhelper.Number("31.22290"), prec: 3},
 			want: "31.222",
 		},
 	}

--- a/pkg/util/round_precision_test.go
+++ b/pkg/util/round_precision_test.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/stretchr/testify/assert"
+)
+
+func number(a interface{}) fixedpoint.Value {
+	switch v := a.(type) {
+	case string:
+		return fixedpoint.MustNewFromString(v)
+	case int:
+		return fixedpoint.NewFromInt(int64(v))
+	case int64:
+		return fixedpoint.NewFromInt(int64(v))
+	case float64:
+		return fixedpoint.NewFromFloat(v)
+	}
+
+	return fixedpoint.Zero
+}
+
+func Test_RoundPrice(t *testing.T) {
+	type args struct {
+		p    fixedpoint.Value
+		prec int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "basic",
+			args: args{p: number("31.2222"), prec: 3},
+			want: "31.222",
+		},
+		{
+			name: "roundup",
+			args: args{p: number("31.22295"), prec: 3},
+			want: "31.223",
+		},
+		{
+			name: "roundup2",
+			args: args{p: number("31.22290"), prec: 3},
+			want: "31.222",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rst := RoundAndTruncatePrice(tt.args.p, tt.args.prec)
+			assert.Equalf(t, tt.want, rst.String(), "RoundAndTruncatePrice(%v, %v)", tt.args.p, tt.args.prec)
+		})
+	}
+}


### PR DESCRIPTION
- refactor: move and export `roundAndTruncatePrice` in `grid` strategy
- round and truncate price for `xgap`