### PR TITLE
REFACTOR: [coinbase] Revise User/Market data stream connection logic

### DIFF
--- a/pkg/exchange/coinbase/stream.go
+++ b/pkg/exchange/coinbase/stream.go
@@ -21,6 +21,12 @@ var logStream = logrus.WithFields(logrus.Fields{
 	"module":   "stream",
 })
 
+var (
+	// interface implementations compile-time check
+	_ types.PrivateChannelSymbolSetter = (*Stream)(nil)
+	_ types.Stream                     = (*Stream)(nil)
+)
+
 //go:generate callbackgen -type Stream
 type Stream struct {
 	types.StandardStream
@@ -54,6 +60,8 @@ type Stream struct {
 
 	lockWorkingOrderMap sync.Mutex // lock to protect lastOrderMap
 	workingOrdersMap    map[string]types.Order
+
+	privateChannelSymbols []string
 }
 
 func NewStream(
@@ -93,6 +101,11 @@ func NewStream(
 	s.OnConnect(s.handleConnect)
 	s.OnDisconnect(s.handleDisconnect)
 	return &s
+}
+
+// types.PrivateChannelSymbolSetter
+func (s *Stream) SetPrivateChannelSymbols(symbols []string) {
+	s.privateChannelSymbols = symbols
 }
 
 func logSubscriptions(m *SubscriptionsMessage) {


### PR DESCRIPTION
Revise the logic of handlers for user/market data stream
- A user data stream will by default subscribe to `user` channel and receive user order related events
- Implement `PrivateChannelSymbolSetter` for a user data stream
   - The symbols to be subscribed for a user data stream is controlled by `privateChannelSymbols`.
- Only query account balances for a user data stream