### PR TITLE
FIX: [okex] Correct RestBaseURL by removing trailing slash and add logging for client creation

### DIFF
--- a/pkg/exchange/okex/exchange.go
+++ b/pkg/exchange/okex/exchange.go
@@ -96,6 +96,7 @@ func WithBrokerId(id string) Option {
 
 func New(key, secret, passphrase string, opts ...Option) *Exchange {
 	client := okexapi.NewClient()
+	log.Infof("creating new okex rest client with base url: %s", okexapi.RestBaseURL)
 
 	if len(key) > 0 && len(secret) > 0 {
 		client.Auth(key, secret, passphrase)

--- a/pkg/exchange/okex/okexapi/client.go
+++ b/pkg/exchange/okex/okexapi/client.go
@@ -21,7 +21,7 @@ import (
 )
 
 const defaultHTTPTimeout = time.Second * 15
-const RestBaseURL = "https://www.okx.com/"
+const RestBaseURL = "https://www.okx.com"
 const PublicWebSocketURL = "wss://ws.okx.com:8443/ws/v5/public"
 const PrivateWebSocketURL = "wss://ws.okx.com:8443/ws/v5/private"
 const PublicBusinessWebSocketURL = "wss://ws.okx.com:8443/ws/v5/business"


### PR DESCRIPTION
Ref: https://www.okx.com/docs-v5/en/#overview-account-mode