### PR TITLE
REFACTOR: [strategy] Logging - Set report caller to true for better debugging

### DIFF
--- a/pkg/strategy/atrpin/strategy.go
+++ b/pkg/strategy/atrpin/strategy.go
@@ -48,10 +48,12 @@ func (s *Strategy) Initialize() error {
 		s.Strategy = &common.Strategy{}
 	}
 
-	s.logger = log.WithFields(logrus.Fields{
+	logger := log.WithFields(logrus.Fields{
 		"symbol": s.Symbol,
 		"window": s.Window,
 	})
+	logger.Logger.SetReportCaller(true)
+	s.logger = logger
 	return nil
 }
 

--- a/pkg/strategy/autoborrow/strategy.go
+++ b/pkg/strategy/autoborrow/strategy.go
@@ -94,9 +94,11 @@ func (s *Strategy) ID() string {
 }
 
 func (s *Strategy) Initialize() error {
-	s.logger = logrus.WithFields(logrus.Fields{
+	logger := logrus.WithFields(logrus.Fields{
 		"strategy": ID,
 	})
+	logger.Logger.SetReportCaller(true)
+	s.logger = logger
 	return nil
 }
 
@@ -595,10 +597,12 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 
 	s.ExchangeSession = session
 
-	s.logger = logrus.WithFields(logrus.Fields{
+	logger := logrus.WithFields(logrus.Fields{
 		"strategy": ID,
 		"exchange": s.ExchangeSession.Name,
 	})
+	logger.Logger.SetReportCaller(true)
+	s.logger = logger
 
 	if !session.Margin {
 		log.Warnf("session %s is not margin enabled, skip autoborrow strategy", session.Name)

--- a/pkg/strategy/dca2/strategy.go
+++ b/pkg/strategy/dca2/strategy.go
@@ -133,6 +133,7 @@ func (s *Strategy) Defaults() error {
 
 func (s *Strategy) Initialize() error {
 	s.logger = log.WithFields(s.LogFields)
+	s.logger.Logger.SetReportCaller(true)
 	return nil
 }
 

--- a/pkg/strategy/deposit2transfer/strategy.go
+++ b/pkg/strategy/deposit2transfer/strategy.go
@@ -101,7 +101,9 @@ func (s *Strategy) Defaults() error {
 
 func (s *Strategy) Initialize() error {
 	if s.logger == nil {
-		s.logger = log.Dup()
+		logger := log.Dup()
+		logger.Logger.SetReportCaller(true)
+		s.logger = logger
 	}
 
 	return nil
@@ -119,7 +121,9 @@ func (s *Strategy) Run(ctx context.Context, orderExecutor bbgo.OrderExecutor, se
 	s.session = session
 	s.watchingDeposits = make(map[string]types.Deposit)
 	s.lastAssetDepositTimes = make(map[string]time.Time)
-	s.logger = s.logger.WithField("exchange", session.ExchangeName)
+	logger := s.logger.WithField("exchange", session.ExchangeName)
+	logger.Logger.SetReportCaller(true)
+	s.logger = logger
 
 	var ok bool
 

--- a/pkg/strategy/grid2/strategy.go
+++ b/pkg/strategy/grid2/strategy.go
@@ -254,6 +254,7 @@ func (s *Strategy) Defaults() error {
 func (s *Strategy) Initialize() error {
 	s.filledOrderIDMap = types.NewSyncOrderMap()
 	s.logger = log.WithFields(s.LogFields)
+	s.logger.Logger.SetReportCaller(true)
 	return nil
 }
 

--- a/pkg/strategy/liquiditymaker/generator.go
+++ b/pkg/strategy/liquiditymaker/generator.go
@@ -43,6 +43,7 @@ func (g *LiquidityOrderGenerator) Generate(
 	if g.logger == nil {
 		logger := log.New()
 		logger.SetLevel(log.ErrorLevel)
+		logger.SetReportCaller(true)
 		g.logger = logger
 	}
 

--- a/pkg/strategy/liquiditymaker/strategy.go
+++ b/pkg/strategy/liquiditymaker/strategy.go
@@ -151,12 +151,13 @@ func (s *Strategy) Initialize() error {
 	if s.Strategy == nil {
 		s.Strategy = &common.Strategy{}
 	}
-
-	s.logger = log.WithFields(log.Fields{
+	logger := log.WithFields(log.Fields{
 		"symbol":      s.Symbol,
 		"strategy":    ID,
 		"strategy_id": s.InstanceID(),
 	})
+	logger.Logger.SetReportCaller(true)
+	s.logger = logger
 
 	s.metricsLabels = prometheus.Labels{
 		"strategy_type": ID,

--- a/pkg/strategy/xalign/strategy.go
+++ b/pkg/strategy/xalign/strategy.go
@@ -27,6 +27,7 @@ var log = logrus.WithField("strategy", ID)
 
 func init() {
 	bbgo.RegisterStrategy(ID, &Strategy{})
+	log.Logger.SetReportCaller(true)
 }
 
 type QuoteCurrencyPreference struct {

--- a/pkg/strategy/xdepthmaker/strategy.go
+++ b/pkg/strategy/xdepthmaker/strategy.go
@@ -322,11 +322,13 @@ func (s *Strategy) Initialize() error {
 
 	s.bidPriceHeartBeat = types.NewPriceHeartBeat(priceUpdateTimeout)
 	s.askPriceHeartBeat = types.NewPriceHeartBeat(priceUpdateTimeout)
-	s.logger = log.WithFields(logrus.Fields{
+	logger := log.WithFields(logrus.Fields{
 		"symbol":            s.Symbol,
 		"strategy":          ID,
 		"strategy_instance": s.InstanceID(),
 	})
+	logger.Logger.SetReportCaller(true)
+	s.logger = logger
 
 	return nil
 }

--- a/pkg/strategy/xgap/strategy.go
+++ b/pkg/strategy/xgap/strategy.go
@@ -89,12 +89,13 @@ func (s *Strategy) Initialize() error {
 	if s.FeeBudget == nil {
 		s.FeeBudget = &common.FeeBudget{}
 	}
-
-	s.logger = logrus.WithFields(logrus.Fields{
+	logger := logrus.WithFields(logrus.Fields{
 		"strategy":          ID,
 		"strategy_instance": s.InstanceID(),
 		"symbol":            s.Symbol,
 	})
+	logger.Logger.SetReportCaller(true)
+	s.logger = logger
 	return nil
 }
 

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -342,13 +342,15 @@ func aggregatePrice(pvs types.PriceVolumeSlice, requiredQuantity fixedpoint.Valu
 func (s *Strategy) Initialize() error {
 	s.bidPriceHeartBeat = types.NewPriceHeartBeat(priceUpdateTimeout)
 	s.askPriceHeartBeat = types.NewPriceHeartBeat(priceUpdateTimeout)
-	s.logger = logrus.WithFields(
+	logger := logrus.WithFields(
 		logrus.Fields{
 			"symbol":      s.Symbol,
 			"strategy":    ID,
 			"strategy_id": s.InstanceID(),
 		},
 	)
+	logger.Logger.SetReportCaller(true)
+	s.logger = logger
 
 	s.metricsLabels = prometheus.Labels{
 		"strategy_type": ID,


### PR DESCRIPTION
By setting `.SetReportCaller(true)`, the logging message become as following screenshots:
![截圖 2025-04-23 晚上10 49 56](https://github.com/user-attachments/assets/4b758ec3-c5c1-4356-a717-b7c8f333bbc2)
![截圖 2025-04-23 晚上10 50 15](https://github.com/user-attachments/assets/8bb9adda-d4b0-4f30-98a5-71a947f34cce)

In this way, I believe it's easier to locate the bugs.