### PR TITLE
FIX: [SerialMarketDataStore] Add symbol check in handleMarketTrade to ensure correct trade processing

### DIFF
--- a/pkg/bbgo/serialmarketdatastore.go
+++ b/pkg/bbgo/serialmarketdatastore.go
@@ -62,6 +62,11 @@ func (store *SerialMarketDataStore) handleKLineClosed(kline types.KLine) {
 }
 
 func (store *SerialMarketDataStore) handleMarketTrade(trade types.Trade) {
+	// the market data stream may subscribe to trades of multiple symbols
+	// so we need to check if the trade is for the symbol we are interested in
+	if trade.Symbol != store.Symbol {
+		return
+	}
 	store.mu.Lock()
 	store.price = trade.Price
 	store.c = store.price


### PR DESCRIPTION
The market data stream may subscribe to multiple symbols at once.
Hence, we should filter on the trade feeds before we update the  data store.