### PR TITLE
FIX: [binance] apply new ws endpoint and use ed25519 authentication for spot trading

### DIFF
--- a/config/binance-futures.yaml
+++ b/config/binance-futures.yaml
@@ -1,0 +1,18 @@
+---
+sessions:
+  # spot
+  binance:
+    exchange: binance
+
+  # cross margin futures
+  binance_futures:
+    exchange: binance
+    futures: true
+
+exchangeStrategies:
+
+- on: binance_futures
+  dummy:
+    symbol: LINKUSDT
+    interval: 1m
+

--- a/config/binance-margin.yaml
+++ b/config/binance-margin.yaml
@@ -1,5 +1,10 @@
 ---
 sessions:
+  # spot
+  binance:
+    exchange: binance
+    margin: true
+
   # cross margin
   binance_margin:
     exchange: binance

--- a/config/binance-margin.yaml
+++ b/config/binance-margin.yaml
@@ -3,7 +3,6 @@ sessions:
   # spot
   binance:
     exchange: binance
-    margin: true
 
   # cross margin
   binance_margin:

--- a/pkg/bbgo/session.go
+++ b/pkg/bbgo/session.go
@@ -915,10 +915,10 @@ func (session *ExchangeSession) newBasicPrivateExchange(exchangeName types.Excha
 	var err error
 	var exMinimal types.ExchangeMinimal
 	if session.Key != "" && session.Secret != "" {
-		options := exchange2.ExchangeOptions{
-			exchange2.ExchangeOptionsKeyAPIKey:        session.Key,
-			exchange2.ExchangeOptionsKeyAPISecret:     session.Secret,
-			exchange2.ExchangeOptionsKeyAPIPassphrase: session.Passphrase,
+		options := exchange2.Options{
+			exchange2.OptionKeyAPIKey:        session.Key,
+			exchange2.OptionKeyAPISecret:     session.Secret,
+			exchange2.OptionKeyAPIPassphrase: session.Passphrase,
 		}
 		exMinimal, err = exchange2.New(exchangeName, options)
 	} else {

--- a/pkg/cmd/userdatastream.go
+++ b/pkg/cmd/userdatastream.go
@@ -53,12 +53,13 @@ var userDataStreamCmd = &cobra.Command{
 			log.Infof("[balanceSnapshot] %+v", trade)
 		})
 
-		log.Infof("connecting...")
+		log.Infof("connecting user data stream...")
 		if err := s.Connect(ctx); err != nil {
 			return fmt.Errorf("failed to connect to %s", sessionName)
 		}
 
-		log.Infof("connected")
+		log.Infof("user data stream connected")
+
 		defer func() {
 			log.Infof("closing connection...")
 			if err := s.Close(); err != nil {

--- a/pkg/exchange/binance/binanceapi/client.go
+++ b/pkg/exchange/binance/binanceapi/client.go
@@ -172,17 +172,12 @@ func (c *RestClient) NewAuthenticatedRequest(
 func (c *RestClient) newAuthenticatedRequest(
 	ctx context.Context, method, refURL string, params url.Values, payload interface{}, signFunc func(string) string,
 ) (*http.Request, error) {
-	if c.IsUsingEd25519Auth() {
-		// Ed25519 authentication
-		if len(c.PrivateKey) == 0 {
-			return nil, errEmptyPrivateKey
-		}
-	} else {
-		// HMAC authentication
-		if len(c.Key) == 0 {
-			return nil, errNoApiKey
-		}
+	if len(c.Key) == 0 {
+		return nil, errNoApiKey
+	}
 
+	if !c.IsUsingEd25519Auth() {
+		// using HMAC authentication
 		if len(c.Secret) == 0 {
 			return nil, errNoApiSecret
 		}

--- a/pkg/exchange/binance/binanceapi/client.go
+++ b/pkg/exchange/binance/binanceapi/client.go
@@ -94,7 +94,7 @@ func (c *RestClient) Auth(key, secret string, privateKey ed25519.PrivateKey) {
 }
 
 func (c *RestClient) IsUsingEd25519Auth() bool {
-	return c.PrivateKey == nil
+	return len(c.PrivateKey) > 0
 }
 
 // NewRequest create new API request. Relative url can be provided in refURL.

--- a/pkg/exchange/binance/binanceapi/client_test.go
+++ b/pkg/exchange/binance/binanceapi/client_test.go
@@ -27,7 +27,7 @@ func getTestClientOrSkip(t *testing.T) *RestClient {
 	}
 
 	client := NewClient("")
-	client.Auth(key, secret)
+	client.Auth(key, secret, nil)
 	return client
 }
 
@@ -141,7 +141,7 @@ func TestClient_privateCall(t *testing.T) {
 	}
 
 	client := NewClient("")
-	client.Auth(key, secret)
+	client.Auth(key, secret, nil)
 
 	ctx := context.Background()
 

--- a/pkg/exchange/binance/binanceapi/util.go
+++ b/pkg/exchange/binance/binanceapi/util.go
@@ -6,8 +6,8 @@ import (
 )
 
 // GenerateSignatureEd25519 generates a signature for the given string with the provided private key.
-func GenerateSignatureEd25519(paramString string, privateKey ed25519.PrivateKey) string {
-	signatureBytes := ed25519.Sign(privateKey, []byte(paramString))
+func GenerateSignatureEd25519(content string, privateKey ed25519.PrivateKey) string {
+	signatureBytes := ed25519.Sign(privateKey, []byte(content))
 	signature := base64.StdEncoding.EncodeToString(signatureBytes)
 	return signature
 }

--- a/pkg/exchange/binance/binanceapi/util.go
+++ b/pkg/exchange/binance/binanceapi/util.go
@@ -1,0 +1,13 @@
+package binanceapi
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+)
+
+// GenerateSignatureEd25519 generates a signature for the given string with the provided private key.
+func GenerateSignatureEd25519(paramString string, privateKey ed25519.PrivateKey) string {
+	signatureBytes := ed25519.Sign(privateKey, []byte(paramString))
+	signature := base64.StdEncoding.EncodeToString(signatureBytes)
+	return signature
+}

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -71,10 +71,6 @@ var log = logrus.WithFields(logrus.Fields{
 
 var debug func(string, ...any)
 
-func debugLog(msg string, args ...any) {
-	log.Infof("BINANCE_DEBUG: "+msg, args...)
-}
-
 func debugDummy(msg string, args ...any) {}
 
 func init() {
@@ -84,7 +80,7 @@ func init() {
 
 	if v, ok := envvar.Bool("DEBUG_BINANCE", false); ok {
 		debugMode = v
-		debug = debugLog
+		debug = log.Infof
 	} else {
 		debug = debugDummy
 	}

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -146,8 +146,9 @@ func New(key, secret string, args ...string) *Exchange {
 	if len(args) > 0 && len(args[0]) > 0 {
 		// override the global private key with args[0] is provided
 		if len(ed25519PKeyPEM) > 0 {
-			log.Warnf("binance exchange: ed25519 private key is set in both env and args, using args[0] instead")
+			debug("binance exchange: ed25519 private key is set in both env and args, using args[0] instead")
 		}
+
 		ed25519PKeyPEM = args[0]
 	}
 
@@ -164,7 +165,7 @@ func New(key, secret string, args ...string) *Exchange {
 	// if parse is successful, we will use ed25519 auth
 	ed25519Auth := len(ed25519PKeyPEM) > 0 && len(ed25519PrivateKey) > 0 && err == nil
 	if ed25519Auth {
-		log.Info("binance exchange: using ed25519 private key for authentication")
+		debug("binance exchange: using ed25519 private key for authentication")
 	}
 
 	var client = binance.NewClient(key, secret)

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -61,8 +61,6 @@ var queryTradeLimiter = rate.NewLimiter(1, 2)
 
 var dualSidePosition = false
 
-var wsApiWebsocketUrl string
-
 var testNet = false
 
 var debugMode = false

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -110,7 +110,7 @@ func (e *ed25519authentication) getEd25519PrivateKey() ed25519.PrivateKey {
 	return e.privateKey
 }
 
-func (e *ed25519authentication) getEd25519Auth() bool {
+func (e *ed25519authentication) isUsingEd25519Auth() bool {
 	return e.usingEd25519
 }
 

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -35,16 +35,22 @@ const DefaultDepthLimit = 5000
 const BinanceUSBaseURL = "https://api.binance.us"
 const BinanceTestBaseURL = "https://testnet.binance.vision"
 const BinanceUSWebSocketURL = "wss://stream.binance.us:9443"
-const WebSocketURL = "wss://stream.binance.com:9443"
-const WebSocketTestURL = "wss://testnet.binance.vision"
-const FutureTestBaseURL = "https://testnet.binancefuture.com"
-const FuturesWebSocketURL = "wss://fstream.binance.com"
-const FuturesWebSocketTestURL = "wss://stream.binancefuture.com"
 
-// WebSocket API
+const WebSocketURL = "wss://stream.binance.com:9443"
+const FuturesWebSocketURL = "wss://fstream.binance.com"
+const TestNetFuturesWebSocketURL = "wss://stream.binancefuture.com"
+
+// TestNet URLs
+const TestNetWebSocketURL = "wss://testnet.binance.vision"
+const TestNetFuturesBaseURL = "https://testnet.binancefuture.com"
+
+// New WebSocket API Endpoints
 // listenKey will be deprecated. Official recommendation is to use ws-api for user data stream
-const WsApiWebSocketURL = "wss://ws-api.binance.com:443/ws-api/v3"
-const WsApiWebSocketTestURL = "wss://testnet.binance.vision/ws-api/v3"
+const WsSpotWebSocketURL = "wss://ws-api.binance.com:443/ws-api/v3"
+const WsTestNetWebSocketURL = "wss://testnet.binance.vision/ws-api/v3"
+
+const WsFuturesWebSocketURL = "wss://ws-fapi.binance.com/ws-fapi/v1"
+const WsTestNetFuturesWebSocketURL = "wss://testnet.binancefuture.com/ws-fapi/v1"
 
 // orderLimiter - the default order limiter apply 5 requests per second and a 2 initial bucket
 // this includes SubmitOrder, CancelOrder and QueryClosedOrders
@@ -54,7 +60,10 @@ var orderLimiter = rate.NewLimiter(5, 2)
 var queryTradeLimiter = rate.NewLimiter(1, 2)
 
 var dualSidePosition = false
+
 var wsApiWebsocketUrl string
+
+var testNet = false
 
 var debugMode = false
 
@@ -93,12 +102,8 @@ func init() {
 	if val, ok := envvar.Bool("BINANCE_ENABLE_FUTURES_HEDGE_MODE"); ok {
 		dualSidePosition = val
 	}
-	testNet, _ := envvar.Bool("BINANCE_TESTNET", false)
-	if testNet {
-		wsApiWebsocketUrl = WsApiWebSocketTestURL
-	} else {
-		wsApiWebsocketUrl = WsApiWebSocketURL
-	}
+
+	testNet, _ = envvar.Bool("BINANCE_TESTNET", false)
 }
 
 func isBinanceUs() bool {

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -106,14 +106,6 @@ type ed25519authentication struct {
 	usingEd25519 bool
 }
 
-func (e *ed25519authentication) getEd25519PrivateKey() ed25519.PrivateKey {
-	return e.privateKey
-}
-
-func (e *ed25519authentication) isUsingEd25519Auth() bool {
-	return e.usingEd25519
-}
-
 type Exchange struct {
 	types.MarginSettings
 	types.FuturesSettings

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -69,9 +69,9 @@ var log = logrus.WithFields(logrus.Fields{
 	"exchange": "binance",
 })
 
-var debug func(string, ...any)
-
 func debugDummy(msg string, args ...any) {}
+
+var debug = debugDummy
 
 func init() {
 	_ = types.Exchange(&Exchange{})
@@ -81,8 +81,6 @@ func init() {
 	if v, ok := envvar.Bool("DEBUG_BINANCE", false); ok {
 		debugMode = v
 		debug = log.Infof
-	} else {
-		debug = debugDummy
 	}
 
 	if n, ok := envvar.Int("BINANCE_ORDER_RATE_LIMITER"); ok {

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -93,10 +93,7 @@ func init() {
 		queryTradeLimiter = rate.NewLimiter(rate.Every(time.Duration(n)*time.Minute), 2)
 	}
 
-	if val, ok := envvar.Bool("BINANCE_ENABLE_FUTURES_HEDGE_MODE"); ok {
-		dualSidePosition = val
-	}
-
+	dualSidePosition, _ = envvar.Bool("BINANCE_ENABLE_FUTURES_HEDGE_MODE", false)
 	testNet, _ = envvar.Bool("BINANCE_TESTNET", false)
 }
 

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -149,9 +149,12 @@ func New(key, secret string) *Exchange {
 		futuresClient2:    futuresClient2,
 	}
 
-	if len(key) > 0 && len(secret) > 0 {
-		client2.Auth(key, secret)
-		futuresClient2.Auth(key, secret)
+	if ed25519Auth {
+		client2.Auth(key, secret, ed25519PrivateKey)
+		futuresClient2.Auth(key, secret, ed25519PrivateKey)
+	} else if len(key) > 0 && len(secret) > 0 {
+		client2.Auth(key, secret, nil)
+		futuresClient2.Auth(key, secret, nil)
 	}
 
 	ctx := context.Background()

--- a/pkg/exchange/binance/futures.go
+++ b/pkg/exchange/binance/futures.go
@@ -96,7 +96,7 @@ func (e *Exchange) QueryFuturesAccount(ctx context.Context) (*types.Account, err
 
 	a := &types.Account{
 		AccountType: types.AccountTypeFutures,
-		FuturesInfo: toGlobalFuturesAccountInfo(account), // In binance GO api, Account define account info which mantain []*AccountAsset and []*AccountPosition.
+		FuturesInfo: toGlobalFuturesAccountInfo(account), // In binance GO api, Account define account info which maintain []*AccountAsset and []*AccountPosition.
 		CanDeposit:  account.CanDeposit,                  // if can transfer in asset
 		CanTrade:    account.CanTrade,                    // if can trade
 		CanWithdraw: account.CanWithdraw,                 // if can transfer out asset

--- a/pkg/exchange/binance/parse.go
+++ b/pkg/exchange/binance/parse.go
@@ -356,10 +356,10 @@ func parseWebSocketEvent(message []byte) (interface{}, error) {
 			eventType = EventTypeBookTicker
 		} else if isPartialDepth(val) {
 			eventType = EventTypePartialDepth
-		}
-	} else {
-		errVal := val.Get("error")
-		if errVal != nil {
+		} else if eventWrapper := val.Get("event"); eventWrapper != nil {
+			eventType = string(eventWrapper.GetStringBytes("e"))
+			message = val.Get("event").MarshalTo(nil)
+		} else if errVal := val.Get("error"); errVal != nil {
 			eventType = EventTypeError
 		}
 	}

--- a/pkg/exchange/binance/stream.go
+++ b/pkg/exchange/binance/stream.go
@@ -251,14 +251,14 @@ func (s *Stream) writeSubscriptions() error {
 		return nil
 	}
 
+	// TODO: handle subscribe response
+	// sample response: {"result":null,"id":2}
 	log.Infof("subscribing channels: %+v", params)
-	err := s.Conn.WriteJSON(&WebSocketCommand{
+	return s.Conn.WriteJSON(&WebSocketCommand{
 		Method: "SUBSCRIBE",
 		Params: params,
 		ID:     2,
 	})
-
-	return err
 }
 
 func (s *Stream) handleContinuousKLineEvent(e *ContinuousKLineEvent) {

--- a/pkg/exchange/binance/stream_callbacks.go
+++ b/pkg/exchange/binance/stream_callbacks.go
@@ -194,6 +194,16 @@ func (s *Stream) EmitListenKeyExpired(e *ListenKeyExpired) {
 	}
 }
 
+func (s *Stream) OnError(cb func(e *ErrorEvent)) {
+	s.errorCallbacks = append(s.errorCallbacks, cb)
+}
+
+func (s *Stream) EmitError(e *ErrorEvent) {
+	for _, cb := range s.errorCallbacks {
+		cb(e)
+	}
+}
+
 type StreamEventHub interface {
 	OnDepthEvent(cb func(e *DepthEvent))
 
@@ -232,4 +242,6 @@ type StreamEventHub interface {
 	OnMarginCallEvent(cb func(e *MarginCallEvent))
 
 	OnListenKeyExpired(cb func(e *ListenKeyExpired))
+
+	OnError(cb func(e *ErrorEvent))
 }

--- a/pkg/types/stream.go
+++ b/pkg/types/stream.go
@@ -500,7 +500,12 @@ func (s *StandardStream) Dial(ctx context.Context, args ...string) (*websocket.C
 		return nil
 	})
 
-	log.Infof("[websocket] connected, public = %v, read timeout = %v", s.PublicOnly, readTimeout)
+	if s.PublicOnly {
+		log.Infof("[websocket] public stream connected, read timeout = %v", readTimeout)
+	} else {
+		log.Infof("[websocket] user data stream connected, read timeout = %v", readTimeout)
+	}
+
 	return conn, nil
 }
 

--- a/pkg/types/stream.go
+++ b/pkg/types/stream.go
@@ -510,7 +510,11 @@ func (s *StandardStream) Dial(ctx context.Context, args ...string) (*websocket.C
 }
 
 func (s *StandardStream) Close() error {
-	log.Debugf("[websocket] closing stream...")
+	if s.PublicOnly {
+		log.Debugf("[websocket] closing public stream...")
+	} else {
+		log.Debugf("[websocket] closing user data stream...")
+	}
 
 	// close the close signal channel, so that reader and ping worker will stop
 	close(s.CloseC)

--- a/pkg/types/stream.go
+++ b/pkg/types/stream.go
@@ -539,6 +539,7 @@ func (s *StandardStream) Close() error {
 	log.Debugf("[websocket] stream closed")
 
 	// let the reader close the connection
+	// TODO: use signal channel instead
 	<-time.After(time.Second)
 	return nil
 }

--- a/pkg/util/ed25519.go
+++ b/pkg/util/ed25519.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+func ParseEd25519PrivateKey(pemString string) (ed25519.PrivateKey, error) {
+	if len(pemString) == 0 {
+		return nil, errors.New("empty PEM string")
+	}
+	block, _ := pem.Decode([]byte(pemString))
+	if block == nil {
+		return nil, errors.New("failed to parse PEM block containing the private key")
+	}
+
+	// Parse the private key
+	pkcs8Key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	privateKey, ok := pkcs8Key.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("not an ED25519 private key: %T given", pkcs8Key)
+	}
+	return privateKey, nil
+}

--- a/pkg/util/ed25519.go
+++ b/pkg/util/ed25519.go
@@ -10,8 +10,9 @@ import (
 
 func ParseEd25519PrivateKey(pemString string) (ed25519.PrivateKey, error) {
 	if len(pemString) == 0 {
-		return nil, errors.New("empty PEM string")
+		return nil, fmt.Errorf("unable to parse private key (PEM format), empty string given")
 	}
+
 	block, _ := pem.Decode([]byte(pemString))
 	if block == nil {
 		return nil, errors.New("failed to parse PEM block containing the private key")
@@ -22,9 +23,11 @@ func ParseEd25519PrivateKey(pemString string) (ed25519.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	privateKey, ok := pkcs8Key.(ed25519.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("not an ED25519 private key: %T given", pkcs8Key)
+		return nil, fmt.Errorf("not a valid ED25519 private key: %T given", pkcs8Key)
 	}
+
 	return privateKey, nil
 }


### PR DESCRIPTION
`listenKey` is deprecated:
https://developers.binance.com/docs/binance-spot-api-docs/CHANGELOG#user-data-streams