### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/bbgo/exit_hh_ll_stop.go
+++ b/pkg/bbgo/exit_hh_ll_stop.go
@@ -157,10 +157,7 @@ func (s *HigherHighLowerLowStop) updateHighLowNumber(kline types.KLine) {
 		// Truncate highLows
 		if len(s.highLows) > s.HighLowWindow {
 			end := len(s.highLows)
-			start := end - s.HighLowWindow
-			if start < 0 {
-				start = 0
-			}
+			start := max(end-s.HighLowWindow, 0)
 			kn := s.highLows[start:]
 			s.highLows = kn
 		}

--- a/pkg/exchange/bitget/stream.go
+++ b/pkg/exchange/bitget/stream.go
@@ -91,10 +91,7 @@ func (s *Stream) syncSubscriptions(opType WsEventType) error {
 	batchSize := 10
 	lenArgs := len(args)
 	for begin := 0; begin < lenArgs; begin += batchSize {
-		end := begin + batchSize
-		if end > lenArgs {
-			end = lenArgs
-		}
+		end := min(begin+batchSize, lenArgs)
 
 		if err := s.Conn.WriteJSON(WsOp{
 			Op:   opType,

--- a/pkg/exchange/bybit/stream.go
+++ b/pkg/exchange/bybit/stream.go
@@ -119,10 +119,7 @@ func (s *Stream) syncSubscriptions(opType WsOpType) error {
 	logger := log.WithField("opType", opType)
 	lens := len(s.Subscriptions)
 	for begin := 0; begin < lens; begin += spotArgsLimit {
-		end := begin + spotArgsLimit
-		if end > lens {
-			end = lens
-		}
+		end := min(begin+spotArgsLimit, lens)
 
 		topics := []string{}
 		for _, subscription := range s.Subscriptions[begin:end] {

--- a/pkg/migrations/mysql/migration_api.go
+++ b/pkg/migrations/mysql/migration_api.go
@@ -54,10 +54,7 @@ func AddMigration(packageName string, up, down rockhopper.TransactionHandler) {
 
 // parseFuncPackageName parses the package name from a given runtime caller function name
 func _parseFuncPackageName(funcName string) string {
-	lastSlash := strings.LastIndexByte(funcName, '/')
-	if lastSlash < 0 {
-		lastSlash = 0
-	}
+	lastSlash := max(strings.LastIndexByte(funcName, '/'), 0)
 
 	lastDot := strings.LastIndexByte(funcName[lastSlash:], '.') + lastSlash
 	packageName := funcName[:lastDot]

--- a/pkg/migrations/sqlite3/migration_api.go
+++ b/pkg/migrations/sqlite3/migration_api.go
@@ -54,10 +54,7 @@ func AddMigration(packageName string, up, down rockhopper.TransactionHandler) {
 
 // parseFuncPackageName parses the package name from a given runtime caller function name
 func _parseFuncPackageName(funcName string) string {
-	lastSlash := strings.LastIndexByte(funcName, '/')
-	if lastSlash < 0 {
-		lastSlash = 0
-	}
+	lastSlash := max(strings.LastIndexByte(funcName, '/'), 0)
 
 	lastDot := strings.LastIndexByte(funcName[lastSlash:], '.') + lastSlash
 	packageName := funcName[:lastDot]

--- a/pkg/optimizer/hpoptimizer.go
+++ b/pkg/optimizer/hpoptimizer.go
@@ -240,10 +240,7 @@ func (o *HyperparameterOptimizer) Run(ctx context.Context, executor Executor, co
 	objective := o.buildObjective(executor, configJson, paramDomains)
 
 	maxEvaluation := o.Config.MaxEvaluation
-	numOfProcesses := o.Config.Executor.LocalExecutorConfig.MaxNumberOfProcesses
-	if numOfProcesses > maxEvaluation {
-		numOfProcesses = maxEvaluation
-	}
+	numOfProcesses := min(o.Config.Executor.LocalExecutorConfig.MaxNumberOfProcesses, maxEvaluation)
 	maxEvaluationPerProcess := maxEvaluation / numOfProcesses
 	if maxEvaluation%numOfProcesses > 0 {
 		maxEvaluationPerProcess++
@@ -277,10 +274,7 @@ func (o *HyperparameterOptimizer) Run(ctx context.Context, executor Executor, co
 	eg, studyCtx := errgroup.WithContext(ctx)
 	study.WithContext(studyCtx)
 	for i := 0; i < numOfProcesses; i++ {
-		processEvaluations := maxEvaluationPerProcess
-		if processEvaluations > maxEvaluation {
-			processEvaluations = maxEvaluation
-		}
+		processEvaluations := min(maxEvaluationPerProcess, maxEvaluation)
 		eg.Go(func() error {
 			return study.Optimize(objective, processEvaluations)
 		})

--- a/pkg/strategy/drift/draw.go
+++ b/pkg/strategy/drift/draw.go
@@ -64,10 +64,7 @@ func (s *Strategy) InitDrawCommands(profit, cumProfit types.Series) {
 
 func (s *Strategy) DrawIndicators(time types.Time) *types.Canvas {
 	canvas := types.NewCanvas(s.InstanceID(), s.Interval)
-	length := s.priceLines.Length()
-	if length > 300 {
-		length = 300
-	}
+	length := min(s.priceLines.Length(), 300)
 	log.Infof("draw indicators with %d data", length)
 	mean := s.priceLines.Mean(length)
 	highestPrice := s.priceLines.Minus(mean).Abs().Highest(length)

--- a/pkg/strategy/elliottwave/draw.go
+++ b/pkg/strategy/elliottwave/draw.go
@@ -54,10 +54,7 @@ func (s *Strategy) InitDrawCommands(store *bbgo.SerialMarketDataStore, profit, c
 func (s *Strategy) DrawIndicators(store *bbgo.SerialMarketDataStore) *types.Canvas {
 	time := types.Time(s.startTime)
 	canvas := types.NewCanvas(s.InstanceID(), s.Interval)
-	Length := s.priceLines.Length()
-	if Length > 300 {
-		Length = 300
-	}
+	Length := min(s.priceLines.Length(), 300)
 	log.Infof("draw indicators with %d data", Length)
 	mean := s.priceLines.Mean(Length)
 	high := s.priceLines.Highest(Length)

--- a/pkg/types/kline.go
+++ b/pkg/types/kline.go
@@ -447,10 +447,7 @@ func (k *KLineWindow) Truncate(size int) {
 	}
 
 	end := len(*k)
-	start := end - size
-	if start < 0 {
-		start = 0
-	}
+	start := max(end-size, 0)
 	kn := (*k)[start:]
 	*k = kn
 }

--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -5,16 +5,12 @@ import (
 	"unicode/utf8"
 )
 
-
 func MaskKey(key string) string {
 	if len(key) == 0 {
 		return "{empty}"
 	}
 
-	h := len(key) / 3
-	if h > 5 {
-		h = 5
-	}
+	h := min(len(key)/3, 5)
 
 	maskKey := key[0:h]
 	maskKey += strings.Repeat("*", len(key)-h*2)


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.