### PR TITLE
improve Queue write speed

### DIFF
--- a/pkg/types/indicator_test.go
+++ b/pkg/types/indicator_test.go
@@ -19,6 +19,17 @@ func TestQueue(t *testing.T) {
 	assert.Equal(t, zeroq.Index(0), 0.)
 	zeroq.Update(1.)
 	assert.Equal(t, zeroq.Length(), 0)
+
+	q := NewQueue(10)
+	for i := 0; i < 10; i++ {
+		q.Update(float64(i))
+	}
+	assert.Equal(t, q.Last(0), 9.0)
+	assert.Equal(t, q.Last(1), 8.0)
+	assert.Equal(t, q.Last(2), 7.0)
+	assert.Equal(t, q.Last(10), 0.0)
+	assert.Equal(t, q.Last(11), 0.0)
+
 }
 
 func TestFloat(t *testing.T) {

--- a/pkg/types/queue_test.go
+++ b/pkg/types/queue_test.go
@@ -1,0 +1,95 @@
+package types
+
+import (
+	"testing"
+)
+
+type OldQueue struct {
+	SeriesBase
+	arr  []float64
+	size int
+}
+
+func (inc *OldQueue) Update(value float64) {
+	inc.arr = append(inc.arr, value)
+	if len(inc.arr) > inc.size {
+		inc.arr = inc.arr[len(inc.arr)-inc.size:]
+	}
+}
+
+func (inc *OldQueue) Last(i int) float64 {
+	if i < 0 || i >= len(inc.arr) {
+		return 0
+	}
+	return inc.arr[len(inc.arr)-1-i]
+}
+
+func BenchmarkQueue(b *testing.B) {
+	q := NewQueue(1000)
+	b.ResetTimer()
+	b.Run("bbgo-latest-queue", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			q.Update(float64(i))
+		}
+	})
+
+	o := &OldQueue{
+		arr:  make([]float64, 0, 1000),
+		size: 1000,
+	}
+	b.ResetTimer()
+	b.Run("bbgo-last-queue", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			o.Update(float64(i))
+		}
+	})
+
+}
+
+func BenchmarkLargeQueue(b *testing.B) {
+	q := NewQueue(200000)
+	b.ResetTimer()
+	b.Run("bbgo-latest-queue", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			q.Update(float64(i))
+		}
+	})
+
+	o := &OldQueue{
+		arr:  make([]float64, 0, 200000),
+		size: 200000,
+	}
+	b.ResetTimer()
+	b.Run("bbgo-last-queue", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			o.Update(float64(i))
+		}
+	})
+}
+
+func BenchmarkQueueLast(b *testing.B) {
+	q := NewQueue(1000)
+	b.Run("bbgo-latest-queue", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			q.Update(float64(i))
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			q.Last(i)
+		}
+	})
+
+	o := &OldQueue{
+		arr:  make([]float64, 0, 1000),
+		size: 1000,
+	}
+	b.Run("bbgo-last-queue", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			o.Update(float64(i))
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			o.Last(i)
+		}
+	})
+}


### PR DESCRIPTION
BenchmarkQueue/bbgo-latest-queue-4         	450343116	         2.594 ns/op	       0 B/op	       0 allocs/op
BenchmarkQueue/bbgo-last-queue-4           	140952798	         8.557 ns/op	      22 B/op	       0 allocs/op
BenchmarkQueueLast/bbgo-latest-queue-4     	1000000000	         0.8136 ns/op	       0 B/op	       0 allocs/op
BenchmarkQueueLast/bbgo-last-queue-4       	1000000000	         0.7814 ns/op	       0 B/op	       0 allocs/op
