### PR TITLE
feature: add Marked Hawkes Process implementation

### DIFF
--- a/pkg/analysis/hawkes.go
+++ b/pkg/analysis/hawkes.go
@@ -1,0 +1,112 @@
+package analysis
+
+import (
+	"math"
+)
+
+/*
+reference: https://hawkeslib.readthedocs.io/en/latest/tutorial.html
+
+Hawkes process is a self-exciting point process where the intensity of the process
+is influenced by past events. The intensity function can be defined as:
+	λ(t) = μ + ∑_{t_i < t} α * m(t_i) * exp(-β * (t - t_i) / τ)
+	where:
+	- λ(t) is the intensity at time t
+	- μ is the baseline intensity
+	- α is the excitation parameter
+	- m(t_i) is the mark function evaluated at time t_i
+	- β is the decay parameter
+	- τ is the time scale parameter
+The Hawkes process can be used to model various phenomena,
+such as financial transactions, earthquakes, or any event-driven processes
+where past events influence future occurrences.
+
+To get the optimized Hawkes model parameters from history,
+we need to maximize the log-likelihood function:
+
+```python
+from scipy.optimize import minimize
+
+initial_guess = [0.1, 0.01, 1.0]  # mu, alpha, beta
+result = minimize(log_likelihood, initial_guess, args=(history, T), method='L-BFGS-B',
+                  bounds=[(1e-6, None), (0.0, None), (1e-6, None)])
+```
+*/
+
+type TimedTuple struct {
+	Time   int64 // Time of the event
+	Params any
+}
+
+type MarkedHawkesProcess interface {
+	MarkFunction(params any) float64
+	GetAlpha() float64
+	GetBeta() float64
+	GetMu() float64
+	GetTimeScale() float64
+}
+
+func GetIntensity(m MarkedHawkesProcess, t int64, params []TimedTuple) float64 {
+	excitation := 0.0
+	alpha := m.GetAlpha()
+	beta := m.GetBeta()
+	mu := m.GetMu()
+	timeScale := m.GetTimeScale()
+
+	for _, tuple := range params {
+		ti := tuple.Time
+		param := tuple.Params
+		if ti < t {
+			excitation += alpha * m.MarkFunction(param) * math.Exp(
+				-beta*float64(t-ti)/timeScale)
+
+		}
+	}
+	return mu + excitation
+}
+
+type VolumePriceData struct {
+	Volume float64
+	Price  float64
+}
+
+// Implementation of MarkedHawkesProcess for volume and price data
+type MarkedHawkesProcessVP struct {
+	alpha     float64
+	beta      float64
+	mu        float64
+	timeScale float64
+}
+
+func NewMarkedHawkesProcessVP(mu, alpha, beta, timeScale float64) *MarkedHawkesProcessVP {
+	return &MarkedHawkesProcessVP{
+		alpha:     alpha,
+		beta:      beta,
+		mu:        mu,
+		timeScale: timeScale,
+	}
+}
+
+func (m *MarkedHawkesProcessVP) MarkFunction(params any) float64 {
+	if vp, ok := params.(VolumePriceData); ok {
+		// the total fund capital
+		return vp.Volume * vp.Price
+	}
+	return 0.0
+}
+
+func (m *MarkedHawkesProcessVP) GetAlpha() float64 {
+	return m.alpha
+}
+
+func (m *MarkedHawkesProcessVP) GetBeta() float64 {
+	return m.beta
+}
+
+func (m *MarkedHawkesProcessVP) GetMu() float64 {
+	return m.mu
+}
+
+func (m *MarkedHawkesProcessVP) GetTimeScale() float64 {
+	return m.timeScale
+}

--- a/pkg/analysis/hawkes_test.go
+++ b/pkg/analysis/hawkes_test.go
@@ -1,0 +1,54 @@
+package analysis
+
+import (
+	"testing"
+)
+
+/*
+import numpy as np
+
+class MarkedHawkesProcessVP:
+    def __init__(self, mu=0.1, alpha=0.01, beta=1.0):
+        self.alpha = alpha  # Intensity of the process
+        self.mu = mu        # Baseline intensity
+        self.beta = beta  # Marks associated with the process
+
+
+    def mark_function(self, volume, price):
+        return volume * price
+
+    def intensity(self, t, history):
+        past_events = [(ti, vi, pi) for ti, vi, pi in history if ti < t]
+        excitation = sum(self.alpha * self.mark_function(vi, pi) *\
+                np.exp(-self.beta * (t - ti)) for ti, vi, pi in past_events)
+        return self.mu + excitation
+
+mu = 0.5
+alpha = 0.1
+beta = 1.0
+process = MarkedHawkesProcessVP(mu, alpha, beta)
+intensity = process.intensity(3, [(1, 100, 10), (2, 200, 20), (3, 300, 30), (4, 400, 40)])
+
+# result: 161.1853047922382
+*/
+
+func TestMarkedHawkesProcessVP(t *testing.T) {
+	mu := 0.5
+	alpha := 0.1
+	beta := 1.0
+
+	process := NewMarkedHawkesProcessVP(mu, alpha, beta, 1.0)
+	history := []TimedTuple{
+		{Time: 1, Params: VolumePriceData{Volume: 100, Price: 10}},
+		{Time: 2, Params: VolumePriceData{Volume: 200, Price: 20}},
+		{Time: 3, Params: VolumePriceData{Volume: 300, Price: 30}},
+		{Time: 4, Params: VolumePriceData{Volume: 400, Price: 40}},
+	}
+
+	intensity := GetIntensity(process, 3, history)
+
+	expectedIntensity := 161.1853047922382
+	if intensity != expectedIntensity {
+		t.Errorf("Expected intensity %f, got %f", expectedIntensity, intensity)
+	}
+}

--- a/pkg/analysis/hawkes_test.go
+++ b/pkg/analysis/hawkes_test.go
@@ -2,6 +2,8 @@ package analysis
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 /*
@@ -51,4 +53,10 @@ func TestMarkedHawkesProcessVP(t *testing.T) {
 	if intensity != expectedIntensity {
 		t.Errorf("Expected intensity %f, got %f", expectedIntensity, intensity)
 	}
+}
+
+func TestMarkedHawkesInvalidParam(t *testing.T) {
+	process := NewMarkedHawkesProcessVP(0.5, 0.1, 1.0, 1.0)
+	result := process.MarkFunction(199)
+	assert.Equal(t, 0.0, result, "Expected mark function to return 0 for invalid input")
 }


### PR DESCRIPTION
add hawkes process on mark_function. if mark_function always returns 1, it means the intensity is for the occurrence of trades(or maybe order? depends on the meaning of historical data).