### PR TITLE
chore: fix inconsistent function name in comment

### DIFF
--- a/pkg/backtest/priceorder.go
+++ b/pkg/backtest/priceorder.go
@@ -40,7 +40,7 @@ func (slice PriceOrderSlice) First() (PriceOrder, bool) {
 	return PriceOrder{}, false
 }
 
-// FindPriceVolumePair finds the pair by the given price, this function is a read-only
+// Find finds the pair by the given price, this function is a read-only
 // operation, so we use the value receiver to avoid copy value from the pointer
 // If the price is not found, it will return the index where the price can be inserted at.
 // true for descending (bid orders), false for ascending (ask orders)

--- a/pkg/exchange/binance/binanceapi/client.go
+++ b/pkg/exchange/binance/binanceapi/client.go
@@ -154,7 +154,7 @@ func (c *RestClient) SendRequest(req *http.Request) (*requestgen.Response, error
 	return c.BaseAPIClient.SendRequest(req)
 }
 
-// newAuthenticatedRequest creates new http request for authenticated routes.
+// NewAuthenticatedRequest creates new http request for authenticated routes.
 func (c *RestClient) NewAuthenticatedRequest(
 	ctx context.Context, method, refURL string, params url.Values, payload interface{},
 ) (*http.Request, error) {

--- a/pkg/exchange/bitget/bitgetapi/client.go
+++ b/pkg/exchange/bitget/bitgetapi/client.go
@@ -51,7 +51,7 @@ func (c *RestClient) Auth(key, secret, passphrase string) {
 	c.passphrase = passphrase
 }
 
-// newAuthenticatedRequest creates new http request for authenticated routes.
+// NewAuthenticatedRequest creates new http request for authenticated routes.
 func (c *RestClient) NewAuthenticatedRequest(
 	ctx context.Context, method, refURL string, params url.Values, payload interface{},
 ) (*http.Request, error) {

--- a/pkg/exchange/bybit/bybitapi/client.go
+++ b/pkg/exchange/bybit/bybitapi/client.go
@@ -58,7 +58,7 @@ func (c *RestClient) Auth(key, secret string) {
 	c.secret = secret
 }
 
-// newAuthenticatedRequest creates new http request for authenticated routes.
+// NewAuthenticatedRequest creates new http request for authenticated routes.
 func (c *RestClient) NewAuthenticatedRequest(ctx context.Context, method, refURL string, params url.Values, payload interface{}) (*http.Request, error) {
 	if len(c.key) == 0 {
 		return nil, errors.New("empty api key")

--- a/pkg/exchange/kucoin/kucoinapi/client.go
+++ b/pkg/exchange/kucoin/kucoinapi/client.go
@@ -63,7 +63,7 @@ func (c *RestClient) Auth(key, secret, passphrase string) {
 	c.Passphrase = passphrase
 }
 
-// newAuthenticatedRequest creates new http request for authenticated routes.
+// NewAuthenticatedRequest creates new http request for authenticated routes.
 func (c *RestClient) NewAuthenticatedRequest(ctx context.Context, method, refURL string, params url.Values, payload interface{}) (*http.Request, error) {
 	if len(c.Key) == 0 {
 		return nil, errors.New("empty api key")


### PR DESCRIPTION
fix inconsistent function name in comment