### PR TITLE
FEATURE: [xmaker] support split hedge

### DIFF
--- a/config/xmaker-splithedge.yaml
+++ b/config/xmaker-splithedge.yaml
@@ -34,10 +34,12 @@ crossExchangeStrategies:
     makerExchange: max
     updateInterval: 1s
 
+    signalSource: binance
+
     # disableHedge disables the hedge orders on the source exchange
     # disableHedge: true
 
-    hedgeInterval: 10s
+    hedgeInterval: 1s
 
     margin: 0.004
     askMargin: 0.004

--- a/pkg/bbgo/activeorderbook.go
+++ b/pkg/bbgo/activeorderbook.go
@@ -354,7 +354,9 @@ func (b *ActiveOrderBook) Update(order types.Order) {
 		// if we can't detect which is newer, isNewerOrderUpdate returns false
 		// if you pass two same objects to isNewerOrderUpdate, it returns false
 		if !isNewerOrderUpdate(order, previousOrder) {
-			b.logger.Infof("[ActiveOrderBook] order #%d (update time %s) is out of date, skip it", order.OrderID, order.UpdateTime)
+			if !order.UpdateTime.Equal(time.Time(previousOrder.UpdateTime)) {
+				b.logger.Debugf("[ActiveOrderBook] order #%d (update time %s) is out of date, skip it", order.OrderID, order.UpdateTime)
+			}
 			b.mu.Unlock()
 			return
 		}

--- a/pkg/strategy/xmaker/hedgeexecutor.go
+++ b/pkg/strategy/xmaker/hedgeexecutor.go
@@ -9,10 +9,34 @@ import (
 	"github.com/c9s/bbgo/pkg/types"
 )
 
+type HedgeExecutor interface {
+	// hedge executes a hedge order based on the uncovered position and the hedge delta
+	// uncoveredPosition: the current uncovered position that needs to be hedged
+	// hedgeDelta: the delta that needs to be hedged, which is the negative of uncoveredPosition
+	// quantity: the absolute value of hedgeDelta, which is the order quantity to be hedged
+	// side: the side of the hedge order, which is determined by the sign of hedgeDelta
+	hedge(
+		ctx context.Context,
+		uncoveredPosition, hedgeDelta, quantity fixedpoint.Value,
+		side types.SideType,
+	) error
+
+	canHedge(
+		ctx context.Context,
+		uncoveredPosition, hedgeDelta, quantity fixedpoint.Value,
+		side types.SideType,
+	) (bool, error)
+
+	// clear clears any pending orders or state related to hedging
+	clear(ctx context.Context) error
+}
+
 type BaseHedgeExecutorConfig struct {
 }
 
 type MarketOrderHedgeExecutorConfig struct {
+	HedgeExecutor
+
 	BaseHedgeExecutorConfig
 
 	MaxOrderQuantity fixedpoint.Value `json:"maxOrderQuantity,omitempty"` // max order quantity for market order hedge
@@ -37,6 +61,15 @@ func newMarketOrderHedgeExecutor(
 func (m *MarketOrderHedgeExecutor) clear(ctx context.Context) error {
 	// no-op for market order hedge executor
 	return nil
+}
+
+func (m *MarketOrderHedgeExecutor) canHedge(
+	ctx context.Context,
+	uncoveredPosition, hedgeDelta, quantity fixedpoint.Value,
+	side types.SideType,
+) (bool, error) {
+	// TODO: implement this
+	return true, nil
 }
 
 func (m *MarketOrderHedgeExecutor) hedge(
@@ -92,6 +125,8 @@ type CounterpartyHedgeExecutorConfig struct {
 }
 
 type CounterpartyHedgeExecutor struct {
+	HedgeExecutor
+
 	*HedgeMarket
 
 	config     *CounterpartyHedgeExecutorConfig
@@ -106,6 +141,15 @@ func newCounterpartyHedgeExecutor(
 		HedgeMarket: market,
 		config:      config,
 	}
+}
+
+func (m *CounterpartyHedgeExecutor) canHedge(
+	ctx context.Context,
+	uncoveredPosition, hedgeDelta, quantity fixedpoint.Value,
+	side types.SideType,
+) (bool, error) {
+	// TODO: implement this
+	return true, nil
 }
 
 func (m *CounterpartyHedgeExecutor) clear(ctx context.Context) error {

--- a/pkg/strategy/xmaker/hedgemarket.go
+++ b/pkg/strategy/xmaker/hedgemarket.go
@@ -523,5 +523,19 @@ func deltaToSide(delta fixedpoint.Value) types.SideType {
 	}
 
 	return side
+}
 
+func positionToSide(pos fixedpoint.Value) types.SideType {
+	side := types.SideTypeBuy
+	if pos.Sign() < 0 {
+		side = types.SideTypeSell
+	}
+	return side
+}
+
+// uncoveredToDelta converts uncovered position to delta by negating it.
+// delta is the amount needed to hedge the uncovered position.
+// For example, if uncovered position is +10 (long 10 units), the delta to hedge it is -10 (sell 10 units).
+func uncoveredToDelta(uncoveredPosition fixedpoint.Value) fixedpoint.Value {
+	return uncoveredPosition.Neg()
 }

--- a/pkg/strategy/xmaker/hedgemarket.go
+++ b/pkg/strategy/xmaker/hedgemarket.go
@@ -35,22 +35,6 @@ const (
 
 const defaultHedgeInterval = 200 * time.Millisecond
 
-type HedgeExecutor interface {
-	// hedge executes a hedge order based on the uncovered position and the hedge delta
-	// uncoveredPosition: the current uncovered position that needs to be hedged
-	// hedgeDelta: the delta that needs to be hedged, which is the negative of uncoveredPosition
-	// quantity: the absolute value of hedgeDelta, which is the order quantity to be hedged
-	// side: the side of the hedge order, which is determined by the sign of hedgeDelta
-	hedge(
-		ctx context.Context,
-		uncoveredPosition, hedgeDelta, quantity fixedpoint.Value,
-		side types.SideType,
-	) error
-
-	// clear clears any pending orders or state related to hedging
-	clear(ctx context.Context) error
-}
-
 type HedgeMarketConfig struct {
 	SymbolSelector string         `json:"symbolSelector"`
 	HedgeMethod    HedgeMethod    `json:"hedgeMethod"`
@@ -152,6 +136,7 @@ func newHedgeMarket(
 	activeMakerOrders.BindStream(session.UserDataStream)
 
 	logger := log.WithFields(logrus.Fields{
+		"session":      session.Name,
 		"exchange":     session.ExchangeName,
 		"hedge_market": market.Symbol,
 	})

--- a/pkg/strategy/xmaker/hedgemarket.go
+++ b/pkg/strategy/xmaker/hedgemarket.go
@@ -311,12 +311,15 @@ func (m *HedgeMarket) canHedge(
 	if !ok {
 		log.Warnf("cannot find balance for currency: %s", currency)
 		return false, nil
+	} else if available.IsZero() {
+		log.Warnf("zero available balance for currency: %s", currency)
+		return false, nil
 	}
 
 	// for margin account, we need to check if the margin level is sufficient
 	if m.session.Margin {
 		// a simple check to ensure the account is not in danger of liquidation
-		if account.MarginLevel.IsZero() || account.MarginLevel.Compare(fixedpoint.NewFromFloat(2.0)) < 0 {
+		if account.MarginLevel.IsZero() || account.MarginLevel.Compare(fixedpoint.NewFromFloat(1.5)) < 0 {
 			log.Warnf("margin level too low to hedge: %s", account.MarginLevel.String())
 			return false, nil
 		}

--- a/pkg/strategy/xmaker/hedgemarket.go
+++ b/pkg/strategy/xmaker/hedgemarket.go
@@ -295,6 +295,46 @@ func (m *HedgeMarket) getQuotePrice() (bid, ask fixedpoint.Value) {
 	return bid, ask
 }
 
+func (m *HedgeMarket) canHedge(
+	ctx context.Context, uncoveredPosition fixedpoint.Value,
+) (bool, error) {
+	hedgeDelta := uncoveredPosition.Neg()
+	quantity := hedgeDelta.Abs()
+	side := deltaToSide(hedgeDelta)
+
+	// get quote price
+	bid, ask := m.getQuotePrice()
+	price := sideTakerPrice(bid, ask, side)
+	currency, required := determineRequiredCurrencyAndAmount(m.market, side, quantity, price)
+	account := m.session.GetAccount()
+	available, ok := getAvailableBalance(account, currency)
+	if !ok {
+		log.Warnf("cannot find balance for currency: %s", currency)
+		return false, nil
+	}
+
+	// for margin account, we need to check if the margin level is sufficient
+	if m.session.Margin {
+		// a simple check to ensure the account is not in danger of liquidation
+		if account.MarginLevel.IsZero() || account.MarginLevel.Compare(fixedpoint.NewFromFloat(2.0)) < 0 {
+			log.Warnf("margin level too low to hedge: %s", account.MarginLevel.String())
+			return false, nil
+		}
+	}
+
+	if !isBalanceSufficient(available, required) {
+		log.Warnf("insufficient balance for hedge: need %s %s, available %s", required.String(), currency, available.String())
+		return false, nil
+	}
+
+	if m.market.IsDustQuantity(quantity, price) {
+		log.Warnf("skip dust quantity: %s @ price %f", quantity.String(), price.Float64())
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func (m *HedgeMarket) hedge(
 	ctx context.Context, uncoveredPosition fixedpoint.Value,
 ) error {

--- a/pkg/strategy/xmaker/splithedge.go
+++ b/pkg/strategy/xmaker/splithedge.go
@@ -1,0 +1,1 @@
+package xmaker

--- a/pkg/strategy/xmaker/splithedge.go
+++ b/pkg/strategy/xmaker/splithedge.go
@@ -1,1 +1,81 @@
 package xmaker
+
+import (
+	"encoding/json"
+
+	"github.com/c9s/bbgo/pkg/bbgo"
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+)
+
+type SplitHedgeProportionMarket struct {
+	Name string `json:"name"`
+
+	Ratio float64 `json:"ratio"`
+
+	MaxQuantity fixedpoint.Value `json:"maxQuantity"`
+
+	MaxQuoteQuantity fixedpoint.Value `json:"maxQuoteQuantity"`
+}
+
+type SplitHedgeProportionAlgo struct {
+	ProportionMarkets []*SplitHedgeProportionMarket `json:"markets"`
+}
+
+type SplitHedge struct {
+	Enabled bool `json:"enabled"`
+
+	Algo string `json:"algo"`
+
+	ProportionAlgo *SplitHedgeProportionAlgo `json:"proportionAlgo"`
+
+	// HedgeMarkets stores session name to hedge market config mapping.
+	HedgeMarkets map[string]*HedgeMarketConfig `json:"hedgeMarketInstances"`
+
+	// hedgeMarketInstances stores session name to hedge market instance mapping.
+	hedgeMarketInstances map[string]*HedgeMarket
+
+	strategy *Strategy
+}
+
+func (h *SplitHedge) UnmarshalJSON(data []byte) error {
+	type Alias SplitHedge
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(h),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if h.HedgeMarkets == nil {
+		h.HedgeMarkets = make(map[string]*HedgeMarketConfig)
+	}
+
+	if h.hedgeMarketInstances == nil {
+		h.hedgeMarketInstances = make(map[string]*HedgeMarket)
+	}
+
+	return nil
+}
+
+func (h *SplitHedge) InitializeAndBind(sessions map[string]*bbgo.ExchangeSession, strategy *Strategy) error {
+	if !h.Enabled {
+		return nil
+	}
+
+	for name, config := range h.HedgeMarkets {
+		hedgeMarket, err := initializeHedgeMarketFromConfig(config, sessions)
+		if err != nil {
+			return err
+		}
+
+		h.hedgeMarketInstances[name] = hedgeMarket
+
+		hedgeMarket.Position.StrategyInstanceID = strategy.InstanceID()
+	}
+
+	h.strategy = strategy
+	return nil
+}

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -2113,6 +2113,10 @@ func (s *Strategy) tryToRepayDebts(ctx context.Context, session *bbgo.ExchangeSe
 			s.logger.WithError(err).Errorf("unable to repay %s asset", asset)
 		}
 	}
+
+	if _, err := session.UpdateAccount(ctx); err != nil {
+		s.logger.WithError(err).Errorf("unable to update account after repay")
+	}
 }
 
 func (s *Strategy) getCoveredPosition() fixedpoint.Value {

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -139,6 +139,8 @@ type Strategy struct {
 
 	DelayedHedge *DelayedHedge `json:"delayedHedge,omitempty"`
 
+	SplitHedge *SplitHedge `json:"splitHedge,omitempty"`
+
 	SpreadMaker *SpreadMaker `json:"spreadMaker,omitempty"`
 
 	EnableBollBandMargin bool             `json:"enableBollBandMargin"`

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -997,16 +997,20 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 	hedgeBalances := hedgeAccount.Balances()
 	hedgeQuota := &bbgo.QuotaTransaction{}
 
+	s.logger.Infof("hedge balances: %+v", hedgeBalances.NotZero())
+
 	if s.sourceSession.Margin &&
 		!s.MinMarginLevel.IsZero() &&
 		!hedgeAccount.MarginLevel.IsZero() {
 
 		if hedgeAccount.MarginLevel.Compare(s.MinMarginLevel) < 0 {
 			s.logger.Warnf(
-				"hedge account margin level %s is less then the min margin level %s, calculating the borrowed positions",
+				"hedge account margin level %s is less then the min margin level %s, trying to repay the debts...",
 				hedgeAccount.MarginLevel.String(),
 				s.MinMarginLevel.String(),
 			)
+
+			s.tryToRepayDebts(ctx, s.sourceSession)
 		} else {
 			s.logger.Infof(
 				"hedge account margin level %s is greater than the min margin level %s, calculating the net value",
@@ -1029,6 +1033,10 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 		} else {
 			s.logger.Warnf("margin hedge buy is disabled, disabling maker ask orders...")
 			disableMakerAsk = true
+		}
+
+		if disableMakerBid || disableMakerAsk {
+			s.tryToRepayDebts(ctx, s.sourceSession)
 		}
 	} else {
 		if b, ok := hedgeBalances[s.sourceMarket.BaseCurrency]; ok {
@@ -2071,6 +2079,39 @@ func (s *Strategy) houseCleanWorker(ctx context.Context) {
 			s.orderStore.Prune(expiryDuration)
 		}
 
+	}
+}
+
+var repayRateLimiter = rate.NewLimiter(rate.Every(30*time.Second), 1)
+
+func (s *Strategy) tryToRepayDebts(ctx context.Context, session *bbgo.ExchangeSession) {
+	if !repayRateLimiter.Allow() {
+		return
+	}
+
+	hedgeBalances := session.GetAccount().Balances()
+	debts := hedgeBalances.Debts()
+
+	s.logger.Infof("trying to repay debts %+v on hedge exchange %s", debts, session.Exchange.Name())
+
+	repayables := make(map[string]fixedpoint.Value)
+	for asset, bal := range debts {
+		if bal.Borrowed.IsZero() || bal.Available.IsZero() {
+			continue
+		}
+
+		repayables[asset] = bal.Available
+	}
+
+	marginService, ok := session.Exchange.(types.MarginBorrowRepayService)
+	if !ok {
+		return
+	}
+
+	for asset, amount := range repayables {
+		if err := marginService.RepayMarginAsset(ctx, asset, amount); err != nil {
+			s.logger.WithError(err).Errorf("unable to repay %s asset", asset)
+		}
 	}
 }
 

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -2561,6 +2561,11 @@ func (s *Strategy) CrossRun(
 	go func() {
 		s.logger.Infof("waiting for authentication connections to be ready...")
 
+		if s.SplitHedge != nil && s.SplitHedge.Enabled {
+			if err := s.SplitHedge.Start(ctx); err != nil {
+				s.logger.WithError(err).Errorf("failed to start split hedge")
+			}
+		}
 		if s.SyntheticHedge != nil && s.SyntheticHedge.Enabled {
 			if err := s.SyntheticHedge.Start(ctx); err != nil {
 				s.logger.WithError(err).Errorf("failed to start syntheticHedge")

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -111,6 +111,8 @@ type Strategy struct {
 
 	EnableSignalMargin bool `json:"enableSignalMargin"`
 
+	SignalSource string `json:"signalSource,omitempty"`
+
 	SignalConfigList *signal.DynamicConfig `json:"signals"`
 
 	SignalReverseSideMargin       *SignalMargin `json:"signalReverseSideMargin,omitempty"`
@@ -1896,6 +1898,10 @@ func (s *Strategy) Defaults() error {
 		s.CircuitBreaker = circuitbreaker.NewBasicCircuitBreaker(ID, s.InstanceID(), s.Symbol)
 	} else {
 		s.CircuitBreaker.SetMetricsInfo(ID, s.InstanceID(), s.Symbol)
+	}
+
+	if s.SignalSource == "" {
+		s.SignalSource = s.SourceExchange
 	}
 
 	if s.EnableSignalMargin {

--- a/pkg/strategy/xmaker/synthetichedge.go
+++ b/pkg/strategy/xmaker/synthetichedge.go
@@ -256,7 +256,7 @@ func (s *SyntheticHedge) Stop(shutdownCtx context.Context) error {
 	s.sourceMarket.Stop(shutdownCtx)
 	s.fiatMarket.Stop(shutdownCtx)
 
-	instanceID := ID
+	instanceID := ID + "-synthetichedge"
 	if s.strategy != nil {
 		instanceID = s.strategy.InstanceID()
 	}

--- a/pkg/strategy/xmaker/synthetichedge.go
+++ b/pkg/strategy/xmaker/synthetichedge.go
@@ -13,53 +13,7 @@ import (
 	"github.com/c9s/bbgo/pkg/types"
 )
 
-type HedgeMethod string
-
-const (
-	// HedgeMethodMarket is the default hedge method that uses the market order to hedge
-	HedgeMethodMarket HedgeMethod = "market"
-
-	// HedgeMethodCounterparty is a hedge method that uses limit order at the specific counterparty price level to hedge
-	HedgeMethodCounterparty HedgeMethod = "counterparty"
-
-	// HedgeMethodQueue is a hedge method that uses limit order at the first price level in the queue to hedge
-	HedgeMethodQueue HedgeMethod = "queue"
-)
-
 const TradeTagMock = "mock"
-
-type HedgeMarketConfig struct {
-	SymbolSelector string         `json:"symbolSelector"`
-	HedgeMethod    HedgeMethod    `json:"hedgeMethod"`
-	HedgeInterval  types.Duration `json:"hedgeInterval"`
-
-	HedgeMethodMarket       *MarketOrderHedgeExecutorConfig  `json:"hedgeMethodMarket,omitempty"`       // for backward compatibility, this is the default hedge method
-	HedgeMethodCounterparty *CounterpartyHedgeExecutorConfig `json:"hedgeMethodCounterparty,omitempty"` // for backward compatibility, this is the default hedge method
-
-	HedgeMethodQueue *struct {
-		PriceLevel int `json:"priceLevel"`
-	} `json:"hedgeMethodQueue,omitempty"` // for backward compatibility, this is the default hedge method
-
-	QuotingDepth        fixedpoint.Value `json:"quotingDepth"`
-	QuotingDepthInQuote fixedpoint.Value `json:"quotingDepthInQuote"`
-}
-
-func initializeHedgeMarketFromConfig(
-	c *HedgeMarketConfig,
-	sessions map[string]*bbgo.ExchangeSession,
-) (*HedgeMarket, error) {
-	session, market, err := parseSymbolSelector(c.SymbolSelector, sessions)
-	if err != nil {
-		return nil, err
-	}
-
-	if c.QuotingDepth.IsZero() && c.QuotingDepthInQuote.IsZero() {
-		return nil, fmt.Errorf("quotingDepth or quotingDepthInQuote must be set for hedge market %s", c.SymbolSelector)
-	}
-
-	hm := newHedgeMarket(c, session, market)
-	return hm, nil
-}
 
 // SyntheticHedge is a strategy that uses synthetic hedging to manage risk
 // SourceSymbol could be something like binance.BTCUSDT

--- a/pkg/strategy/xmaker/synthetichedge.go
+++ b/pkg/strategy/xmaker/synthetichedge.go
@@ -77,6 +77,9 @@ func (s *SyntheticHedge) InitializeAndBind(sessions map[string]*bbgo.ExchangeSes
 	// BTC/USDT -> USDT/TWD = forward
 	// BTC/USDT -> USDC/USDT = reverse (!forward)
 	s.forward = s.sourceMarket.market.QuoteCurrency == s.fiatMarket.market.BaseCurrency
+
+	s.sourceMarket.positionExposure.OnCover(strategy.positionExposure.Cover)
+	s.sourceMarket.positionExposure.OnClose(strategy.positionExposure.Close)
 	return s.initialize(strategy)
 }
 

--- a/pkg/types/balance.go
+++ b/pkg/types/balance.go
@@ -105,7 +105,7 @@ func (b Balance) ValueString() (o string) {
 }
 
 func (b Balance) String() (o string) {
-	o = fmt.Sprintf("%s: %s", b.Currency, b.Net().String())
+	o = fmt.Sprintf("%s: %s", b.Currency, b.Available.String())
 
 	if b.Locked.Sign() > 0 {
 		o += fmt.Sprintf(" (locked %f)", b.Locked.Float64())
@@ -119,6 +119,7 @@ func (b Balance) String() (o string) {
 		o += fmt.Sprintf(" (interest: %f)", b.Interest.Float64())
 	}
 
+	o += fmt.Sprintf(" (net: %f)", b.Net().Float64())
 	return o
 }
 

--- a/pkg/types/position_test.go
+++ b/pkg/types/position_test.go
@@ -294,6 +294,35 @@ func TestPosition(t *testing.T) {
 			expectedQuote:       fixedpoint.NewFromFloat(2000.0*0.01 + 3000.0*0.03),
 			expectedProfit:      fixedpoint.Zero,
 		},
+
+		{
+			name: "different symbols",
+			trades: []Trade{
+				{
+					Symbol:        "BTCUSDT",
+					Side:          SideTypeBuy,
+					Price:         fixedpoint.NewFromInt(1000),
+					Quantity:      fixedpoint.NewFromFloat(0.01),
+					QuoteQuantity: fixedpoint.NewFromFloat(1000.0 * 0.01),
+					Fee:           fixedpoint.Zero,
+					FeeCurrency:   "BTC",
+				},
+				{
+					Symbol:        "BTCUSD",
+					Side:          SideTypeSell,
+					Price:         fixedpoint.NewFromInt(1020),
+					Quantity:      fixedpoint.NewFromFloat(0.01),
+					QuoteQuantity: fixedpoint.NewFromFloat(1020.0 * 0.01),
+					Fee:           fixedpoint.Zero,
+					FeeCurrency:   "BTC",
+				},
+			},
+			expectedAverageCost: fixedpoint.NewFromFloat(1000.0 * 0.01).
+				Div(fixedpoint.NewFromFloat(0.01)),
+			expectedBase:   fixedpoint.NewFromFloat(0.0),
+			expectedQuote:  fixedpoint.NewFromFloat(20.0 * 0.01),
+			expectedProfit: fixedpoint.NewFromFloat(0.2),
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -304,11 +333,11 @@ func TestPosition(t *testing.T) {
 				QuoteCurrency: "USDT",
 			}
 			profitAmount, _, profit := pos.AddTrades(testcase.trades)
-			assert.Equal(t, testcase.expectedQuote, pos.Quote, "expectedQuote")
-			assert.Equal(t, testcase.expectedBase, pos.Base, "expectedBase")
-			assert.Equal(t, testcase.expectedAverageCost, pos.AverageCost, "expectedAverageCost")
+			assert.InDelta(t, testcase.expectedQuote.Float64(), pos.Quote.Float64(), 1e-3, "expectedQuote")
+			assert.InDelta(t, testcase.expectedBase.Float64(), pos.Base.Float64(), 1e-8, "expectedBase")
+			assert.InDelta(t, testcase.expectedAverageCost.Float64(), pos.AverageCost.Float64(), 1e-8, "expectedAverageCost")
 			if profit {
-				assert.Equal(t, testcase.expectedProfit, profitAmount, "expectedProfit")
+				assert.InDelta(t, testcase.expectedProfit.Float64(), profitAmount.Float64(), 1e-8, "expectedProfit")
 			}
 		})
 	}

--- a/pkg/types/trade.go
+++ b/pkg/types/trade.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
@@ -291,4 +292,22 @@ func (trade Trade) Validate() error {
 	}
 
 	return nil
+}
+
+// LogFields returns logrus.Fields for structured logging
+func (trade Trade) LogFields() logrus.Fields {
+	orderID := trade.OrderUUID
+	if orderID == "" {
+		orderID = strconv.FormatUint(trade.OrderID, 10)
+	}
+
+	return logrus.Fields{
+		"exchange":  trade.Exchange.String(),
+		"symbol":    trade.Symbol,
+		"side":      trade.Side,
+		"orderID":   orderID,
+		"tradeID":   trade.ID,
+		"time":      trade.Time.Time().Format(time.RFC3339Nano),
+		"liquidity": trade.Liquidity(),
+	}
 }

--- a/prompts/api/core-api.md
+++ b/prompts/api/core-api.md
@@ -1,0 +1,66 @@
+# BBGO Core API
+
+## Reading Account Info
+
+You can get account info from `*bbgo.ExchangeSession`, like this:
+
+```go
+account := session.GetAccount()
+```
+
+GetAccount() is a thread-safe method, you can call it anywhere.
+
+To retrieve an updated account (real-time data from exchange), you can use `UpdateAccount` method:
+
+```go
+account, err := session.UpdateAccount(ctx)
+if err != nil {
+    log.Error("failed to update account: ", err)
+    return
+}
+
+// use account here
+```
+
+## Reading Current Balances
+
+You can get all balances from `*bbgo.ExchangeSession`, like this:
+
+```go
+balances := session.GetAccount().Balances()
+
+// to iterate the balances, you can do:
+for _, balance := range balances {
+    log.Infof("%s: available: %f, locked: %f\n", balance.Currency, balance.Available.Float64(), balance.Locked.Float64())
+}
+```
+
+To get one specific balance, you can use `GetBalance` method:
+
+```go
+balance, ok := session.GetAccount().Balance("BTC")
+if ok {
+    log.Infof("BTC balance: available: %f, locked: %f\n", balance.Available.Float64(), balance.Locked.Float64())
+} else {
+    log.Warn("no BTC balance")
+}
+```
+
+### Quantity Checking
+
+`types.Market` provides the market info, you can use it to check if the quantity is dust or not:
+
+```
+if market.IsDustQuantity(quantity, price) {
+    m.logger.Infof("skip dust quantity: %s @ price %f", quantity.String(), price.Float64())
+    return nil
+}
+```
+
+`types.Market` is defined in `bbgo/types/market.go`
+
+
+
+
+
+


### PR DESCRIPTION
```yaml
    splitHedge:
      enabled: true
      algo: "proportion"
      proportionAlgo:
        markets:
        - name: coinbase
          ratio: 0.5
          maxQuantity: 1.0
          maxQuoteAmount: 5000.0
        - name: binance

      hedgeMarkets:
        coinbase:
          symbolSelector: "coinbase.BTCUSDT"
          quotingDepthInQuote: 10_000.0
          hedgeMethod: "market"
          hedgeInterval: 200ms
          hedgeMethodCounterparty:
            priceLevel: 1
        binance:
          symbolSelector: "binance.BTCUSDT"
          quotingDepthInQuote: 10_000.0
          hedgeMethod: "market"
          hedgeInterval: 200ms
          hedgeMethodCounterparty:
            priceLevel: 1

```