### PR TITLE
chore: remove unused min/max func

### DIFF
--- a/pkg/fixedpoint/dec.go
+++ b/pkg/fixedpoint/dec.go
@@ -108,19 +108,6 @@ var halfpow10 = [...]uint64{
 	500000000000000000,
 	5000000000000000000}
 
-func min(a int, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a int, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
 
 func (v Value) Value() (driver.Value, error) {
 	return v.Float64(), nil

--- a/pkg/indicator/util.go
+++ b/pkg/indicator/util.go
@@ -1,11 +1,5 @@
 package indicator
 
-func max(x, y int) int {
-	if x > y {
-		return x
-	}
-	return y
-}
 
 func Min(x, y int) int {
 	if x < y {

--- a/pkg/indicator/v2/rsi.go
+++ b/pkg/indicator/v2/rsi.go
@@ -46,17 +46,3 @@ func (s *RSIStream) Calculate(_ float64) float64 {
 	rsi := 100.0 - (100.0 / (1.0 + rs))
 	return rsi
 }
-
-func max(x, y int) int {
-	if x > y {
-		return x
-	}
-	return y
-}
-
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}

--- a/pkg/strategy/xdepthmaker/strategy.go
+++ b/pkg/strategy/xdepthmaker/strategy.go
@@ -1336,11 +1336,3 @@ func selectSessions2(
 	s2 = sessions[n2]
 	return s1, s2, nil
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
-}


### PR DESCRIPTION
Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 