### PR TITLE
refactor: remove obsolete //+build comments

### DIFF
--- a/pkg/backtest/assets_dummy.go
+++ b/pkg/backtest/assets_dummy.go
@@ -1,5 +1,4 @@
 //go:build !web
-// +build !web
 
 package backtest
 

--- a/pkg/cmd/pprof.go
+++ b/pkg/cmd/pprof.go
@@ -1,5 +1,4 @@
 //go:build pprof
-// +build pprof
 
 package cmd
 

--- a/pkg/depth/buffer_test.go
+++ b/pkg/depth/buffer_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package depth
 

--- a/pkg/exchange/bitfinex/generate_symbol_map.go
+++ b/pkg/exchange/bitfinex/generate_symbol_map.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/pkg/exchange/coinbase/generate_symbol_map.go
+++ b/pkg/exchange/coinbase/generate_symbol_map.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/pkg/exchange/kucoin/generate_symbol_map.go
+++ b/pkg/exchange/kucoin/generate_symbol_map.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/pkg/exchange/okex/gensymbols.go
+++ b/pkg/exchange/okex/gensymbols.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/pkg/fixedpoint/div128.go
+++ b/pkg/fixedpoint/div128.go
@@ -1,5 +1,4 @@
 //go:build dnum
-// +build dnum
 
 // Copyright Suneido Software Corp. All rights reserved.
 // Governed by the MIT license found in the LICENSE file.

--- a/pkg/strategy/tri/debug.go
+++ b/pkg/strategy/tri/debug.go
@@ -1,5 +1,4 @@
 //go:build debug
-// +build debug
 
 package tri
 

--- a/pkg/strategy/xmaker/strategy_test.go
+++ b/pkg/strategy/xmaker/strategy_test.go
@@ -1,5 +1,4 @@
 //go:build !dnum
-// +build !dnum
 
 package xmaker
 

--- a/pkg/util/pointer.go
+++ b/pkg/util/pointer.go
@@ -1,5 +1,4 @@
 //go:build !go1.18
-// +build !go1.18
 
 package util
 

--- a/pkg/util/pointer_18.go
+++ b/pkg/util/pointer_18.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 package util
 

--- a/pkg/util/trylock.go
+++ b/pkg/util/trylock.go
@@ -1,5 +1,4 @@
 //go:build !go1.18
-// +build !go1.18
 
 package util
 

--- a/pkg/util/trylock_18.go
+++ b/pkg/util/trylock_18.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 package util
 

--- a/pkg/version/dev.go
+++ b/pkg/version/dev.go
@@ -1,5 +1,4 @@
 //go:build !release
-// +build !release
 
 package version
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,5 +1,4 @@
 //go:build release
-// +build release
 
 package version
 


### PR DESCRIPTION
The plusbuild analyzer suggests a fix to remove obsolete build tags of the form:

        //+build linux,amd64

in files that also contain a Go 1.18-style tag such as:

        //go:build linux && amd64

(It does not check that the old and new tags are consistent;
that is the job of the 'buildtag' analyzer in the vet suite.)