### PR TITLE
FEATURE: [xfundingv2] most profitable market selection

### DIFF
--- a/pkg/strategy/xfundingv2/cost_estimator.go
+++ b/pkg/strategy/xfundingv2/cost_estimator.go
@@ -58,10 +58,13 @@ type EstimatedCost struct {
 	SpreadPnL       fixedpoint.Value
 }
 
+// TotalFeeCost returns the total trading fee cost (spot fee + futures fee) in quote currency
 func (e *EstimatedCost) TotalFeeCost() fixedpoint.Value {
 	return e.SpotFee.Add(e.FuturesFee)
 }
 
+// Spread returns the price difference between spot and futures
+// i.e spread = spot price - futures price
 func (e *EstimatedCost) Spread() fixedpoint.Value {
 	return e.SpreadPnL.Div(e.FuturesPosition)
 }

--- a/pkg/strategy/xfundingv2/cost_estimator.go
+++ b/pkg/strategy/xfundingv2/cost_estimator.go
@@ -16,23 +16,15 @@ func AnnualizedRate(fundingRate fixedpoint.Value, fundingIntervalHours int) fixe
 }
 
 type CostEstimator struct {
-	market types.Market
-
 	// targetPosition is the open position size in futures (can be positive or negative)
 	// the open position size in spot is always the same but with opposite sign
 	targetPosition fixedpoint.Value
 
-	futuresOrderBook, spotOrderBook *types.StreamOrderBook
-
 	futuresFeeRate, spotFeeRate types.ExchangeFee
 }
 
-func NewCostEstimator(market types.Market, futuresOrderBook, spotOrderBook *types.StreamOrderBook) *CostEstimator {
-	return &CostEstimator{
-		market:           market,
-		futuresOrderBook: futuresOrderBook,
-		spotOrderBook:    spotOrderBook,
-	}
+func NewCostEstimator() *CostEstimator {
+	return &CostEstimator{}
 }
 
 func (c *CostEstimator) SetFuturesFeeRate(feeRate types.ExchangeFee) *CostEstimator {
@@ -70,8 +62,7 @@ func (e *EstimatedCost) Spread() fixedpoint.Value {
 }
 
 // EstimateEntryCost calculates the cost of entering the position
-// Note that the cost is based on the current order book, the cost is estimated by the time this function is called.
-func (c *CostEstimator) EstimateEntryCost(isMaker bool) (EstimatedCost, error) {
+func (c *CostEstimator) EstimateEntryCost(isMaker bool, spotOrderBook, futuresOrderBook types.OrderBook) (EstimatedCost, error) {
 	if c.targetPosition.IsZero() {
 		return EstimatedCost{}, nil
 	}
@@ -80,15 +71,15 @@ func (c *CostEstimator) EstimateEntryCost(isMaker bool) (EstimatedCost, error) {
 	if c.targetPosition.Sign() < 0 {
 		// short futures, long spot
 		// buy spot at best ask
-		spotPV, spotOk = c.spotOrderBook.BestAsk()
+		spotPV, spotOk = spotOrderBook.BestAsk()
 		// sell futures at best bid
-		futuresPV, futuresOk = c.futuresOrderBook.BestBid()
+		futuresPV, futuresOk = futuresOrderBook.BestBid()
 	} else {
 		// long futures, short spot
 		// sell spot at best bid
-		spotPV, spotOk = c.spotOrderBook.BestBid()
+		spotPV, spotOk = spotOrderBook.BestBid()
 		// buy futures at best ask
-		futuresPV, futuresOk = c.futuresOrderBook.BestAsk()
+		futuresPV, futuresOk = futuresOrderBook.BestAsk()
 	}
 
 	if !spotOk || !futuresOk {
@@ -98,7 +89,7 @@ func (c *CostEstimator) EstimateEntryCost(isMaker bool) (EstimatedCost, error) {
 	return c.estimateCost(isMaker, spotPV.Price, futuresPV.Price), nil
 }
 
-func (c *CostEstimator) EstimateExitCost(isMaker bool) (EstimatedCost, error) {
+func (c *CostEstimator) EstimateExitCost(isMaker bool, spotOrderBook, futuresOrderBook types.OrderBook) (EstimatedCost, error) {
 	if c.targetPosition.IsZero() {
 		return EstimatedCost{}, nil
 	}
@@ -107,12 +98,12 @@ func (c *CostEstimator) EstimateExitCost(isMaker bool) (EstimatedCost, error) {
 	var spotOk, futuresOk bool
 	if c.targetPosition.Sign() < 0 {
 		// long futures, short spot to close
-		spotPV, spotOk = c.spotOrderBook.BestBid()          // sell spot at best bid
-		futuresPV, futuresOk = c.futuresOrderBook.BestAsk() // buy futures at best ask
+		spotPV, spotOk = spotOrderBook.BestBid()          // sell spot at best bid
+		futuresPV, futuresOk = futuresOrderBook.BestAsk() // buy futures at best ask
 	} else {
 		// short futures, long spot to close
-		spotPV, spotOk = c.spotOrderBook.BestAsk()          // buy spot at best ask
-		futuresPV, futuresOk = c.futuresOrderBook.BestBid() // sell futures at best bid
+		spotPV, spotOk = spotOrderBook.BestAsk()          // buy spot at best ask
+		futuresPV, futuresOk = futuresOrderBook.BestBid() // sell futures at best bid
 	}
 
 	if !spotOk || !futuresOk {

--- a/pkg/strategy/xfundingv2/cost_estimator.go
+++ b/pkg/strategy/xfundingv2/cost_estimator.go
@@ -58,6 +58,14 @@ type EstimatedCost struct {
 	SpreadPnL       fixedpoint.Value
 }
 
+func (e *EstimatedCost) TotalFeeCost() fixedpoint.Value {
+	return e.SpotFee.Add(e.FuturesFee)
+}
+
+func (e *EstimatedCost) Spread() fixedpoint.Value {
+	return e.SpreadPnL.Div(e.FuturesPosition)
+}
+
 // EstimateEntryCost calculates the cost of entering the position
 // Note that the cost is based on the current order book, the cost is estimated by the time this function is called.
 func (c *CostEstimator) EstimateEntryCost(isMaker bool) (EstimatedCost, error) {

--- a/pkg/strategy/xfundingv2/cost_estimator_test.go
+++ b/pkg/strategy/xfundingv2/cost_estimator_test.go
@@ -1,0 +1,243 @@
+package xfundingv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+
+	. "github.com/c9s/bbgo/pkg/testing/testhelper"
+)
+
+func newOrderBook(bestBidPrice, bestBidVolume, bestAskPrice, bestAskVolume float64) *types.SliceOrderBook {
+	return &types.SliceOrderBook{
+		Bids: types.PriceVolumeSlice{
+			types.NewPriceVolume(Number(bestBidPrice), Number(bestBidVolume)),
+		},
+		Asks: types.PriceVolumeSlice{
+			types.NewPriceVolume(Number(bestAskPrice), Number(bestAskVolume)),
+		},
+	}
+}
+
+func TestAnnualizedRate(t *testing.T) {
+	t.Run("8h funding interval", func(t *testing.T) {
+		rate := fixedpoint.NewFromFloat(0.0001)
+		annualized := AnnualizedRate(rate, 8)
+		// 24*365/8 = 1095
+		expected := rate.Mul(fixedpoint.NewFromInt(1095))
+		assert.Equal(t, expected, annualized)
+	})
+
+	t.Run("4h funding interval", func(t *testing.T) {
+		rate := fixedpoint.NewFromFloat(0.0002)
+		annualized := AnnualizedRate(rate, 4)
+		// 24*365/4 = 2190
+		expected := rate.Mul(fixedpoint.NewFromInt(2190))
+		assert.Equal(t, expected, annualized)
+	})
+}
+
+func TestCostEstimator_SettersChaining(t *testing.T) {
+	ce := NewCostEstimator().
+		SetTargetPosition(Number(-1.0)).
+		SetSpotFeeRate(types.ExchangeFee{MakerFeeRate: Number(0.001), TakerFeeRate: Number(0.002)}).
+		SetFuturesFeeRate(types.ExchangeFee{MakerFeeRate: Number(0.0005), TakerFeeRate: Number(0.001)})
+
+	assert.Equal(t, Number(-1.0), ce.targetPosition)
+	assert.Equal(t, Number(0.001), ce.spotFeeRate.MakerFeeRate)
+	assert.Equal(t, Number(0.0005), ce.futuresFeeRate.MakerFeeRate)
+}
+
+func TestEstimatedCost_TotalFeeCost(t *testing.T) {
+	ec := EstimatedCost{
+		SpotFee:    Number(10),
+		FuturesFee: Number(5),
+	}
+	assert.Equal(t, Number(15), ec.TotalFeeCost())
+}
+
+func TestEstimatedCost_Spread(t *testing.T) {
+	ec := EstimatedCost{
+		SpreadPnL:       Number(100),
+		FuturesPosition: Number(2),
+	}
+	assert.Equal(t, Number(50), ec.Spread())
+}
+
+func TestCostEstimator_EstimateEntryCost(t *testing.T) {
+	spotFee := types.ExchangeFee{MakerFeeRate: Number(0.001), TakerFeeRate: Number(0.002)}
+	futuresFee := types.ExchangeFee{MakerFeeRate: Number(0.0005), TakerFeeRate: Number(0.001)}
+
+	t.Run("zero position returns zero cost", func(t *testing.T) {
+		ce := NewCostEstimator().SetTargetPosition(Number(0))
+		spotOB := newOrderBook(100, 10, 101, 10)
+		futuresOB := newOrderBook(100, 10, 101, 10)
+		cost, err := ce.EstimateEntryCost(false, spotOB, futuresOB)
+		assert.NoError(t, err)
+		assert.True(t, cost.SpotFee.IsZero())
+		assert.True(t, cost.FuturesFee.IsZero())
+		assert.True(t, cost.SpreadPnL.IsZero())
+	})
+
+	t.Run("short futures entry (negative target)", func(t *testing.T) {
+		// short futures, long spot: buy spot at ask, sell futures at bid
+		ce := NewCostEstimator().
+			SetTargetPosition(Number(-1.0)).
+			SetSpotFeeRate(spotFee).
+			SetFuturesFeeRate(futuresFee)
+
+		spotOB := newOrderBook(99, 10, 100, 10)     // best ask = 100
+		futuresOB := newOrderBook(101, 10, 102, 10) // best bid = 101
+
+		cost, err := ce.EstimateEntryCost(false, spotOB, futuresOB)
+		assert.NoError(t, err)
+
+		// spread = spot - futures = 100 - 101 = -1
+		// spreadPnL = spread * targetPosition = -1 * -1 = 1
+		assert.Equal(t, Number(1), cost.SpreadPnL)
+
+		// positionSize = abs(-1) = 1
+		// spotFee = 100 * 1 * 0.002 = 0.2
+		assert.Equal(t, Number(0.2), cost.SpotFee)
+		// futuresFee = 101 * 1 * 0.001 = 0.101
+		assert.Equal(t, Number(0.101), cost.FuturesFee)
+		assert.Equal(t, Number(-1), cost.FuturesPosition)
+	})
+
+	t.Run("long futures entry (positive target)", func(t *testing.T) {
+		// long futures, short spot: sell spot at bid, buy futures at ask
+		ce := NewCostEstimator().
+			SetTargetPosition(Number(2.0)).
+			SetSpotFeeRate(spotFee).
+			SetFuturesFeeRate(futuresFee)
+
+		spotOB := newOrderBook(99, 10, 100, 10)     // best bid = 99
+		futuresOB := newOrderBook(101, 10, 102, 10) // best ask = 102
+
+		cost, err := ce.EstimateEntryCost(false, spotOB, futuresOB)
+		assert.NoError(t, err)
+
+		// spread = spot - futures = 99 - 102 = -3
+		// spreadPnL = -3 * 2 = -6
+		assert.Equal(t, Number(-6), cost.SpreadPnL)
+
+		// positionSize = 2
+		// spotFee = 99 * 2 * 0.002 = 0.396
+		assert.Equal(t, Number(0.396), cost.SpotFee)
+		// futuresFee = 102 * 2 * 0.001 = 0.204
+		assert.Equal(t, Number(0.204), cost.FuturesFee)
+	})
+
+	t.Run("maker fee rates", func(t *testing.T) {
+		ce := NewCostEstimator().
+			SetTargetPosition(Number(-1.0)).
+			SetSpotFeeRate(spotFee).
+			SetFuturesFeeRate(futuresFee)
+
+		spotOB := newOrderBook(99, 10, 100, 10)
+		futuresOB := newOrderBook(101, 10, 102, 10)
+
+		cost, err := ce.EstimateEntryCost(true, spotOB, futuresOB)
+		assert.NoError(t, err)
+
+		// maker: spotFee = 100 * 1 * 0.001 = 0.1
+		assert.Equal(t, Number(0.1), cost.SpotFee)
+		// maker: futuresFee = 101 * 1 * 0.0005 = 0.0505
+		assert.Equal(t, Number(0.0505), cost.FuturesFee)
+	})
+
+	t.Run("empty order book returns error", func(t *testing.T) {
+		ce := NewCostEstimator().
+			SetTargetPosition(Number(-1.0)).
+			SetSpotFeeRate(spotFee).
+			SetFuturesFeeRate(futuresFee)
+
+		emptyOB := &types.SliceOrderBook{}
+		spotOB := newOrderBook(100, 10, 101, 10)
+
+		_, err := ce.EstimateEntryCost(false, emptyOB, spotOB)
+		assert.Error(t, err)
+
+		_, err = ce.EstimateEntryCost(false, spotOB, emptyOB)
+		assert.Error(t, err)
+	})
+}
+
+func TestCostEstimator_EstimateExitCost(t *testing.T) {
+	spotFee := types.ExchangeFee{MakerFeeRate: Number(0.001), TakerFeeRate: Number(0.002)}
+	futuresFee := types.ExchangeFee{MakerFeeRate: Number(0.0005), TakerFeeRate: Number(0.001)}
+
+	t.Run("zero position returns zero cost", func(t *testing.T) {
+		ce := NewCostEstimator().SetTargetPosition(Number(0))
+		spotOB := newOrderBook(100, 10, 101, 10)
+		futuresOB := newOrderBook(100, 10, 101, 10)
+		cost, err := ce.EstimateExitCost(false, spotOB, futuresOB)
+		assert.NoError(t, err)
+		assert.True(t, cost.SpotFee.IsZero())
+	})
+
+	t.Run("exit short futures (negative target)", func(t *testing.T) {
+		// to close short futures: buy futures at ask, sell spot at bid
+		ce := NewCostEstimator().
+			SetTargetPosition(Number(-1.0)).
+			SetSpotFeeRate(spotFee).
+			SetFuturesFeeRate(futuresFee)
+
+		spotOB := newOrderBook(99, 10, 100, 10)     // best bid = 99
+		futuresOB := newOrderBook(101, 10, 102, 10) // best ask = 102
+
+		cost, err := ce.EstimateExitCost(false, spotOB, futuresOB)
+		assert.NoError(t, err)
+
+		// spread = spot - futures = 99 - 102 = -3
+		// spreadPnL = -3 * -1 = 3
+		assert.Equal(t, Number(3), cost.SpreadPnL)
+
+		// spotFee = 99 * 1 * 0.002 = 0.198
+		assert.Equal(t, Number(0.198), cost.SpotFee)
+		// futuresFee = 102 * 1 * 0.001 = 0.102
+		assert.Equal(t, Number(0.102), cost.FuturesFee)
+	})
+
+	t.Run("exit long futures (positive target)", func(t *testing.T) {
+		// to close long futures: sell futures at bid, buy spot at ask
+		ce := NewCostEstimator().
+			SetTargetPosition(Number(2.0)).
+			SetSpotFeeRate(spotFee).
+			SetFuturesFeeRate(futuresFee)
+
+		spotOB := newOrderBook(99, 10, 100, 10)     // best ask = 100
+		futuresOB := newOrderBook(101, 10, 102, 10) // best bid = 101
+
+		cost, err := ce.EstimateExitCost(false, spotOB, futuresOB)
+		assert.NoError(t, err)
+
+		// spread = spot - futures = 100 - 101 = -1
+		// spreadPnL = -1 * 2 = -2
+		assert.Equal(t, Number(-2), cost.SpreadPnL)
+
+		// spotFee = 100 * 2 * 0.002 = 0.4
+		assert.Equal(t, Number(0.4), cost.SpotFee)
+		// futuresFee = 101 * 2 * 0.001 = 0.202
+		assert.Equal(t, Number(0.202), cost.FuturesFee)
+	})
+
+	t.Run("empty order book returns error", func(t *testing.T) {
+		ce := NewCostEstimator().
+			SetTargetPosition(Number(-1.0)).
+			SetSpotFeeRate(spotFee).
+			SetFuturesFeeRate(futuresFee)
+
+		emptyOB := &types.SliceOrderBook{}
+		spotOB := newOrderBook(100, 10, 101, 10)
+
+		_, err := ce.EstimateExitCost(false, emptyOB, spotOB)
+		assert.Error(t, err)
+
+		_, err = ce.EstimateExitCost(false, spotOB, emptyOB)
+		assert.Error(t, err)
+	})
+}

--- a/pkg/strategy/xfundingv2/market_selector.go
+++ b/pkg/strategy/xfundingv2/market_selector.go
@@ -64,8 +64,8 @@ func NewMarketSelector(config MarketSelectionConfig, exchange *binance.Exchange,
 	}
 }
 
-// RankMarkets returns a ranked list of market candidates
-func (s *MarketSelector) RankMarkets(ctx context.Context, symbols []string) ([]MarketCandidate, error) {
+// SelectMarkets returns a list of market candidates that meet the selection criteria
+func (s *MarketSelector) SelectMarkets(ctx context.Context, symbols []string) ([]MarketCandidate, error) {
 	// Step 1: Query premium indexes for each symbol
 	indices, err := queryFundingRates(ctx, s.binanceFutures, s.logger, symbols)
 	if err != nil {
@@ -148,8 +148,6 @@ func (s *MarketSelector) RankMarkets(ctx context.Context, symbols []string) ([]M
 		})
 	}
 
-	// TODO: compute composite score and sort candidates
-
 	return candidates, nil
 }
 
@@ -180,41 +178,4 @@ func queryFundingInfo(ctx context.Context, futuresExchange *binance.Exchange) (m
 		m[info.Symbol] = &info
 	}
 	return m, nil
-}
-
-// calculateScores calculates composite scores for ranking
-// Score = AnnualizedRate * 0.6 + NormalizedVolume * 0.4
-func (s *MarketSelector) calculateScores(candidates []MarketCandidate) {
-	if len(candidates) == 0 {
-		return
-	}
-
-	// Find max values for normalization
-	var maxRate, maxVolume fixedpoint.Value
-	for _, c := range candidates {
-		if c.AnnualizedRate.Compare(maxRate) > 0 {
-			maxRate = c.AnnualizedRate
-		}
-		if c.TakerBuyQuoteVolume24h.Compare(maxVolume) > 0 {
-			maxVolume = c.TakerBuyQuoteVolume24h
-		}
-	}
-
-	// Calculate normalized scores
-	for i := range candidates {
-		var normalizedRate, normalizedVolume fixedpoint.Value
-
-		if !maxRate.IsZero() {
-			normalizedRate = candidates[i].AnnualizedRate.Div(maxRate)
-		}
-		if !maxVolume.IsZero() {
-			normalizedVolume = candidates[i].TakerBuyQuoteVolume24h.Div(maxVolume)
-		}
-
-		// Weighted score: rate (60%) + volume (40%)
-		rateScore := normalizedRate.Mul(fixedpoint.NewFromFloat(0.6))
-		volumeScore := normalizedVolume.Mul(fixedpoint.NewFromFloat(0.4))
-
-		candidates[i].Score = rateScore.Add(volumeScore)
-	}
 }

--- a/pkg/strategy/xfundingv2/market_selector.go
+++ b/pkg/strategy/xfundingv2/market_selector.go
@@ -2,6 +2,7 @@ package xfundingv2
 
 import (
 	"context"
+	"time"
 
 	"github.com/c9s/bbgo/pkg/exchange/binance"
 	"github.com/c9s/bbgo/pkg/exchange/binance/binanceapi"
@@ -10,8 +11,20 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func getPostionSign(positionType types.PositionType) int {
+	switch positionType {
+	case types.PositionLong:
+		return 1
+	case types.PositionShort:
+		return -1
+	default:
+		return 0
+	}
+}
+
 // MarketSelectionConfig configures the market selection criteria
 type MarketSelectionConfig struct {
+	FuturesDirection types.PositionType `json:"futuresDirection"`
 
 	// Minimum annualized funding rate to consider (e.g., 0.10 = 10%)
 	// recommended to default to 5%
@@ -23,29 +36,50 @@ type MarketSelectionConfig struct {
 	MinCollateralRate fixedpoint.Value `json:"minCollateralRate"`
 
 	// Depth
-	DepthRatio          fixedpoint.Value `json:"depthRatio"`
-	RequiredQuoteVolume fixedpoint.Value `json:"requiredQuoteVolume"`
-
+	DepthRatio                  fixedpoint.Value `json:"depthRatio"`
+	RequiredQuoteVolume         fixedpoint.Value `json:"requiredQuoteVolume"`
 	RequiredTakerQuoteVolume24h fixedpoint.Value `json:"requiredTakerVolume24h"`
 
 	// Top N markets by market cap to consider
 	TopNCap int `json:"topNCap"`
 }
 
+func (c *MarketSelectionConfig) Defaults() {
+	if c.FuturesDirection == "" {
+		c.FuturesDirection = types.PositionShort
+	}
+	if c.MinAnnualizedRate.IsZero() {
+		c.MinAnnualizedRate = fixedpoint.NewFromFloat(0.05) // 5%
+	}
+	if c.MinCollateralRate.IsZero() {
+		c.MinCollateralRate = fixedpoint.NewFromFloat(0.95)
+	}
+	if c.DepthRatio.IsZero() {
+		c.DepthRatio = fixedpoint.NewFromFloat(0.05) // 5% depth
+	}
+	if c.RequiredQuoteVolume.IsZero() {
+		c.RequiredQuoteVolume = fixedpoint.NewFromFloat(100000)
+	}
+	if c.TopNCap == 0 {
+		c.TopNCap = 10
+	}
+}
+
 // MarketCandidate represents a ranked market candidate
 type MarketCandidate struct {
-	Symbol string `json:"symbol"`
+	Symbol string
 
-	LastFundingRate fixedpoint.Value `json:"lastFundingRate"`
+	LastFundingRate fixedpoint.Value
 	// FundingIntervalHours is the funding interval in hours (e.g., 8 for 8h funding)
 	// It's normally 8 for the most Binance perpetuals, but some may have different intervals like 4h.
 	// See https://www.binance.com/en/futures/funding-history/perpetual/real-time-funding-rate
-	FundingIntervalHours   int              `json:"fundingIntervalHours"`
-	AnnualizedRate         fixedpoint.Value `json:"annualizedRate"`
-	TakerBuyQuoteVolume24h fixedpoint.Value `json:"takerBuyQuoteVolume24h"`
-	InRangeDepth           fixedpoint.Value `json:"inRangeDepth"`
+	FundingIntervalHours   int
+	AnnualizedRate         fixedpoint.Value
+	TakerBuyQuoteVolume24h fixedpoint.Value
+	InRangeDepth           fixedpoint.Value
 
-	Score fixedpoint.Value `json:"score"` // maybe later
+	// MinHoldingDuration is the estimated minimum holding interval to break even for this market candidate
+	MinHoldingDuration time.Duration
 }
 
 // MarketSelector selects the best market based on funding rate and liquidity
@@ -99,8 +133,10 @@ func (s *MarketSelector) SelectMarkets(ctx context.Context, symbols []string) ([
 		takerQuoteVolumes[symbol] = takerVals[0].BuyVol.Mul(ticker.Last)
 	}
 	for _, idx := range indices {
-		// Only consider positive funding rates above threshold
-		if idx.LastFundingRate.Sign() <= 0 {
+		// filter by funding rate direction
+		// short futures -> positive funding rate for funding income
+		// long futures -> negative funding rate for funding income
+		if getPostionSign(s.FuturesDirection)*idx.LastFundingRate.Sign() > 0 {
 			continue
 		}
 
@@ -110,7 +146,7 @@ func (s *MarketSelector) SelectMarkets(ctx context.Context, symbols []string) ([
 		}
 		annualized := AnnualizedRate(idx.LastFundingRate, info.FundingIntervalHours)
 
-		if annualized.Compare(s.MinAnnualizedRate) < 0 {
+		if annualized.Abs().Compare(s.MinAnnualizedRate) < 0 {
 			continue
 		}
 

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -440,7 +440,15 @@ func (s *Strategy) calculateMinHoldingIntervals(candidate MarketCandidate, bestP
 	if err != nil {
 		return fixedpoint.Zero, err
 	}
-	totalCost := estimateEntryCost.TotalFeeCost().Add(estimateEntryCost.SpreadPnL)
+	estimateExitCost, err := costEstimator.EstimateExitCost(true)
+	if err != nil {
+		return fixedpoint.Zero, err
+	}
+	totalCost := estimateEntryCost.
+		TotalFeeCost().
+		Add(estimateEntryCost.SpreadPnL).
+		Add(estimateExitCost.TotalFeeCost()).
+		Add(estimateExitCost.SpreadPnL)
 	amount := targetPosition.Abs().Mul(bestPrice)
 	estimateFundingFeePerInterval := amount.Mul(candidate.LastFundingRate.Abs())
 	if estimateFundingFeePerInterval.IsZero() {

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/c9s/bbgo/pkg/bbgo"
 	"github.com/c9s/bbgo/pkg/datasource/coinmarketcap"
+	"github.com/c9s/bbgo/pkg/exchange/binance"
+	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
 	"github.com/sirupsen/logrus"
 )
@@ -31,7 +34,10 @@ type Strategy struct {
 	// CandidateSymbols is the list of symbols to consider for selection
 	// IMPORTANT: xfundingv2 is now assuming trading on U-major pairs
 	CandidateSymbols []string `json:"candidateSymbols"`
-	TickSymbol       string   `json:"tickSymbol"` // symbol used for ticking the strategy, default to the first candidate symbol
+
+	// TickSymbol is the symbol used for ticking the strategy, default to the first candidate symbol
+	TickSymbol string `json:"tickSymbol"`
+
 	// Market selection criteria
 	MarketSelectionConfig *MarketSelectionConfig `json:"marketSelection,omitempty"`
 
@@ -42,6 +48,8 @@ type Strategy struct {
 	spotMarkets, futuresMarkets       types.MarketMap
 	spotSession, futuresSession       *bbgo.ExchangeSession
 	candidateSymbols                  []string
+	costEstimators                    map[string]*CostEstimator
+	preliminaryMarketSelector         *MarketSelector
 
 	coinmarketcapClient *coinmarketcap.DataSource
 	mu                  sync.Mutex
@@ -65,9 +73,16 @@ func (s *Strategy) Defaults() error {
 	if len(s.CandidateSymbols) == 0 {
 		return errors.New("empty candidateSymbols")
 	}
+
 	if s.TickSymbol == "" {
 		s.TickSymbol = s.CandidateSymbols[0]
 	}
+
+	if s.MarketSelectionConfig == nil {
+		s.MarketSelectionConfig = &MarketSelectionConfig{}
+	}
+	s.MarketSelectionConfig.Defaults()
+
 	return nil
 }
 
@@ -84,13 +99,11 @@ func (s *Strategy) Initialize() error {
 	}
 	s.futuresOrderBooks = make(map[string]*types.StreamOrderBook)
 	s.spotOrderBooks = make(map[string]*types.StreamOrderBook)
+	s.costEstimators = make(map[string]*CostEstimator)
 	return nil
 }
 
 func (s *Strategy) Validate() error {
-	if s.MarketSelectionConfig == nil {
-		return errors.New("marketSelection config is required")
-	}
 	if len(s.CandidateSymbols) == 0 {
 		return errors.New("candidateSymbols is required")
 	}
@@ -189,6 +202,24 @@ func (s *Strategy) CrossRun(
 		spotBook.BindStream(spotStream)
 		spotStream.Subscribe(types.BookChannel, symbol, types.SubscribeOptions{})
 		s.spotOrderBooks[symbol] = spotBook
+
+		market, ok := s.futuresMarkets[symbol]
+		if !ok {
+			return fmt.Errorf("market %s not found in futures markets", symbol)
+		}
+		costEstimator := NewCostEstimator(
+			market, futuresBook, spotBook,
+		)
+		costEstimator.
+			SetFuturesFeeRate(types.ExchangeFee{
+				MakerFeeRate: s.futuresSession.MakerFeeRate,
+				TakerFeeRate: s.futuresSession.TakerFeeRate,
+			}).
+			SetSpotFeeRate(types.ExchangeFee{
+				MakerFeeRate: s.spotSession.MakerFeeRate,
+				TakerFeeRate: s.spotSession.TakerFeeRate,
+			})
+		s.costEstimators[symbol] = costEstimator
 	}
 	if err := futureStream.Connect(ctx); err != nil {
 		return fmt.Errorf("failed to connect future stream books: %w", err)
@@ -197,19 +228,22 @@ func (s *Strategy) CrossRun(
 		return fmt.Errorf("failed to connect spot stream books: %w", err)
 	}
 
+	binanceEx, ok := s.futuresSession.Exchange.(*binance.Exchange)
+	s.preliminaryMarketSelector = NewMarketSelector(*s.MarketSelectionConfig, binanceEx, s.logger)
+
 	for _, sess := range []*bbgo.ExchangeSession{s.spotSession, s.futuresSession} {
 		sess.MarketDataStream.OnMarketTrade(types.TradeWith(s.TickSymbol, func(trade types.Trade) {
-			s.tick(trade.Time.Time())
+			s.tick(ctx, trade.Time.Time())
 		}))
 		sess.MarketDataStream.OnKLineClosed(types.KLineWith(s.TickSymbol, types.Interval1m, func(kline types.KLine) {
-			s.tick(kline.EndTime.Time())
+			s.tick(ctx, kline.EndTime.Time())
 		}))
 	}
 
 	return nil
 }
 
-func (s *Strategy) tick(tickTime time.Time) {
+func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -231,9 +265,8 @@ func (s *Strategy) tick(tickTime time.Time) {
 		return
 	}
 
-	// start checking
-	// 1. check if any open round needs to be closed
-	// 2. check if new round can be opened or existing round needs to be adjusted
+	// start processing
+	s.process(ctx)
 
 	// check interval done, reset and start new check interval
 	s.checkRoundStartTime = s.currentTime
@@ -306,4 +339,113 @@ func (s *Strategy) filterMarketCollateralRate(ctx context.Context, symbols []str
 		}
 	}
 	return candidateSymbols
+}
+
+func (s *Strategy) process(ctx context.Context) {
+	// 1. check if there is any active round needs to be closed
+	// TODO: implement round management and closing logic
+
+	// 2. check if new round can be opened or existing round needs to be adjusted
+	candidates, err := s.preliminaryMarketSelector.SelectMarkets(ctx, s.candidateSymbols)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to select market candidates")
+		return
+	}
+	if len(candidates) == 0 {
+		// no candidates, nothing to do in this round
+		return
+	}
+
+	selectedCandidate, _ := s.selectMostPorfitableMarket(candidates)
+	if selectedCandidate == nil {
+		// no profitable candidate found, nothing to do in this round
+		return
+	}
+	// TODO: implement round opening logic with the selected candidate
+}
+
+// selectMostProfitableMarket selects the most profitable market among the candidates based on the estimated break-even holding intervals
+// it will also return the target position for the futures trade
+// the most profitable market is the one with the shortest break-even holding intervals
+func (s *Strategy) selectMostPorfitableMarket(candidates []MarketCandidate) (*MarketCandidate, fixedpoint.Value) {
+	if len(candidates) == 0 {
+		return nil, fixedpoint.Zero
+	}
+	spotAccount := s.spotSession.GetAccount()
+	breakevenIntervals := make(map[string]fixedpoint.Value)
+	targetPositions := make(map[string]fixedpoint.Value)
+	for _, candidate := range candidates {
+		spotMarket := s.spotMarkets[candidate.Symbol]
+		if s.MarketSelectionConfig.FuturesDirection == types.PositionShort {
+			// long spot -> find the amount for the quote currency
+			quoteBalance, ok := spotAccount.Balance(spotMarket.QuoteCurrency)
+			if !ok {
+				continue
+			}
+			// long spot -> trade on the sell side of the order book
+			sellBook := s.spotOrderBooks[candidate.Symbol].SideBook(types.SideTypeSell)
+			spotPrice := sellBook.AverageDepthPriceByQuote(quoteBalance.Available, 0)
+			targetSize := quoteBalance.Available.Div(spotPrice)
+			// short futures -> trade on the buy side of the order book
+			buyBook := s.futuresOrderBooks[candidate.Symbol].SideBook(types.SideTypeBuy)
+			futuresPrice := buyBook.AverageDepthPrice(targetSize)
+			// short futures -> target future position should be negative
+			breakEvenIntervals, err := s.calculateMinHoldingIntervals(candidate, futuresPrice, targetSize.Neg())
+			if err != nil {
+				continue
+			}
+			breakevenIntervals[candidate.Symbol] = breakEvenIntervals
+			targetPositions[candidate.Symbol] = targetSize.Neg()
+		} else if s.MarketSelectionConfig.FuturesDirection == types.PositionLong {
+			baseBalance, ok := spotAccount.Balance(spotMarket.BaseCurrency)
+			if !ok {
+				continue
+			}
+			targetSize := baseBalance.Available
+			// long futures -> trade on the sell side of the order book
+			sellBook := s.futuresOrderBooks[candidate.Symbol].SideBook(types.SideTypeSell)
+			futuresPrice := sellBook.AverageDepthPrice(targetSize)
+			// long futures -> target future position should be positive
+			breakEvenIntervals, err := s.calculateMinHoldingIntervals(candidate, futuresPrice, targetSize)
+			if err != nil {
+				continue
+			}
+			breakevenIntervals[candidate.Symbol] = breakEvenIntervals
+			targetPositions[candidate.Symbol] = targetSize
+		} else {
+			return nil, fixedpoint.Zero
+		}
+	}
+	if len(breakevenIntervals) == 0 {
+		return nil, fixedpoint.Zero
+	}
+	sortedCandidates := candidates
+	sort.Slice(sortedCandidates, func(i, j int) bool {
+		candidate1 := sortedCandidates[i]
+		candidate2 := sortedCandidates[j]
+		return breakevenIntervals[candidate1.Symbol].Compare(breakevenIntervals[candidate2.Symbol]) <= 0
+	})
+	bestCandidate := &sortedCandidates[0]
+	targetPosition := targetPositions[bestCandidate.Symbol]
+	// set the estimated min holding interval for the selected candidate
+	numHoldingHours := breakevenIntervals[bestCandidate.Symbol].Int() * bestCandidate.FundingIntervalHours
+	bestCandidate.MinHoldingDuration = time.Duration(numHoldingHours) * time.Hour
+	return bestCandidate, targetPosition
+}
+
+func (s *Strategy) calculateMinHoldingIntervals(candidate MarketCandidate, bestPrice, targetPosition fixedpoint.Value) (fixedpoint.Value, error) {
+	costEstimator := s.costEstimators[candidate.Symbol]
+	costEstimator.SetTargetPosition(targetPosition)
+	estimateEntryCost, err := costEstimator.EstimateEntryCost(true)
+	if err != nil {
+		return fixedpoint.Zero, err
+	}
+	totalCost := estimateEntryCost.TotalFeeCost().Add(estimateEntryCost.SpreadPnL)
+	amount := targetPosition.Abs().Mul(bestPrice)
+	estimateFundingFeePerInterval := amount.Mul(candidate.LastFundingRate.Abs())
+	if estimateFundingFeePerInterval.IsZero() {
+		return fixedpoint.Zero, nil
+	}
+	breakEvenIntervals := totalCost.Div(estimateFundingFeePerInterval).Round(0, fixedpoint.Up)
+	return breakEvenIntervals, nil
 }

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -48,7 +48,7 @@ type Strategy struct {
 	spotMarkets, futuresMarkets       types.MarketMap
 	spotSession, futuresSession       *bbgo.ExchangeSession
 	candidateSymbols                  []string
-	costEstimators                    map[string]*CostEstimator
+	costEstimator                     *CostEstimator
 	preliminaryMarketSelector         *MarketSelector
 
 	coinmarketcapClient *coinmarketcap.DataSource
@@ -99,7 +99,7 @@ func (s *Strategy) Initialize() error {
 	}
 	s.futuresOrderBooks = make(map[string]*types.StreamOrderBook)
 	s.spotOrderBooks = make(map[string]*types.StreamOrderBook)
-	s.costEstimators = make(map[string]*CostEstimator)
+
 	return nil
 }
 
@@ -160,6 +160,18 @@ func (s *Strategy) CrossRun(
 	}
 	s.futuresMarkets = futuresMarkets
 
+	// initialize cost estimator
+	s.costEstimator = NewCostEstimator()
+	s.costEstimator.
+		SetFuturesFeeRate(types.ExchangeFee{
+			MakerFeeRate: s.futuresSession.MakerFeeRate,
+			TakerFeeRate: s.futuresSession.TakerFeeRate,
+		}).
+		SetSpotFeeRate(types.ExchangeFee{
+			MakerFeeRate: s.spotSession.MakerFeeRate,
+			TakerFeeRate: s.spotSession.TakerFeeRate,
+		})
+
 	// static filters
 	var candidateSymbols []string
 	// 1. should be listed on both spot and futures
@@ -202,24 +214,6 @@ func (s *Strategy) CrossRun(
 		spotBook.BindStream(spotStream)
 		spotStream.Subscribe(types.BookChannel, symbol, types.SubscribeOptions{})
 		s.spotOrderBooks[symbol] = spotBook
-
-		market, ok := s.futuresMarkets[symbol]
-		if !ok {
-			return fmt.Errorf("market %s not found in futures markets", symbol)
-		}
-		costEstimator := NewCostEstimator(
-			market, futuresBook, spotBook,
-		)
-		costEstimator.
-			SetFuturesFeeRate(types.ExchangeFee{
-				MakerFeeRate: s.futuresSession.MakerFeeRate,
-				TakerFeeRate: s.futuresSession.TakerFeeRate,
-			}).
-			SetSpotFeeRate(types.ExchangeFee{
-				MakerFeeRate: s.spotSession.MakerFeeRate,
-				TakerFeeRate: s.spotSession.TakerFeeRate,
-			})
-		s.costEstimators[symbol] = costEstimator
 	}
 	if err := futureStream.Connect(ctx); err != nil {
 		return fmt.Errorf("failed to connect future stream books: %w", err)
@@ -434,13 +428,20 @@ func (s *Strategy) selectMostPorfitableMarket(candidates []MarketCandidate) (*Ma
 }
 
 func (s *Strategy) calculateMinHoldingIntervals(candidate MarketCandidate, bestPrice, targetPosition fixedpoint.Value) (fixedpoint.Value, error) {
-	costEstimator := s.costEstimators[candidate.Symbol]
-	costEstimator.SetTargetPosition(targetPosition)
-	estimateEntryCost, err := costEstimator.EstimateEntryCost(true)
+	s.costEstimator.SetTargetPosition(targetPosition)
+	spotOrderBook, spotFound := s.spotOrderBooks[candidate.Symbol]
+	futuresOrderBook, futuresFound := s.futuresOrderBooks[candidate.Symbol]
+	if !spotFound || !futuresFound {
+		return fixedpoint.Zero, errors.New("order book not found for candidate symbol")
+	}
+	spotOrderBookSnapshot := spotOrderBook.Copy()
+	futuresOrderBookShapshot := futuresOrderBook.Copy()
+
+	estimateEntryCost, err := s.costEstimator.EstimateEntryCost(true, spotOrderBookSnapshot, futuresOrderBookShapshot)
 	if err != nil {
 		return fixedpoint.Zero, err
 	}
-	estimateExitCost, err := costEstimator.EstimateExitCost(true)
+	estimateExitCost, err := s.costEstimator.EstimateExitCost(true, spotOrderBookSnapshot, futuresOrderBookShapshot)
 	if err != nil {
 		return fixedpoint.Zero, err
 	}

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -41,6 +41,7 @@ type Strategy struct {
 	futuresOrderBooks, spotOrderBooks map[string]*types.StreamOrderBook
 	spotMarkets, futuresMarkets       types.MarketMap
 	spotSession, futuresSession       *bbgo.ExchangeSession
+	candidateSymbols                  []string
 
 	coinmarketcapClient *coinmarketcap.DataSource
 	mu                  sync.Mutex
@@ -98,17 +99,21 @@ func (s *Strategy) Validate() error {
 }
 
 func (s *Strategy) CrossSubscribe(sessions map[string]*bbgo.ExchangeSession) {
-	spotSession := sessions[s.SpotSession]
-	futuresSession := sessions[s.FuturesSession]
-
-	for _, symbol := range s.CandidateSymbols {
-		spotSession.Subscribe(types.KLineChannel, symbol, types.SubscribeOptions{Interval: types.Interval1m})
-		spotSession.Subscribe(types.BookChannel, symbol, types.SubscribeOptions{})
-		futuresSession.Subscribe(types.KLineChannel, symbol, types.SubscribeOptions{Interval: types.Interval1m})
-		futuresSession.Subscribe(types.BookChannel, symbol, types.SubscribeOptions{})
+	spotSession, ok := sessions[s.SpotSession]
+	if !ok {
+		s.logger.Warnf("spot session %s not found, skip subscription", s.SpotSession)
+		return
 	}
-	spotSession.Subscribe(types.MarketTradeChannel, s.TickSymbol, types.SubscribeOptions{})
-	futuresSession.Subscribe(types.MarketTradeChannel, s.TickSymbol, types.SubscribeOptions{})
+	futuresSession, ok := sessions[s.FuturesSession]
+	if !ok {
+		s.logger.Warnf("futures session %s not found, skip subscription", s.FuturesSession)
+		return
+	}
+
+	for _, sess := range []*bbgo.ExchangeSession{spotSession, futuresSession} {
+		sess.Subscribe(types.KLineChannel, s.TickSymbol, types.SubscribeOptions{Interval: types.Interval1m})
+		sess.Subscribe(types.MarketTradeChannel, s.TickSymbol, types.SubscribeOptions{})
+	}
 }
 
 func (s *Strategy) CrossRun(
@@ -155,6 +160,8 @@ func (s *Strategy) CrossRun(
 		return errors.New("no candidate symbols after filtering")
 	}
 
+	s.candidateSymbols = candidateSymbols
+
 	// subscribe BNB pairs for trading fee calculation
 	quoteCurrencies := make(map[string]struct{})
 	for _, symbol := range candidateSymbols {
@@ -190,12 +197,14 @@ func (s *Strategy) CrossRun(
 		return fmt.Errorf("failed to connect spot stream books: %w", err)
 	}
 
-	s.spotSession.MarketDataStream.OnMarketTrade(types.TradeWith(s.TickSymbol, func(trade types.Trade) {
-		s.tick(trade.Time.Time())
-	}))
-	s.futuresSession.MarketDataStream.OnMarketTrade(types.TradeWith(s.TickSymbol, func(trade types.Trade) {
-		s.tick(trade.Time.Time())
-	}))
+	for _, sess := range []*bbgo.ExchangeSession{s.spotSession, s.futuresSession} {
+		sess.MarketDataStream.OnMarketTrade(types.TradeWith(s.TickSymbol, func(trade types.Trade) {
+			s.tick(trade.Time.Time())
+		}))
+		sess.MarketDataStream.OnKLineClosed(types.KLineWith(s.TickSymbol, types.Interval1m, func(kline types.KLine) {
+			s.tick(kline.EndTime.Time())
+		}))
+	}
 
 	return nil
 }
@@ -204,22 +213,27 @@ func (s *Strategy) tick(tickTime time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.checkRoundStartTime.IsZero() {
+	if s.checkRoundStartTime.IsZero() || s.currentTime.IsZero() {
 		s.checkRoundStartTime = tickTime
+		s.currentTime = tickTime
 		return
 	}
+	// from now on, s.checkRoundStartTime and s.currentTime are not zero
 
-	if !s.currentTime.IsZero() && tickTime.Before(s.currentTime) {
+	// skip tick that's before current time
+	if tickTime.Before(s.currentTime) {
 		return
 	}
 	s.currentTime = tickTime
 
+	// check if it's time to check for new round
 	if s.currentTime.Sub(s.checkRoundStartTime) < s.CheckInterval {
 		return
 	}
 
+	// start checking
 	// 1. check if any open round needs to be closed
-	// 2. check if new round can be opened
+	// 2. check if new round can be opened or existing round needs to be adjusted
 
 	// check interval done, reset and start new check interval
 	s.checkRoundStartTime = s.currentTime


### PR DESCRIPTION
- Add `FuturesDirection`
    - when it is `"short"`, the strategy will only short on the futures.
    - when it is `"long"`, the strategy will only long on the futures.
- select market to start a new round based on profitability
    - the most profitable markets = the market that can break-even with the entry+exit cost fastest