### PR TITLE
FIX: [binance] migrate the futures ws address to new method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,14 @@ go 1.25.0
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/squirrel v1.5.3
-	github.com/adshao/go-binance/v2 v2.8.9
+	github.com/adshao/go-binance/v2 v2.8.11
 	github.com/c-bata/goptuna v0.8.1
 	github.com/c9s/requestgen v1.6.0
 	github.com/c9s/rockhopper/v2 v2.0.6
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/codingconcepts/env v0.0.0-20200821220118-a8fbf8d84482
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/fatih/color v1.14.1
@@ -32,6 +33,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/leekchan/accounting v0.0.0-20191218023648-17a4ce5f94d4
 	github.com/mattn/go-shellwords v1.0.12
+	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/muesli/clusters v0.0.0-20180605185049-a07a36e67d36
 	github.com/muesli/kmeans v0.3.0
 	github.com/pkg/errors v0.9.1
@@ -53,6 +55,7 @@ require (
 	github.com/zserge/lorca v0.1.9
 	go.uber.org/mock v0.4.0
 	go.uber.org/multierr v1.11.0
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/oauth2 v0.22.0
 	golang.org/x/sync v0.18.0
 	golang.org/x/time v0.6.0
@@ -81,7 +84,6 @@ require (
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/denisenkom/go-mssqldb v0.12.3 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -116,7 +118,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/mattn/go-sqlite3 v1.14.42 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -146,7 +147,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	golang.org/x/arch v0.9.0 // indirect
 	golang.org/x/crypto v0.44.0 // indirect
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/image v0.22.0 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
-github.com/adshao/go-binance/v2 v2.8.9 h1:NX+4u/LgEmrjTS7OMWU+9ZgfHKFM61RPhnr9/SqWPhc=
-github.com/adshao/go-binance/v2 v2.8.9/go.mod h1:XkkuecSyJKPolaCGf/q4ovJYB3t0P+7RUYTbGr+LMGM=
+github.com/adshao/go-binance/v2 v2.8.11 h1:uE9bERWjrUMykankotJrEdSmweYL65Zv/auQHzutEMM=
+github.com/adshao/go-binance/v2 v2.8.11/go.mod h1:XkkuecSyJKPolaCGf/q4ovJYB3t0P+7RUYTbGr+LMGM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -412,8 +412,6 @@ github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.23 h1:gbShiuAP1W5j9UOksQ06aiiqPMxYecovVGwmTxWtuw0=
-github.com/mattn/go-sqlite3 v1.14.23/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/go-sqlite3 v1.14.42 h1:MigqEP4ZmHw3aIdIT7T+9TLa90Z6smwcthx+Azv4Cgo=
 github.com/mattn/go-sqlite3 v1.14.42/go.mod h1:pjEuOr8IwzLJP2MfGeTb0A35jauH+C2kbHKBr7yXKVQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/pkg/exchange/binance/exchange.go
+++ b/pkg/exchange/binance/exchange.go
@@ -59,6 +59,15 @@ const WsTestNetWebSocketURL = "wss://testnet.binance.vision/ws-api/v3"
 const WsFuturesWebSocketURL = "wss://ws-fapi.binance.com/ws-fapi/v1"
 const WsTestNetFuturesWebSocketURL = "wss://testnet.binancefuture.com/ws-fapi/v1"
 
+// Futures segmented WebSocket endpoints (new as of 2025-10, replaces deprecated /ws path)
+const FuturesPublicWebSocketURL  = "wss://fstream.binance.com/public"
+const FuturesMarketWebSocketURL  = "wss://fstream.binance.com/market"
+const FuturesPrivateWebSocketURL = "wss://fstream.binance.com/private"
+
+const TestNetFuturesPublicWebSocketURL  = "wss://stream.binancefuture.com/public"
+const TestNetFuturesMarketWebSocketURL  = "wss://stream.binancefuture.com/market"
+const TestNetFuturesPrivateWebSocketURL = "wss://stream.binancefuture.com/private"
+
 // orderLimiter - the default order limiter apply 5 requests per second and a 2 initial bucket
 // this includes SubmitOrder, CancelOrder and QueryClosedOrders
 //

--- a/pkg/exchange/binance/stream.go
+++ b/pkg/exchange/binance/stream.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/sirupsen/logrus"
 
 	"github.com/c9s/bbgo/pkg/depth"
@@ -120,6 +121,13 @@ type Stream struct {
 	listenToken           string
 	listenTokenExpiration time.Time
 	once                  util.Reonce
+
+	// futuresAuxStream handles /public subscriptions (depth, bookTicker) when the main
+	// stream connects to /market. Only created for futures PublicOnly streams with mixed
+	// subscription types. nil when not needed.
+	futuresAuxStream  *types.StandardStream
+	futuresPublicSubs []types.Subscription // cached /public subscriptions
+	futuresMarketSubs []types.Subscription // cached /market subscriptions
 }
 
 func NewStream(ex *Exchange, client *binance.Client, futuresClient *futures.Client) *Stream {
@@ -256,8 +264,30 @@ func (s *Stream) handleBeforeConnect(ctx context.Context) error {
 
 func (s *Stream) handleConnect() {
 	if s.PublicOnly {
-		if err := s.writeSubscriptions(); err != nil {
-			log.WithError(err).Error("subscribe error")
+		if s.exchange.IsFutures {
+			// Determine which subscriptions to send on the main connection:
+			//   - mixed or market-only → main conn is /market → send futuresMarketSubs
+			//   - public-only (depth/bookTicker only) → main conn is /public → send futuresPublicSubs
+			mainSubs := s.futuresMarketSubs
+			if s.futuresAuxStream == nil && len(s.futuresPublicSubs) > 0 {
+				mainSubs = s.futuresPublicSubs
+			}
+			if err := s.writeSpecificSubscriptions(s.Conn, mainSubs); err != nil {
+				log.WithError(err).Error("futures subscribe error")
+			}
+			// if mixed subscriptions, connect aux stream to /public independently
+			if s.futuresAuxStream != nil {
+				connCtx := s.ConnCtx
+				go func() {
+					if err := s.futuresAuxStream.DialAndConnect(connCtx); err != nil {
+						log.WithError(err).Error("futures aux stream (/public) connect error")
+					}
+				}()
+			}
+		} else {
+			if err := s.writeSubscriptions(); err != nil {
+				log.WithError(err).Error("subscribe error")
+			}
 		}
 	} else if s.canUseWsApiEndpoint() {
 
@@ -267,7 +297,7 @@ func (s *Stream) handleConnect() {
 
 		time.Sleep(1 * time.Second)
 
-		// futures does
+		// futures does not support ed25519 login on WsApi
 		if !s.exchange.IsFutures {
 			if err := s.sendSubscribeUserDataStreamCommand(); err != nil {
 				log.WithError(err).Error("subscribe user data stream error")
@@ -295,6 +325,20 @@ func (s *Stream) handleConnect() {
 		// spawn a goroutine to emit auth event to prevent blocking the main event loop
 		go s.EmitAuth()
 	}
+}
+
+// Close closes the stream and, if present, the auxiliary futures /public stream.
+func (s *Stream) Close() error {
+	s.ConnLock.Lock()
+	auxStream := s.futuresAuxStream
+	s.ConnLock.Unlock()
+
+	if auxStream != nil {
+		if err := auxStream.Close(); err != nil {
+			log.WithError(err).Warn("futures aux stream close error")
+		}
+	}
+	return s.StandardStream.Close()
 }
 
 // sendEd25519LoginCommand
@@ -342,25 +386,48 @@ func (s *Stream) sendListenTokenSubscribeCommand() error {
 	})
 }
 
-// writeSubscriptions send the subscription command to the websocket
-// server in order to establish the connection to market data sources
-func (s *Stream) writeSubscriptions() error {
-	var params []string
-	for _, subscription := range s.Subscriptions {
-		params = append(params, convertSubscription(subscription))
-	}
-	if len(params) == 0 {
+// writeSpecificSubscriptions sends a SUBSCRIBE command for a given set of subscriptions
+// on the provided connection. Returns nil without writing if subs is empty or conn is nil.
+func (s *Stream) writeSpecificSubscriptions(conn *websocket.Conn, subs []types.Subscription) error {
+	if len(subs) == 0 {
 		return nil
 	}
-
+	var params []string
+	for _, subscription := range subs {
+		params = append(params, convertSubscription(subscription))
+	}
 	// TODO: handle subscribe response
 	// sample response: {"result":null,"id":2}
 	log.Infof("subscribing channels: %+v", params)
-	return s.Conn.WriteJSON(&WebSocketCommand{
+	return conn.WriteJSON(&WebSocketCommand{
 		Method: "SUBSCRIBE",
 		Params: params,
 		ID:     2,
 	})
+}
+
+// writeSubscriptions sends a SUBSCRIBE command for all of s.Subscriptions.
+func (s *Stream) writeSubscriptions() error {
+	return s.writeSpecificSubscriptions(s.Conn, s.Subscriptions)
+}
+
+// initFuturesAuxStream creates the auxiliary StandardStream that connects to the futures
+// /public endpoint. It shares the same parser and dispatcher as the main stream so that
+// events are delivered through the same callback system.
+// Only called once; handleConnect guards with futuresAuxStream != nil check.
+func (s *Stream) initFuturesAuxStream() {
+	aux := types.NewStandardStream()
+	aux.SetParser(parseWebSocketEvent)
+	aux.SetDispatcher(s.dispatchEvent)
+	aux.SetEndpointCreator(func(ctx context.Context) (string, error) {
+		return s.getFuturesPublicEndpointUrl(), nil
+	})
+	aux.OnConnect(func() {
+		if err := s.writeSpecificSubscriptions(aux.Conn, s.futuresPublicSubs); err != nil {
+			log.WithError(err).Error("futures aux stream /public subscribe error")
+		}
+	})
+	s.futuresAuxStream = &aux
 }
 
 func (s *Stream) handleContinuousKLineEvent(e *ContinuousKLineEvent) {
@@ -509,11 +576,22 @@ func (s *Stream) handleOrderTradeUpdateEvent(e *OrderTradeUpdateEvent) {
 
 func (s *Stream) getPublicEndpointUrl() string {
 	if s.exchange.IsFutures {
-		if testNet {
-			return TestNetFuturesBaseURL + "/ws"
+		s.futuresPublicSubs, s.futuresMarketSubs = classifyFuturesSubscriptions(s.Subscriptions)
+		if len(s.futuresPublicSubs) > 0 && len(s.futuresMarketSubs) > 0 {
+			// Mixed: main stream → /market, aux stream → /public (init once)
+			if s.futuresAuxStream == nil {
+				s.initFuturesAuxStream()
+			}
+
+			return s.getFuturesMarketEndpointUrl()
+		} else if len(s.futuresPublicSubs) > 0 {
+
+			// Only depth/bookTicker subscriptions
+			return s.getFuturesPublicEndpointUrl()
 		}
 
-		return FuturesWebSocketURL + "/ws"
+		// Only market subscriptions (or no subscriptions yet)
+		return s.getFuturesMarketEndpointUrl()
 	} else if isBinanceUs() {
 		if testNet {
 			return BinanceTestBaseURL + "/ws"
@@ -531,6 +609,10 @@ func (s *Stream) getPublicEndpointUrl() string {
 }
 
 func (s *Stream) getUserDataStreamEndpointUrl(listenKey string) string {
+	if s.exchange.IsFutures {
+		return s.getFuturesPrivateEndpointUrl(listenKey)
+	}
+
 	u := s.getPublicEndpointUrl()
 	return u + "/" + listenKey
 }
@@ -878,4 +960,55 @@ func (s *Stream) handleAlgoOrderUpdateEvent(e *AlgoOrderUpdateEvent) {
 	}
 
 	s.EmitOrderUpdate(*order)
+}
+
+// isFuturesPublicChannel reports whether a channel belongs to the /public endpoint.
+// The /public endpoint handles high-frequency data: depth and bookTicker.
+// All other channels belong to the /market endpoint.
+func isFuturesPublicChannel(ch types.Channel) bool {
+	switch ch {
+	case types.BookChannel, types.BookTickerChannel:
+		return true
+	}
+	return false
+}
+
+// classifyFuturesSubscriptions splits subscriptions into /public and /market groups.
+func classifyFuturesSubscriptions(subs []types.Subscription) (public, market []types.Subscription) {
+	for _, s := range subs {
+		if isFuturesPublicChannel(s.Channel) {
+			public = append(public, s)
+		} else {
+			market = append(market, s)
+		}
+	}
+	return
+}
+
+func (s *Stream) getFuturesPublicEndpointUrl() string {
+	if testNet {
+		return TestNetFuturesPublicWebSocketURL + "/ws"
+	}
+	return FuturesPublicWebSocketURL + "/ws"
+}
+
+func (s *Stream) getFuturesMarketEndpointUrl() string {
+	if testNet {
+		return TestNetFuturesMarketWebSocketURL + "/ws"
+	}
+	return FuturesMarketWebSocketURL + "/ws"
+}
+
+// futuresPrivateStreamEvents lists the user data stream events to subscribe on the new
+// /private endpoint. The &events= parameter is required — omitting it causes Binance to
+// push listenKeyExpired immediately after connecting.
+// Ref: https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice
+const futuresPrivateStreamEvents = "ORDER_TRADE_UPDATE/TRADE_LITE/ACCOUNT_UPDATE/ACCOUNT_CONFIG_UPDATE/MARGIN_CALL/ALGO_UPDATE"
+
+func (s *Stream) getFuturesPrivateEndpointUrl(listenKey string) string {
+	base := FuturesPrivateWebSocketURL
+	if testNet {
+		base = TestNetFuturesPrivateWebSocketURL
+	}
+	return base + "/ws?listenKey=" + listenKey + "&events=" + futuresPrivateStreamEvents
 }

--- a/pkg/exchange/binance/stream_test.go
+++ b/pkg/exchange/binance/stream_test.go
@@ -1,0 +1,135 @@
+package binance
+
+import (
+	"testing"
+
+	"github.com/c9s/bbgo/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsFuturesPublicChannel(t *testing.T) {
+	assert.True(t, isFuturesPublicChannel(types.BookChannel))
+	assert.True(t, isFuturesPublicChannel(types.BookTickerChannel))
+	assert.False(t, isFuturesPublicChannel(types.KLineChannel))
+	assert.False(t, isFuturesPublicChannel(types.AggTradeChannel))
+	assert.False(t, isFuturesPublicChannel(types.MarketTradeChannel))
+	assert.False(t, isFuturesPublicChannel(types.MarkPriceChannel))
+	assert.False(t, isFuturesPublicChannel(types.ForceOrderChannel))
+}
+
+func TestClassifyFuturesSubscriptions(t *testing.T) {
+	subs := []types.Subscription{
+		{Channel: types.BookChannel, Symbol: "BTCUSDT"},
+		{Channel: types.BookTickerChannel, Symbol: "ETHUSDT"},
+		{Channel: types.KLineChannel, Symbol: "BTCUSDT"},
+		{Channel: types.AggTradeChannel, Symbol: "BTCUSDT"},
+		{Channel: types.MarkPriceChannel, Symbol: "BTCUSDT"},
+	}
+	public, market := classifyFuturesSubscriptions(subs)
+	assert.Len(t, public, 2)
+	assert.Len(t, market, 3)
+	assert.Equal(t, types.BookChannel, public[0].Channel)
+	assert.Equal(t, types.BookTickerChannel, public[1].Channel)
+	assert.Equal(t, types.KLineChannel, market[0].Channel)
+}
+
+func TestClassifyFuturesSubscriptions_OnlyPublic(t *testing.T) {
+	subs := []types.Subscription{{Channel: types.BookChannel, Symbol: "BTCUSDT"}}
+	public, market := classifyFuturesSubscriptions(subs)
+	assert.Len(t, public, 1)
+	assert.Empty(t, market)
+}
+
+func TestClassifyFuturesSubscriptions_OnlyMarket(t *testing.T) {
+	subs := []types.Subscription{{Channel: types.KLineChannel, Symbol: "BTCUSDT"}}
+	public, market := classifyFuturesSubscriptions(subs)
+	assert.Empty(t, public)
+	assert.Len(t, market, 1)
+}
+
+func TestGetFuturesPublicEndpointUrl(t *testing.T) {
+	s := &Stream{exchange: &Exchange{}}
+	testNet = false
+	assert.Equal(t, FuturesPublicWebSocketURL+"/ws", s.getFuturesPublicEndpointUrl())
+}
+
+func TestGetFuturesMarketEndpointUrl(t *testing.T) {
+	s := &Stream{exchange: &Exchange{}}
+	testNet = false
+	assert.Equal(t, FuturesMarketWebSocketURL+"/ws", s.getFuturesMarketEndpointUrl())
+}
+
+func TestGetFuturesPrivateEndpointUrl(t *testing.T) {
+	s := &Stream{exchange: &Exchange{}}
+	testNet = false
+	url := s.getFuturesPrivateEndpointUrl("mykey123")
+	assert.Equal(t, FuturesPrivateWebSocketURL+"/ws?listenKey=mykey123&events="+futuresPrivateStreamEvents, url)
+}
+
+func TestWriteSpecificSubscriptions_Empty(t *testing.T) {
+	s := &Stream{exchange: &Exchange{}}
+	// nil conn — should return nil without panicking when subs is empty
+	err := s.writeSpecificSubscriptions(nil, nil)
+	assert.NoError(t, err)
+}
+
+func TestGetPublicEndpointUrl_FuturesOnlyMarket(t *testing.T) {
+	testNet = false
+	ex := &Exchange{}
+	ex.FuturesSettings.IsFutures = true
+	s := &Stream{
+		StandardStream: types.NewStandardStream(),
+		exchange:       ex,
+	}
+	s.Subscriptions = []types.Subscription{
+		{Channel: types.KLineChannel, Symbol: "BTCUSDT"},
+	}
+	url := s.getPublicEndpointUrl()
+	assert.Equal(t, FuturesMarketWebSocketURL+"/ws", url)
+	assert.Nil(t, s.futuresAuxStream)
+}
+
+func TestGetPublicEndpointUrl_FuturesOnlyPublic(t *testing.T) {
+	testNet = false
+	ex := &Exchange{}
+	ex.FuturesSettings.IsFutures = true
+	s := &Stream{
+		StandardStream: types.NewStandardStream(),
+		exchange:       ex,
+	}
+	s.Subscriptions = []types.Subscription{
+		{Channel: types.BookChannel, Symbol: "BTCUSDT"},
+	}
+	url := s.getPublicEndpointUrl()
+	assert.Equal(t, FuturesPublicWebSocketURL+"/ws", url)
+	assert.Nil(t, s.futuresAuxStream)
+}
+
+func TestGetPublicEndpointUrl_FuturesMixed(t *testing.T) {
+	testNet = false
+	ex := &Exchange{}
+	ex.FuturesSettings.IsFutures = true
+	s := &Stream{
+		StandardStream: types.NewStandardStream(),
+		exchange:       ex,
+	}
+	s.Subscriptions = []types.Subscription{
+		{Channel: types.BookChannel, Symbol: "BTCUSDT"},
+		{Channel: types.KLineChannel, Symbol: "BTCUSDT"},
+	}
+	url := s.getPublicEndpointUrl()
+	assert.Equal(t, FuturesMarketWebSocketURL+"/ws", url)
+	assert.NotNil(t, s.futuresAuxStream)
+}
+
+func TestGetUserDataStreamEndpointUrl_Futures(t *testing.T) {
+	testNet = false
+	ex := &Exchange{}
+	ex.FuturesSettings.IsFutures = true
+	s := &Stream{
+		StandardStream: types.NewStandardStream(),
+		exchange:       ex,
+	}
+	url := s.getUserDataStreamEndpointUrl("listenkey123")
+	assert.Equal(t, FuturesPrivateWebSocketURL+"/ws?listenKey=listenkey123&events="+futuresPrivateStreamEvents, url)
+}


### PR DESCRIPTION
https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#%E5%85%BC%E5%AE%B9%E6%80%A7%E4%B8%8E%E8%BF%81%E7%A7%BB%E5%BB%BA%E8%AE%AEmigration
Due to sustained heavy traffic, upgraded the WebSocket URL structure by introducing a root plus dedicated entry points for Public / Market / Private traffic. This separation improves stability, scalability, and operational isolation across different data types. The legacy URLs will remain available until 2026-04-23