### PR TITLE
FIX: [xfundingv2] fix ticking and orders/trades tracking

### DIFF
--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -41,9 +41,11 @@ type transferRetry struct {
 type ArbitrageRound struct {
 	mu sync.Mutex
 
-	triggeredFundingRate fixedpoint.Value
-	minHoldingIntervals  int
-	fundingIntervalHours int
+	triggeredFundingRate                     fixedpoint.Value
+	minHoldingIntervals                      int
+	fundingIntervalHours                     int
+	fundingIntervalStart, fundingIntervalEnd time.Time
+	fundingFeeRecords                        map[int64]FundingFee
 
 	// TWAP workers
 	spotWorker     *TWAPWorker
@@ -54,8 +56,6 @@ type ArbitrageRound struct {
 	retryDuration      time.Duration
 	retryTransferTickC chan time.Time
 	retryTransfers     map[uint64]transferRetry
-
-	fundingFeeRecords map[int64]FundingFee
 
 	state RoundState
 
@@ -69,7 +69,7 @@ type ArbitrageRound struct {
 }
 
 func NewArbitrageRound(
-	fundingRate fixedpoint.Value, minHoldingIntervals, fundingIntervalHours int,
+	fundingRate *types.PremiumIndex, minHoldingIntervals, fundingIntervalHours int,
 	spotTwap, futuresTwap *TWAPWorker, futuresService FuturesService) *ArbitrageRound {
 	var asset string
 	if spotTwap.TargetPosition().Sign() > 0 {
@@ -79,18 +79,25 @@ func NewArbitrageRound(
 		// short spot, long futures -> collateral is quote asset
 		asset = spotTwap.Market().QuoteCurrency
 	}
+	fundingIntervalStart := fundingRate.NextFundingTime.Add(-time.Duration(fundingIntervalHours) * time.Hour)
+	fundingIntervalEnd := fundingRate.NextFundingTime.Add(-time.Second)
 	return &ArbitrageRound{
-		triggeredFundingRate: fundingRate,
+		triggeredFundingRate: fundingRate.LastFundingRate,
 		minHoldingIntervals:  minHoldingIntervals,
 		fundingIntervalHours: fundingIntervalHours,
-		spotWorker:           spotTwap,
-		futuresWorker:        futuresTwap,
-		futuresService:       futuresService,
-		asset:                asset,
-		state:                RoundPending,
-		retryTransfers:       make(map[uint64]transferRetry),
-		retryTransferTickC:   make(chan time.Time, 1),
+		fundingIntervalStart: fundingIntervalStart,
+		fundingIntervalEnd:   fundingIntervalEnd,
 		fundingFeeRecords:    make(map[int64]FundingFee),
+
+		spotWorker:    spotTwap,
+		futuresWorker: futuresTwap,
+
+		futuresService: futuresService,
+		asset:          asset,
+
+		state:              RoundPending,
+		retryTransfers:     make(map[uint64]transferRetry),
+		retryTransferTickC: make(chan time.Time, 1),
 	}
 }
 
@@ -103,10 +110,9 @@ func (r *ArbitrageRound) IsClosable(currentTime time.Time) bool {
 		return false
 	}
 	intervalDuration := time.Duration(r.fundingIntervalHours) * time.Hour
-	intervalStart := r.startTime.Truncate(intervalDuration)
 	lastIntervalEnd := currentTime.Truncate(intervalDuration)
-	numIntervalPassed := int(lastIntervalEnd.Sub(intervalStart) / intervalDuration)
-	return numIntervalPassed > r.minHoldingIntervals
+	numIntervalPassed := int(lastIntervalEnd.Sub(r.fundingIntervalStart) / intervalDuration)
+	return numIntervalPassed >= r.minHoldingIntervals
 }
 
 func (r *ArbitrageRound) String() string {
@@ -232,6 +238,14 @@ func (r *ArbitrageRound) syncFundingFeeRecords(ctx context.Context, currentTime 
 
 func (r *ArbitrageRound) Start(ctx context.Context, currentTime time.Time) error {
 	if r.startTime.IsZero() {
+		if currentTime.After(r.fundingIntervalEnd) {
+			// the round is triggered after the funding interval -> error
+			return fmt.Errorf(
+				"the round is triggered after the funding interval end (%s): %s",
+				r.fundingIntervalEnd.Format(time.RFC3339),
+				currentTime.Format(time.RFC3339),
+			)
+		}
 		if err := r.spotWorker.Start(ctx, currentTime); err != nil {
 			return fmt.Errorf("failed to start spot worker: %w", err)
 		}

--- a/pkg/strategy/xfundingv2/arb_round_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_test.go
@@ -1,0 +1,190 @@
+package xfundingv2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/c9s/bbgo/pkg/exchange/binance/binanceapi"
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+
+	. "github.com/c9s/bbgo/pkg/testing/testhelper"
+)
+
+// mockFuturesService implements FuturesService for testing
+type mockFuturesService struct {
+	incomeHistory []binanceapi.FuturesIncome
+	transferErr   error
+}
+
+func (m *mockFuturesService) QueryFuturesIncomeHistory(
+	ctx context.Context, symbol string, incomeType binanceapi.FuturesIncomeType,
+	startTime, endTime *time.Time,
+) ([]binanceapi.FuturesIncome, error) {
+	return m.incomeHistory, nil
+}
+
+func (m *mockFuturesService) TransferFuturesAccountAsset(
+	ctx context.Context, asset string, amount fixedpoint.Value, direction types.TransferDirection,
+) error {
+	return m.transferErr
+}
+
+func (m *mockFuturesService) QueryPremiumIndex(ctx context.Context, symbol string) (*types.PremiumIndex, error) {
+	return nil, nil
+}
+
+func newTestArbitrageRound(t *testing.T, ctrl *gomock.Controller, fundingIntervalHours, minHoldingIntervals int, nextFundingTime time.Time) (*ArbitrageRound, *mockFuturesService) {
+	config := TWAPWorkerConfig{
+		Duration:  10 * time.Minute,
+		NumSlices: 5,
+	}
+
+	spotWorker, _, _, _ := newTestTWAPWorker(t, ctrl, config)
+	spotWorker.SetTargetPosition(Number(1.0)) // long spot
+
+	futuresWorker, _, _, _ := newTestTWAPWorker(t, ctrl, config)
+	futuresWorker.SetTargetPosition(Number(-1.0)) // short futures
+
+	mockService := &mockFuturesService{}
+
+	fundingRate := &types.PremiumIndex{
+		LastFundingRate: Number(0.001),
+		NextFundingTime: nextFundingTime,
+	}
+
+	round := NewArbitrageRound(fundingRate, minHoldingIntervals, fundingIntervalHours, spotWorker, futuresWorker, mockService)
+	return round, mockService
+}
+
+func TestArbitrageRound_IsClosable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// funding interval: 8 hours, min holding: 3 intervals
+	// nextFundingTime = 2024-01-01 08:00 UTC
+	// fundingIntervalStart = 2024-01-01 00:00 UTC
+	nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+	round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+
+	t.Run("not closable when startTime is zero", func(t *testing.T) {
+		currentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+		assert.False(t, round.IsClosable(currentTime))
+	})
+
+	// Set startTime to simulate a started round
+	round.startTime = time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	t.Run("not closable before min holding intervals", func(t *testing.T) {
+		// fundingIntervalStart = 2024-01-01 00:00 UTC
+		// After 2 intervals (16h): currentTime = 2024-01-01 16:00 UTC
+		// lastIntervalEnd = Truncate(16:00, 8h) = 16:00
+		// numIntervalPassed = (16:00 - 00:00) / 8h = 2
+		// 2 < 3 (minHoldingIntervals) -> not closable
+		currentTime := time.Date(2024, 1, 1, 16, 0, 0, 0, time.UTC)
+		assert.False(t, round.IsClosable(currentTime))
+	})
+
+	t.Run("closable after min holding intervals", func(t *testing.T) {
+		// After 3 intervals (24h): currentTime = 2024-01-02 00:00 UTC
+		// lastIntervalEnd = Truncate(00:00 on Jan 2, 8h) = 00:00 on Jan 2
+		// numIntervalPassed = (24:00 - 00:00) / 8h = 3
+		// 3 >= 3 -> closable
+		currentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+		assert.True(t, round.IsClosable(currentTime))
+	})
+
+	t.Run("closable well after min holding intervals", func(t *testing.T) {
+		// After 5 intervals (40h): currentTime = 2024-01-02 16:00 UTC
+		currentTime := time.Date(2024, 1, 2, 16, 0, 0, 0, time.UTC)
+		assert.True(t, round.IsClosable(currentTime))
+	})
+
+	t.Run("not closable in middle of interval period", func(t *testing.T) {
+		// currentTime = 2024-01-01 20:00 UTC (between 2nd and 3rd interval)
+		// lastIntervalEnd = Truncate(20:00, 8h) = 16:00
+		// numIntervalPassed = (16:00 - 00:00) / 8h = 2
+		// 2 < 3 -> not closable
+		currentTime := time.Date(2024, 1, 1, 20, 0, 0, 0, time.UTC)
+		assert.False(t, round.IsClosable(currentTime))
+	})
+}
+
+func TestArbitrageRound_CollectedFunding(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+	round, mockService := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+
+	t.Run("returns zero when startTime is zero", func(t *testing.T) {
+		ctx := context.Background()
+		currentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+		result := round.CollectedFunding(ctx, currentTime)
+		assert.Equal(t, fixedpoint.Zero, result)
+	})
+
+	t.Run("sums funding fee records", func(t *testing.T) {
+		round.startTime = time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC)
+
+		// Simulate funding fee income returned by the service
+		mockService.incomeHistory = []binanceapi.FuturesIncome{
+			{
+				Symbol:     "BTCUSDT",
+				IncomeType: binanceapi.FuturesIncomeFundingFee,
+				Income:     Number(0.005),
+				Asset:      "USDT",
+				TranId:     1001,
+				Time:       types.NewMillisecondTimestampFromInt(time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC).UnixMilli()),
+			},
+			{
+				Symbol:     "BTCUSDT",
+				IncomeType: binanceapi.FuturesIncomeFundingFee,
+				Income:     Number(0.003),
+				Asset:      "USDT",
+				TranId:     1002,
+				Time:       types.NewMillisecondTimestampFromInt(time.Date(2024, 1, 1, 16, 0, 0, 0, time.UTC).UnixMilli()),
+			},
+		}
+
+		ctx := context.Background()
+		currentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+		result := round.CollectedFunding(ctx, currentTime)
+
+		expected := Number(0.005).Add(Number(0.003))
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("deduplicates by transaction ID", func(t *testing.T) {
+		// Call again with same income history - should not double-count
+		ctx := context.Background()
+		currentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+		result := round.CollectedFunding(ctx, currentTime)
+
+		expected := Number(0.005).Add(Number(0.003))
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("accumulates new records", func(t *testing.T) {
+		// Add a third funding fee
+		mockService.incomeHistory = append(mockService.incomeHistory, binanceapi.FuturesIncome{
+			Symbol:     "BTCUSDT",
+			IncomeType: binanceapi.FuturesIncomeFundingFee,
+			Income:     Number(0.002),
+			Asset:      "USDT",
+			TranId:     1003,
+			Time:       types.NewMillisecondTimestampFromInt(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC).UnixMilli()),
+		})
+
+		ctx := context.Background()
+		currentTime := time.Date(2024, 1, 2, 8, 0, 0, 0, time.UTC)
+		result := round.CollectedFunding(ctx, currentTime)
+
+		expected := Number(0.005).Add(Number(0.003)).Add(Number(0.002))
+		assert.Equal(t, expected, result)
+	})
+}

--- a/pkg/strategy/xfundingv2/market_selector.go
+++ b/pkg/strategy/xfundingv2/market_selector.go
@@ -74,7 +74,7 @@ func (c *MarketSelectionConfig) Defaults() {
 type MarketCandidate struct {
 	Symbol string
 
-	LastFundingRate fixedpoint.Value
+	PremiumIndex *types.PremiumIndex
 	// FundingIntervalHours is the funding interval in hours (e.g., 8 for 8h funding)
 	// It's normally 8 for the most Binance perpetuals, but some may have different intervals like 4h.
 	// See https://www.binance.com/en/futures/funding-history/perpetual/real-time-funding-rate
@@ -186,7 +186,7 @@ func (s *MarketSelector) SelectMarkets(ctx context.Context, symbols []string) ([
 		candidates = append(candidates, MarketCandidate{
 			Symbol:                 idx.Symbol,
 			FundingIntervalHours:   info.FundingIntervalHours,
-			LastFundingRate:        idx.LastFundingRate,
+			PremiumIndex:           idx,
 			AnnualizedRate:         annualized,
 			TakerBuyQuoteVolume24h: takerQuoteVol,
 			InRangeDepth:           inRangeDepth,

--- a/pkg/strategy/xfundingv2/market_selector.go
+++ b/pkg/strategy/xfundingv2/market_selector.go
@@ -83,6 +83,7 @@ type MarketCandidate struct {
 	TakerBuyQuoteVolume24h fixedpoint.Value
 	InRangeDepth           fixedpoint.Value
 
+	TargetFuturesPosition fixedpoint.Value
 	// MinHoldingDuration is the estimated minimum holding interval to break even for this market candidate
 	MinHoldingDuration time.Duration
 	// MiinHoldingIntervals = MinHoldingDuration / FundingIntervalHours

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -167,7 +167,6 @@ func (s *Strategy) CrossSubscribe(sessions map[string]*bbgo.ExchangeSession) {
 
 	for _, sess := range []*bbgo.ExchangeSession{spotSession, futuresSession} {
 		sess.Subscribe(types.KLineChannel, s.TickSymbol, types.SubscribeOptions{Interval: types.Interval1m})
-		sess.Subscribe(types.MarketTradeChannel, s.TickSymbol, types.SubscribeOptions{})
 	}
 }
 
@@ -318,9 +317,6 @@ func (s *Strategy) CrossRun(
 	s.preliminaryMarketSelector = NewMarketSelector(*s.MarketSelectionConfig, binanceEx, s.logger)
 
 	for _, sess := range []*bbgo.ExchangeSession{s.spotSession, s.futuresSession} {
-		sess.MarketDataStream.OnMarketTrade(types.TradeWith(s.TickSymbol, func(trade types.Trade) {
-			s.tick(ctx, trade.Time.Time())
-		}))
 		sess.MarketDataStream.OnKLineClosed(types.KLineWith(s.TickSymbol, types.Interval1m, func(kline types.KLine) {
 			s.tick(ctx, kline.EndTime.Time())
 		}))

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -477,7 +477,7 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 			return
 		}
 
-		selectedCandidate, _ := s.selectMostPorfitableMarket(candidates)
+		selectedCandidate := s.selectMostPorfitableMarket(candidates)
 		if selectedCandidate == nil {
 			// no profitable candidate found, nothing to do
 			return
@@ -490,6 +490,7 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 				s.logger.WithError(err).Errorf("failed to create TWAP worker for spot %s", selectedCandidate.Symbol)
 				return
 			}
+			spotTwap.SetTargetPosition(selectedCandidate.TargetFuturesPosition.Neg())
 			futuresExecutor := s.futuresGeneralOrderExecutors[selectedCandidate.Symbol]
 			futuresTwap, err := NewTWAPWorker(ctx, selectedCandidate.Symbol, s.futuresSession, futuresExecutor, s.TWAPWorkerConfig)
 			if err != nil {
@@ -593,13 +594,13 @@ func (s *Strategy) filterMarketCollateralRate(ctx context.Context, symbols []str
 // selectMostProfitableMarket selects the most profitable market among the candidates based on the estimated break-even holding intervals
 // it will also return the target position for the futures trade
 // the most profitable market is the one with the shortest break-even holding intervals
-func (s *Strategy) selectMostPorfitableMarket(candidates []MarketCandidate) (*MarketCandidate, fixedpoint.Value) {
+func (s *Strategy) selectMostPorfitableMarket(candidates []MarketCandidate) *MarketCandidate {
 	if len(candidates) == 0 {
-		return nil, fixedpoint.Zero
+		return nil
 	}
 	spotAccount := s.spotSession.GetAccount()
 	breakevenIntervals := make(map[string]fixedpoint.Value)
-	targetPositions := make(map[string]fixedpoint.Value)
+	targetFuturePositions := make(map[string]fixedpoint.Value)
 	for _, candidate := range candidates {
 		spotMarket, ok := s.spotSession.Market(candidate.Symbol)
 		if !ok {
@@ -624,7 +625,7 @@ func (s *Strategy) selectMostPorfitableMarket(candidates []MarketCandidate) (*Ma
 				continue
 			}
 			breakevenIntervals[candidate.Symbol] = breakEvenIntervals
-			targetPositions[candidate.Symbol] = targetSize.Neg()
+			targetFuturePositions[candidate.Symbol] = targetSize.Neg()
 		} else if s.MarketSelectionConfig.FuturesDirection == types.PositionLong {
 			baseBalance, ok := spotAccount.Balance(spotMarket.BaseCurrency)
 			if !ok {
@@ -640,13 +641,13 @@ func (s *Strategy) selectMostPorfitableMarket(candidates []MarketCandidate) (*Ma
 				continue
 			}
 			breakevenIntervals[candidate.Symbol] = breakEvenIntervals
-			targetPositions[candidate.Symbol] = targetSize
+			targetFuturePositions[candidate.Symbol] = targetSize
 		} else {
-			return nil, fixedpoint.Zero
+			return nil
 		}
 	}
 	if len(breakevenIntervals) == 0 {
-		return nil, fixedpoint.Zero
+		return nil
 	}
 	sortedCandidates := candidates
 	sort.Slice(sortedCandidates, func(i, j int) bool {
@@ -655,12 +656,16 @@ func (s *Strategy) selectMostPorfitableMarket(candidates []MarketCandidate) (*Ma
 		return breakevenIntervals[candidate1.Symbol].Compare(breakevenIntervals[candidate2.Symbol]) <= 0
 	})
 	bestCandidate := &sortedCandidates[0]
-	targetPosition := targetPositions[bestCandidate.Symbol]
+	targetPosition := targetFuturePositions[bestCandidate.Symbol]
+	if targetPosition.IsZero() {
+		return nil
+	}
 	// set the estimated min holding interval for the selected candidate
 	bestCandidate.MinHoldingIntervals = breakevenIntervals[bestCandidate.Symbol].Int()
 	numHoldingHours := bestCandidate.MinHoldingIntervals * bestCandidate.FundingIntervalHours
 	bestCandidate.MinHoldingDuration = time.Duration(numHoldingHours) * time.Hour
-	return bestCandidate, targetPosition
+	bestCandidate.TargetFuturesPosition = targetPosition
+	return bestCandidate
 }
 
 func (s *Strategy) calculateMinHoldingIntervals(candidate MarketCandidate, bestPrice, targetPosition fixedpoint.Value) (fixedpoint.Value, error) {

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -696,6 +696,10 @@ func (s *Strategy) calculateMinHoldingIntervals(candidate MarketCandidate, bestP
 }
 
 func (s *Strategy) handleRoundExit(ctx context.Context, round *ArbitrageRound) {
+	// stop the round
+	round.Stop()
+
+	// transfer asset back to spot account
 	var asset string
 	switch s.MarketSelectionConfig.FuturesDirection {
 	case types.PositionShort:

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -498,7 +498,7 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 				return
 			}
 			round := NewArbitrageRound(
-				selectedCandidate.LastFundingRate,
+				selectedCandidate.PremiumIndex,
 				selectedCandidate.MinHoldingIntervals,
 				selectedCandidate.FundingIntervalHours,
 				spotTwap,
@@ -692,7 +692,7 @@ func (s *Strategy) calculateMinHoldingIntervals(candidate MarketCandidate, bestP
 		Add(estimateExitCost.TotalFeeCost()).
 		Add(estimateExitCost.SpreadPnL)
 	amount := targetPosition.Abs().Mul(bestPrice)
-	estimateFundingFeePerInterval := amount.Mul(candidate.LastFundingRate.Abs())
+	estimateFundingFeePerInterval := amount.Mul(candidate.PremiumIndex.LastFundingRate.Abs())
 	if estimateFundingFeePerInterval.IsZero() {
 		return fixedpoint.Zero, nil
 	}

--- a/pkg/strategy/xfundingv2/twap_order_executor.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor.go
@@ -22,8 +22,8 @@ type TWAPExecutor struct {
 	market   types.Market
 	executor *bbgo.GeneralOrderExecutor
 
-	ordersMap map[uint64]struct{}
-	trades    []types.Trade
+	orders map[uint64]types.OrderQuery
+	trades map[uint64]types.Trade
 
 	logger logrus.FieldLogger
 }
@@ -43,7 +43,8 @@ func NewTWAPOrderExecutor(
 		executor: executor,
 		market:   market,
 
-		ordersMap: make(map[uint64]struct{}),
+		orders: make(map[uint64]types.OrderQuery),
+		trades: make(map[uint64]types.Trade),
 	}
 }
 
@@ -68,8 +69,8 @@ func (o *TWAPExecutor) AddTrade(trade types.Trade) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	if _, exists := o.ordersMap[trade.OrderID]; exists {
-		o.trades = append(o.trades, trade)
+	if _, exists := o.orders[trade.OrderID]; exists {
+		o.trades[trade.ID] = trade
 	}
 }
 
@@ -78,13 +79,12 @@ func (o *TWAPExecutor) Stop() error {
 	return nil
 }
 
+// SyncOrder queries the latest order status and updates the internal store and trades.
+// it's designed to be called to restore the state of the executor after a restart or to sync a existing order.
+// it's not thread-safe
 func (o *TWAPExecutor) SyncOrder(order types.Order) error {
-	storeOrder, ok := o.executor.OrderStore().Get(order.OrderID)
-	if !ok {
-		return fmt.Errorf("order not found in store: %s", order)
-	}
-
-	if storeOrder.GetRemainingQuantity().IsZero() {
+	storeOrder, exists := o.executor.OrderStore().Get(order.OrderID)
+	if exists && storeOrder.GetRemainingQuantity().IsZero() {
 		return nil
 	}
 
@@ -105,17 +105,23 @@ func (o *TWAPExecutor) SyncOrder(order types.Order) error {
 		return fmt.Errorf("failed to query order trades: %v, %v", query, err)
 	}
 
-	// order exists in the store (by the check at the beginning), we update the order
-	o.executor.OrderStore().Update(*updatedOrder)
-	for _, trade := range trades {
-		o.executor.TradeCollector().ProcessTrade(trade)
+	orderStore := o.executor.OrderStore()
+	if !exists {
+		orderStore.AddOrderUpdate = true
 	}
+	orderStore.HandleOrderUpdate(*updatedOrder)
+	orderStore.AddOrderUpdate = false
+	tradeCollector := o.executor.TradeCollector()
+	for _, trade := range trades {
+		tradeCollector.ProcessTrade(trade)
+	}
+	tradeCollector.Process()
 
 	return nil
 }
 
 func (o *TWAPExecutor) GetOrder(orderID uint64) (types.Order, bool) {
-	if _, exists := o.ordersMap[orderID]; !exists {
+	if _, exists := o.orders[orderID]; !exists {
 		return types.Order{}, false
 	}
 	return o.executor.OrderStore().Get(orderID)
@@ -124,7 +130,7 @@ func (o *TWAPExecutor) GetOrder(orderID uint64) (types.Order, bool) {
 func (o *TWAPExecutor) AllOrders() []types.Order {
 	var orders []types.Order
 
-	for orderID := range o.ordersMap {
+	for orderID := range o.orders {
 		if order, exists := o.executor.OrderStore().Get(orderID); exists {
 			orders = append(orders, order)
 		}
@@ -133,7 +139,11 @@ func (o *TWAPExecutor) AllOrders() []types.Order {
 }
 
 func (o *TWAPExecutor) AllTrades() []types.Trade {
-	return o.trades
+	var trades []types.Trade
+	for _, trade := range o.trades {
+		trades = append(trades, trade)
+	}
+	return trades
 }
 
 // place order
@@ -158,7 +168,7 @@ func (o *TWAPExecutor) PlaceOrder(quantity fixedpoint.Value, side types.SideType
 	if err != nil || len(createdOrders) == 0 {
 		return nil, fmt.Errorf("failed to submit order: %+v, %v", order, err)
 	}
-	o.ordersMap[createdOrders[0].OrderID] = struct{}{}
+	o.orders[createdOrders[0].OrderID] = createdOrders[0].AsQuery()
 	return &createdOrders[0], nil
 }
 

--- a/pkg/strategy/xfundingv2/twap_order_executor_test.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor_test.go
@@ -392,23 +392,50 @@ func TestTWAPOrderExecutor_PlaceOrder(t *testing.T) {
 }
 
 func TestTWAPOrderExecutor_SyncOrder(t *testing.T) {
-	t.Run("order not in store returns error", func(t *testing.T) {
+	t.Run("order not in store queries exchange and adds order", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		config := TWAPWorkerConfig{}
-		executor, _, _ := testExecutorSetup(t, ctrl, config)
+		executor, mockOrderQuery, _ := testExecutorSetup(t, ctrl, config)
 
 		order := types.Order{
 			OrderID: 12345,
 			SubmitOrder: types.SubmitOrder{
-				Symbol: "BTCUSDT",
+				Symbol:   "BTCUSDT",
+				Quantity: Number(1.0),
 			},
 		}
 
+		updatedOrder := &types.Order{
+			OrderID: 12345,
+			SubmitOrder: types.SubmitOrder{
+				Symbol:   "BTCUSDT",
+				Quantity: Number(1.0),
+			},
+			ExecutedQuantity: Number(0.5),
+			Status:           types.OrderStatusPartiallyFilled,
+		}
+		trades := []types.Trade{
+			{ID: 1, OrderID: 12345},
+		}
+
+		mockOrderQuery.EXPECT().
+			QueryOrder(gomock.Any(), gomock.Any()).
+			Return(updatedOrder, nil).
+			Times(1)
+		mockOrderQuery.EXPECT().
+			QueryOrderTrades(gomock.Any(), gomock.Any()).
+			Return(trades, nil).
+			Times(1)
+
 		err := executor.SyncOrder(order)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "order not found in store")
+		assert.NoError(t, err)
+
+		// Verify order was added to store
+		storedOrder, found := executor.executor.OrderStore().Get(12345)
+		assert.True(t, found)
+		assert.Equal(t, types.OrderStatusPartiallyFilled, storedOrder.Status)
 	})
 
 	t.Run("fully filled order skips sync", func(t *testing.T) {
@@ -656,7 +683,7 @@ func TestTWAPOrderExecutor_GetOrder(t *testing.T) {
 			Symbol: "BTCUSDT",
 		},
 	}
-	executor.ordersMap[order.OrderID] = struct{}{} // Add to ordersMap to simulate tracking
+	executor.orders[order.OrderID] = order.AsQuery() // Add to ordersMap to simulate tracking
 	executor.executor.OrderStore().Add(order)
 
 	// Test GetOrder


### PR DESCRIPTION
- Tick the strategy solely on 1m kline closed events
- Set target position when starting the round
- Local orders/trades map for tracking
    - preliminary works for custom sync to restore states of the strategy when restarts
- Round start time check
    - round should start within the funding interval that it's created in