### PR TITLE
FIX: [xfundingv2] Update the state transition rules for the arbitrage round

### DIFF
--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -66,6 +66,8 @@ type ArbitrageRound struct {
 	// closingTime is the time when the round is entered closing state
 	closingTime     time.Time
 	closingDuration time.Duration
+	// lastUpdateTime is the last time when the round is updated
+	lastUpdateTime time.Time
 }
 
 func NewArbitrageRound(
@@ -125,6 +127,14 @@ func (r *ArbitrageRound) MinHoldingIntervals() int {
 
 func (r *ArbitrageRound) TargetPosition() fixedpoint.Value {
 	return r.spotWorker.TargetPosition()
+}
+
+func (r *ArbitrageRound) LastUpdateTime() time.Time {
+	return r.lastUpdateTime
+}
+
+func (r *ArbitrageRound) SetUpdateTime(t time.Time) {
+	r.lastUpdateTime = t
 }
 
 func (r *ArbitrageRound) String() string {

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -105,14 +105,26 @@ func (r *ArbitrageRound) StartTime() time.Time {
 	return r.startTime
 }
 
-func (r *ArbitrageRound) IsClosable(currentTime time.Time) bool {
+func (r *ArbitrageRound) TriggeredFundingRate() fixedpoint.Value {
+	return r.triggeredFundingRate
+}
+
+func (r *ArbitrageRound) NumHoldingIntervals(currentTime time.Time) int {
 	if r.startTime.IsZero() {
-		return false
+		return 0
 	}
+	// the funding rate has not flipped, check if the minimum holding time has passed
 	intervalDuration := time.Duration(r.fundingIntervalHours) * time.Hour
 	lastIntervalEnd := currentTime.Truncate(intervalDuration)
-	numIntervalPassed := int(lastIntervalEnd.Sub(r.fundingIntervalStart) / intervalDuration)
-	return numIntervalPassed >= r.minHoldingIntervals
+	return int(lastIntervalEnd.Sub(r.fundingIntervalStart) / intervalDuration)
+}
+
+func (r *ArbitrageRound) MinHoldingIntervals() int {
+	return r.minHoldingIntervals
+}
+
+func (r *ArbitrageRound) TargetPosition() fixedpoint.Value {
+	return r.spotWorker.TargetPosition()
 }
 
 func (r *ArbitrageRound) String() string {

--- a/pkg/strategy/xfundingv2/arb_round_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_test.go
@@ -61,59 +61,6 @@ func newTestArbitrageRound(t *testing.T, ctrl *gomock.Controller, fundingInterva
 	return round, mockService
 }
 
-func TestArbitrageRound_IsClosable(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	// funding interval: 8 hours, min holding: 3 intervals
-	// nextFundingTime = 2024-01-01 08:00 UTC
-	// fundingIntervalStart = 2024-01-01 00:00 UTC
-	nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
-	round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
-
-	t.Run("not closable when startTime is zero", func(t *testing.T) {
-		currentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
-		assert.False(t, round.IsClosable(currentTime))
-	})
-
-	// Set startTime to simulate a started round
-	round.startTime = time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC)
-
-	t.Run("not closable before min holding intervals", func(t *testing.T) {
-		// fundingIntervalStart = 2024-01-01 00:00 UTC
-		// After 2 intervals (16h): currentTime = 2024-01-01 16:00 UTC
-		// lastIntervalEnd = Truncate(16:00, 8h) = 16:00
-		// numIntervalPassed = (16:00 - 00:00) / 8h = 2
-		// 2 < 3 (minHoldingIntervals) -> not closable
-		currentTime := time.Date(2024, 1, 1, 16, 0, 0, 0, time.UTC)
-		assert.False(t, round.IsClosable(currentTime))
-	})
-
-	t.Run("closable after min holding intervals", func(t *testing.T) {
-		// After 3 intervals (24h): currentTime = 2024-01-02 00:00 UTC
-		// lastIntervalEnd = Truncate(00:00 on Jan 2, 8h) = 00:00 on Jan 2
-		// numIntervalPassed = (24:00 - 00:00) / 8h = 3
-		// 3 >= 3 -> closable
-		currentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
-		assert.True(t, round.IsClosable(currentTime))
-	})
-
-	t.Run("closable well after min holding intervals", func(t *testing.T) {
-		// After 5 intervals (40h): currentTime = 2024-01-02 16:00 UTC
-		currentTime := time.Date(2024, 1, 2, 16, 0, 0, 0, time.UTC)
-		assert.True(t, round.IsClosable(currentTime))
-	})
-
-	t.Run("not closable in middle of interval period", func(t *testing.T) {
-		// currentTime = 2024-01-01 20:00 UTC (between 2nd and 3rd interval)
-		// lastIntervalEnd = Truncate(20:00, 8h) = 16:00
-		// numIntervalPassed = (16:00 - 00:00) / 8h = 2
-		// 2 < 3 -> not closable
-		currentTime := time.Date(2024, 1, 1, 20, 0, 0, 0, time.UTC)
-		assert.False(t, round.IsClosable(currentTime))
-	})
-}
-
 func TestArbitrageRound_CollectedFunding(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -40,6 +40,7 @@ type Strategy struct {
 	// IMPORTANT: xfundingv2 is now assuming trading on U-major pairs
 	CandidateSymbols     []string       `json:"candidateSymbols"`
 	OpenPositionInterval types.Duration `json:"openPositionInterval"`
+	TransitRoundInterval types.Duration `json:"transitRoundInterval"`
 
 	// TickSymbol is the symbol used for ticking the strategy, default to the first candidate symbol
 	TickSymbol string `json:"tickSymbol"`
@@ -100,6 +101,9 @@ func (s *Strategy) Defaults() error {
 	}
 	if s.OpenPositionInterval.Duration() == 0 {
 		s.OpenPositionInterval = types.Duration(time.Minute * 30)
+	}
+	if s.TransitRoundInterval.Duration() == 0 {
+		s.TransitRoundInterval = types.Duration(time.Minute * 10)
 	}
 
 	if s.MarketSelectionConfig == nil {
@@ -387,7 +391,20 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 }
 
 func (s *Strategy) transitRoundState(ctx context.Context, round *ArbitrageRound, currentTime time.Time) {
+	// still in the first funding interval, do not transit
 	if round.NumHoldingIntervals(currentTime) <= 1 {
+		if round.LastUpdateTime().IsZero() {
+			round.SetUpdateTime(currentTime)
+		}
+		return
+	}
+	lastUpdateTime := round.LastUpdateTime()
+	if lastUpdateTime.IsZero() {
+		lastUpdateTime = currentTime
+		round.SetUpdateTime(currentTime)
+	}
+
+	if currentTime.Sub(lastUpdateTime) < s.TransitRoundInterval.Duration() {
 		return
 	}
 
@@ -397,6 +414,7 @@ func (s *Strategy) transitRoundState(ctx context.Context, round *ArbitrageRound,
 	case RoundClosing:
 		s.transitClosingRound(ctx, round, currentTime)
 	}
+	round.SetUpdateTime(currentTime)
 }
 
 func (s *Strategy) transitOpeningOrReadyRound(ctx context.Context, round *ArbitrageRound, currentTime time.Time) {

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -387,22 +387,20 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 }
 
 func (s *Strategy) transitRoundState(ctx context.Context, round *ArbitrageRound, currentTime time.Time) {
-	if !round.IsClosable(currentTime) {
+	if round.NumHoldingIntervals(currentTime) <= 1 {
 		return
 	}
+
 	switch round.State() {
-	case RoundOpening:
-		s.transitOpeningRound(ctx, round, currentTime)
-	case RoundReady:
-		s.transitReadyRound(ctx, round, currentTime)
+	case RoundOpening, RoundReady:
+		s.transitOpeningOrReadyRound(ctx, round, currentTime)
 	case RoundClosing:
 		s.transitClosingRound(ctx, round, currentTime)
 	}
 }
 
-func (s *Strategy) transitOpeningRound(ctx context.Context, round *ArbitrageRound, currentTime time.Time) {
-	// the round is expired and is in opening state
-	// if the current funding rate is still favorable, keep opening, otherwise transit to closing
+func (s *Strategy) transitOpeningOrReadyRound(ctx context.Context, round *ArbitrageRound, currentTime time.Time) {
+	// if the current funding rate is still favorable, stay in current state, otherwise transit to closing
 	timedCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
 
@@ -411,46 +409,43 @@ func (s *Strategy) transitOpeningRound(ctx context.Context, round *ArbitrageRoun
 		return
 	}
 
-	if getPostionSign(s.MarketSelectionConfig.FuturesDirection)*fundingRate.LastFundingRate.Sign() >= 0 {
-		// the funding rate is not favorable anymore, transit to closing
-		// short futures -> positive funding rate for funding income
-		// long futures -> negative funding rate for funding income
-		s.logger.Infof(
-			"[transitOpeningRound %s] transit to closing, current funding rate %s: %s",
-			currentTime.Format(time.RFC3339), fundingRate.LastFundingRate, round)
-		round.SetClosing(currentTime, s.TWAPWorkerConfig.ClosingDuration)
-	} else if s.allowLog(currentTime) {
-		s.logger.Infof(
-			"[transitOpeningRound %s] round stays opening, current funding rate %s: %s",
-			currentTime.Format(time.RFC3339), fundingRate.LastFundingRate, round,
-		)
+	// the funding rate has flipped
+	if round.TriggeredFundingRate().Sign()*fundingRate.LastFundingRate.Sign() <= 0 {
+		if round.NumHoldingIntervals(currentTime) >= round.MinHoldingIntervals() {
+			// the min holding time has passed, transit to closing
+			s.logger.Infof(
+				"[transitOpeningOrReadyRound %s] min holding time passed, transit state %s -> closing, current funding rate %s: %s",
+				currentTime.Format(time.RFC3339), round.State(), fundingRate.LastFundingRate, round)
+			round.SetClosing(currentTime, s.TWAPWorkerConfig.ClosingDuration)
+			return
+		}
+		// the funding rate is not favorable anymore, check the exit cost to see if it's worth to transit to closing
+		s.costEstimator.SetTargetPosition(round.TargetPosition())
+		spotOrderBook, spotOk := s.spotOrderBooks[round.SpotSymbol()]
+		futuresOrderBook, futuresOk := s.futuresOrderBooks[round.FuturesSymbol()]
+		if !spotOk || !futuresOk {
+			s.logger.Warnf("[transitOpeningOrReadyRound] order book not found for symbols: %s", round.SpotSymbol())
+			return
+		}
+		cost, err := s.costEstimator.EstimateExitCost(true, spotOrderBook.Copy(), futuresOrderBook.Copy())
+		if err != nil {
+			s.logger.WithError(err).Errorf("[transitOpeningOrReadyRound] failed to estimate exit cost: %s", round.SpotSymbol())
+			return
+		}
+		// the spread PnL is large enough to cover the exit cost, transit to closing
+		if cost.SpreadPnL.Compare(cost.TotalFeeCost()) > 0 {
+			s.logger.Infof(
+				"[transitOpeningOrReadyRound %s] transit state %s -> closing, current funding rate %s: %s",
+				currentTime.Format(time.RFC3339), round.State(), fundingRate.LastFundingRate, round)
+			round.SetClosing(currentTime, s.TWAPWorkerConfig.ClosingDuration)
+			return
+		}
 	}
-}
 
-func (s *Strategy) transitReadyRound(ctx context.Context, round *ArbitrageRound, currentTime time.Time) {
-	// the round is expired and is in ready state
-	// if the current funding rate is still favorable, keep ready, otherwise transit to closing
-	timedCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	defer cancel()
-
-	fundingRate, err := s.futuresService.QueryPremiumIndex(timedCtx, round.FuturesSymbol())
-	if err != nil {
-		return
-	}
-
-	if getPostionSign(s.MarketSelectionConfig.FuturesDirection)*fundingRate.LastFundingRate.Sign() >= 0 {
-		// the funding rate is not favorable anymore, transit to closing
-		// short futures -> positive funding rate for funding income
-		// long futures -> negative funding rate for funding income
+	if s.allowLog(currentTime) {
 		s.logger.Infof(
-			"[transitReadyRound %s] transit to closing, current funding rate %s: %s",
-			currentTime.Format(time.RFC3339), fundingRate.LastFundingRate, round,
-		)
-		round.SetClosing(currentTime, s.TWAPWorkerConfig.ClosingDuration)
-	} else if s.allowLog(currentTime) {
-		s.logger.Infof(
-			"[transitReadyRound %s] round stays ready, current funding rate %s: %s",
-			currentTime.Format(time.RFC3339), fundingRate.LastFundingRate, round,
+			"[transitOpeningOrReadyRound %s] round stays %s, current funding rate %s: %s",
+			currentTime.Format(time.RFC3339), round.State(), fundingRate.LastFundingRate, round,
 		)
 	}
 }


### PR DESCRIPTION
- Remove `IsClosable` for the arbitrage round
- Update the round state transition rule for the opening and ready states
    - if it's in the first funding interval, do nothing
    - If the funding rate flipped
        - if the exit spread PnL is large enough to cover the trading fee, switch to closing state
        - if it exceeds the min holding intervals, switch to closing state
        - otherwise, stays in the current state