### PR TITLE
FEATURE: [xfundingv2] Fee asset preparation

### DIFF
--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -53,6 +53,8 @@ type ArbitrageRound struct {
 	futuresService FuturesService
 	asset          string // base asset, e.g. "BTC"
 
+	spotFeeAssetAmount, futuresFeeAssetAmount fixedpoint.Value
+
 	retryDuration      time.Duration
 	retryTransferTickC chan time.Time
 	retryTransfers     map[uint64]transferRetry
@@ -101,6 +103,34 @@ func NewArbitrageRound(
 		retryTransfers:     make(map[uint64]transferRetry),
 		retryTransferTickC: make(chan time.Time, 1),
 	}
+}
+
+func (r *ArbitrageRound) SetSpotFeeAssetAmount(amount fixedpoint.Value) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.spotFeeAssetAmount = amount
+}
+
+func (r *ArbitrageRound) SpotFeeAssetAmount() fixedpoint.Value {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.spotFeeAssetAmount
+}
+
+func (r *ArbitrageRound) SetFuturesFeeAssetAmount(amount fixedpoint.Value) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.futuresFeeAssetAmount = amount
+}
+
+func (r *ArbitrageRound) FuturesFeeAssetAmount() fixedpoint.Value {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.futuresFeeAssetAmount
 }
 
 func (r *ArbitrageRound) StartTime() time.Time {

--- a/pkg/strategy/xfundingv2/arb_round_fee.go
+++ b/pkg/strategy/xfundingv2/arb_round_fee.go
@@ -1,0 +1,149 @@
+package xfundingv2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+func (s *Strategy) processPendingRounds(ctx context.Context, currentTime time.Time) {
+	var pendingRounds []*ArbitrageRound
+	for _, round := range s.pendingRounds {
+		// moving round out from the pending list
+		delete(s.pendingRounds, round.SpotSymbol())
+		pendingRounds = append(pendingRounds, round)
+	}
+	var processedRounds []*ArbitrageRound
+	for _, round := range pendingRounds {
+		// calculate the fee asset required for the round
+		if err := s.calculateRoundFeeAsset(round); err != nil {
+			s.logger.WithError(err).Errorf(
+				"failed to prepare fee asset for round: %s",
+				round,
+			)
+			continue
+		}
+		processedRounds = append(processedRounds, round)
+	}
+	if err := s.acquireFeeAssetAndTransfer(ctx, processedRounds); err != nil {
+		s.logger.WithError(err).Error("failed to acquire fee asset and transfer for pending rounds")
+		return
+	}
+
+	for _, round := range processedRounds {
+		if err := round.Start(ctx, currentTime); err != nil {
+			s.logger.WithError(err).Errorf(
+				"failed to start round after fee asset preparation: %s",
+				round,
+			)
+			continue
+		}
+		s.activeRounds[round.SpotSymbol()] = round
+		s.logger.Infof("round started: %s", round)
+	}
+}
+
+func (s *Strategy) acquireFeeAssetAndTransfer(ctx context.Context, rounds []*ArbitrageRound) error {
+	var requiredSpotFeeAmount, requiredFuturesFeeAmount fixedpoint.Value
+	for _, round := range rounds {
+		requiredSpotFeeAmount = requiredSpotFeeAmount.Add(round.SpotFeeAssetAmount())
+		requiredFuturesFeeAmount = requiredFuturesFeeAmount.Add(round.FuturesFeeAssetAmount())
+	}
+	spotAccount := s.spotSession.GetAccount()
+	futuresAccount := s.futuresSession.GetAccount()
+	market, _ := s.spotSession.Market(s.FeeSymbol)
+	spotFeeBalance, _ := spotAccount.Balance(market.BaseCurrency)
+	futuresFeeBalance, _ := futuresAccount.Balance(market.BaseCurrency)
+	spotDeficit := requiredSpotFeeAmount.Sub(spotFeeBalance.Available)
+	futuresDeficit := requiredFuturesFeeAmount.Sub(futuresFeeBalance.Available)
+	var buyQuantity, transferAmount fixedpoint.Value
+	var transferDirection types.TransferDirection
+	if spotDeficit.Add(futuresDeficit).Sign() >= 0 {
+		// this case means the total fee asset balance is not sufficient
+		// need to buy and transfer in the fee asset to cover the deficit
+		buyQuantity = spotDeficit.Add(futuresDeficit) // must be positive or zero
+		transferAmount = fixedpoint.Max(fixedpoint.Zero, futuresDeficit)
+		transferDirection = types.TransferIn
+	} else {
+		// this case means the total fee asset balance is sufficient
+		if futuresDeficit.Sign() > 0 {
+			transferAmount = futuresDeficit
+			transferDirection = types.TransferIn
+		}
+		if spotDeficit.Sign() > 0 {
+			transferAmount = spotDeficit
+			transferDirection = types.TransferOut
+		}
+	}
+	if !buyQuantity.IsZero() {
+		if _, err := s.spotSession.Exchange.SubmitOrder(ctx, types.SubmitOrder{
+			Symbol:   s.FeeSymbol,
+			Side:     types.SideTypeBuy,
+			Type:     types.OrderTypeMarket,
+			Quantity: buyQuantity,
+		}); err != nil {
+			return fmt.Errorf("failed to buy fee asset for pending rounds: %w", err)
+		}
+	}
+	if !transferAmount.IsZero() {
+		if err := s.futuresService.TransferFuturesAccountAsset(ctx, market.BaseCurrency, transferAmount, transferDirection); err != nil {
+			return fmt.Errorf("failed to transfer %s %s for pending rounds fee preparation: %w", transferAmount, market.BaseCurrency, err)
+		}
+	}
+	return nil
+}
+
+func (s *Strategy) calculateRoundFeeAsset(round *ArbitrageRound) error {
+	feeOrderBook, ok := s.spotOrderBooks[s.FeeSymbol]
+	if !ok {
+		return nil
+	}
+
+	spotFeeRate := s.spotSession.TakerFeeRate
+	futuresFeeRate := s.futuresSession.TakerFeeRate
+
+	// calculate the spot/futures leg fee assets
+	var spotFeeAmount, futuresFeeAmount fixedpoint.Value
+	targetPosition := round.TargetPosition()
+	positionSize := targetPosition.Abs()
+
+	// get fee asset price (we need to buy it, so use the sell/ask side)
+	feeSellBook := feeOrderBook.SideBook(types.SideTypeSell)
+	var spotBasePrice, futuresBasePrice fixedpoint.Value
+	if targetPosition.Sign() > 0 {
+		// long spot (buy at ask side), short futures (sell at bid side)
+		spotSellBook := s.spotOrderBooks[round.SpotSymbol()].SideBook(types.SideTypeSell)
+		futuresBuyBook := s.futuresOrderBooks[round.FuturesSymbol()].SideBook(types.SideTypeBuy)
+
+		spotBasePrice = spotSellBook.AverageDepthPrice(positionSize)
+		futuresBasePrice = futuresBuyBook.AverageDepthPrice(positionSize)
+		if spotBasePrice.IsZero() || futuresBasePrice.IsZero() {
+			return errors.New("order book data is not ready yet")
+		}
+	} else {
+		// short spot (sell at bid side), long futures (buy at ask side)
+		spotBuyBook := s.spotOrderBooks[round.SpotSymbol()].SideBook(types.SideTypeBuy)
+		futuresSellBook := s.futuresOrderBooks[round.FuturesSymbol()].SideBook(types.SideTypeSell)
+
+		spotBasePrice = spotBuyBook.AverageDepthPrice(positionSize)
+		futuresBasePrice = futuresSellBook.AverageDepthPrice(positionSize)
+		if spotBasePrice.IsZero() || futuresBasePrice.IsZero() {
+			return errors.New("order book data is not ready yet")
+		}
+	}
+	spotFeeInQuote := spotBasePrice.Mul(positionSize).Mul(spotFeeRate)
+	futuresFeeInQuote := futuresBasePrice.Mul(positionSize).Mul(futuresFeeRate)
+	totalFeeInQuote := spotFeeInQuote.Add(futuresFeeInQuote)
+	feeAssetPrice := feeSellBook.AverageDepthPriceByQuote(totalFeeInQuote, 0)
+	spotFeeAmount = spotFeeInQuote.Div(feeAssetPrice)
+	futuresFeeAmount = futuresFeeInQuote.Div(feeAssetPrice)
+
+	round.SetSpotFeeAssetAmount(spotFeeAmount)
+	round.SetFuturesFeeAssetAmount(futuresFeeAmount)
+
+	return nil
+}

--- a/pkg/strategy/xfundingv2/arb_round_fee_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_fee_test.go
@@ -1,0 +1,447 @@
+package xfundingv2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/c9s/bbgo/pkg/bbgo"
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+	"github.com/c9s/bbgo/pkg/types/mocks"
+
+	. "github.com/c9s/bbgo/pkg/testing/testhelper"
+)
+
+// mockFuturesServiceForFee extends the mock to track transfer calls
+type mockFuturesServiceForFee struct {
+	mockFuturesService
+	transferredAsset     string
+	transferredAmount    fixedpoint.Value
+	transferredDirection types.TransferDirection
+	transferCalled       bool
+}
+
+func (m *mockFuturesServiceForFee) TransferFuturesAccountAsset(
+	ctx context.Context, asset string, amount fixedpoint.Value, direction types.TransferDirection,
+) error {
+	m.transferCalled = true
+	m.transferredAsset = asset
+	m.transferredAmount = amount
+	m.transferredDirection = direction
+	return m.transferErr
+}
+
+func TestStrategy_AquireFeeAssetAndTransfer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Helper to create a strategy with mocked sessions
+	setup := func(
+		spotBNBBalance, futuresBNBBalance fixedpoint.Value,
+	) (*Strategy, *mocks.MockExchange, *mockFuturesServiceForFee) {
+		mockExchange := mocks.NewMockExchange(ctrl)
+		mockExchange.EXPECT().Name().Return(types.ExchangeBinance).AnyTimes()
+
+		spotAccount := types.NewAccount()
+		spotAccount.SetBalance("BNB", types.Balance{
+			Currency:  "BNB",
+			Available: spotBNBBalance,
+		})
+
+		futuresAccount := types.NewAccount()
+		futuresAccount.SetBalance("BNB", types.Balance{
+			Currency:  "BNB",
+			Available: futuresBNBBalance,
+		})
+
+		spotSession := &bbgo.ExchangeSession{
+			Account:  spotAccount,
+			Exchange: mockExchange,
+		}
+		spotSession.SetMarkets(types.MarketMap{
+			"BNBUSDT": {
+				Symbol:          "BNBUSDT",
+				BaseCurrency:    "BNB",
+				QuoteCurrency:   "USDT",
+				TickSize:        Number(0.01),
+				StepSize:        Number(0.001),
+				PricePrecision:  2,
+				VolumePrecision: 3,
+			},
+		})
+
+		futuresSession := &bbgo.ExchangeSession{
+			Account: futuresAccount,
+		}
+
+		mockService := &mockFuturesServiceForFee{}
+
+		s := &Strategy{
+			FeeSymbol:      "BNBUSDT",
+			spotSession:    spotSession,
+			futuresSession: futuresSession,
+			futuresService: mockService,
+		}
+
+		return s, mockExchange, mockService
+	}
+
+	// Helper to create rounds with preset fee amounts
+	makeRounds := func(spotFee, futuresFee fixedpoint.Value) []*ArbitrageRound {
+		round := &ArbitrageRound{}
+		round.SetSpotFeeAssetAmount(spotFee)
+		round.SetFuturesFeeAssetAmount(futuresFee)
+		return []*ArbitrageRound{round}
+	}
+
+	t.Run("both accounts have sufficient fee asset", func(t *testing.T) {
+		// Spot needs 0.5 BNB, has 1.0 BNB; Futures needs 0.3 BNB, has 1.0 BNB
+		s, _, mockService := setup(Number(1.0), Number(1.0))
+		rounds := makeRounds(Number(0.5), Number(0.3))
+
+		ctx := context.Background()
+		err := s.acquireFeeAssetAndTransfer(ctx, rounds)
+
+		assert.NoError(t, err)
+		// No buy needed and no transfer needed
+		assert.False(t, mockService.transferCalled)
+	})
+
+	t.Run("both accounts are in shortage of fee asset", func(t *testing.T) {
+		// Spot needs 1.0 BNB, has 0.2 BNB; Futures needs 0.8 BNB, has 0.1 BNB
+		// spotDeficit = 1.0 - 0.2 = 0.8, futuresDeficit = 0.8 - 0.1 = 0.7
+		// total deficit = 0.8 + 0.7 = 1.5 > 0 → buy 1.5, transfer max(0, 0.7) = 0.7 to futures
+		s, mockExchange, mockService := setup(Number(0.2), Number(0.1))
+		rounds := makeRounds(Number(1.0), Number(0.8))
+
+		mockExchange.EXPECT().
+			SubmitOrder(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, order types.SubmitOrder) (*types.Order, error) {
+				assert.Equal(t, "BNBUSDT", order.Symbol)
+				assert.Equal(t, types.SideTypeBuy, order.Side)
+				assert.Equal(t, types.OrderTypeMarket, order.Type)
+				assert.Equal(t, Number(1.5), order.Quantity)
+				return &types.Order{}, nil
+			})
+
+		ctx := context.Background()
+		err := s.acquireFeeAssetAndTransfer(ctx, rounds)
+
+		assert.NoError(t, err)
+		assert.True(t, mockService.transferCalled)
+		assert.Equal(t, "BNB", mockService.transferredAsset)
+		assert.Equal(t, Number(0.7), mockService.transferredAmount)
+		assert.Equal(t, types.TransferIn, mockService.transferredDirection)
+	})
+
+	t.Run("spot sufficient, futures not, total sufficient - transfer only", func(t *testing.T) {
+		// Spot needs 0.5 BNB, has 2.0 BNB; Futures needs 1.0 BNB, has 0.3 BNB
+		// spotDeficit = 0.5 - 2.0 = -1.5, futuresDeficit = 1.0 - 0.3 = 0.7
+		// total = -1.5 + 0.7 = -0.8 < 0 → no buy needed
+		// futuresDeficit > 0 → transfer 0.7 in (spot → futures)
+		s, _, mockService := setup(Number(2.0), Number(0.3))
+		rounds := makeRounds(Number(0.5), Number(1.0))
+
+		ctx := context.Background()
+		err := s.acquireFeeAssetAndTransfer(ctx, rounds)
+
+		assert.NoError(t, err)
+		assert.True(t, mockService.transferCalled)
+		assert.Equal(t, "BNB", mockService.transferredAsset)
+		assert.Equal(t, Number(0.7), mockService.transferredAmount)
+		assert.Equal(t, types.TransferIn, mockService.transferredDirection)
+	})
+
+	t.Run("spot sufficient, futures not, total insufficient - buy and transfer", func(t *testing.T) {
+		// Spot needs 0.5 BNB, has 0.6 BNB; Futures needs 2.0 BNB, has 0.5 BNB
+		// spotDeficit = 0.5 - 0.6 = -0.1, futuresDeficit = 2.0 - 0.5 = 1.5
+		// total = -0.1 + 1.5 = 1.4 >= 0 → buy 1.4, transfer max(0, 1.5) = 1.5 to futures
+		s, mockExchange, mockService := setup(Number(0.6), Number(0.5))
+		rounds := makeRounds(Number(0.5), Number(2.0))
+
+		mockExchange.EXPECT().
+			SubmitOrder(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, order types.SubmitOrder) (*types.Order, error) {
+				assert.Equal(t, "BNBUSDT", order.Symbol)
+				assert.Equal(t, types.SideTypeBuy, order.Side)
+				assert.Equal(t, types.OrderTypeMarket, order.Type)
+				assert.Equal(t, Number(1.4), order.Quantity)
+				return &types.Order{}, nil
+			})
+
+		ctx := context.Background()
+		err := s.acquireFeeAssetAndTransfer(ctx, rounds)
+
+		assert.NoError(t, err)
+		assert.True(t, mockService.transferCalled)
+		assert.Equal(t, "BNB", mockService.transferredAsset)
+		assert.Equal(t, Number(1.5), mockService.transferredAmount)
+		assert.Equal(t, types.TransferIn, mockService.transferredDirection)
+	})
+
+	t.Run("futures sufficient, spot not, total sufficient - transfer only", func(t *testing.T) {
+		// Spot needs 1.0 BNB, has 0.4 BNB; Futures needs 0.3 BNB, has 2.0 BNB
+		// spotDeficit = 1.0 - 0.4 = 0.6, futuresDeficit = 0.3 - 2.0 = -1.7
+		// total = 0.6 + (-1.7) = -1.1 < 0 → no buy needed
+		// spotDeficit > 0 → transfer 0.6 out (futures → spot)
+		s, _, mockService := setup(Number(0.4), Number(2.0))
+		rounds := makeRounds(Number(1.0), Number(0.3))
+
+		ctx := context.Background()
+		err := s.acquireFeeAssetAndTransfer(ctx, rounds)
+
+		assert.NoError(t, err)
+		assert.True(t, mockService.transferCalled)
+		assert.Equal(t, "BNB", mockService.transferredAsset)
+		assert.Equal(t, Number(0.6), mockService.transferredAmount)
+		assert.Equal(t, types.TransferOut, mockService.transferredDirection)
+	})
+
+	t.Run("futures sufficient, spot not, total insufficient - buy and transfer", func(t *testing.T) {
+		// Spot needs 2.0 BNB, has 0.3 BNB; Futures needs 0.5 BNB, has 0.6 BNB
+		// spotDeficit = 2.0 - 0.3 = 1.7, futuresDeficit = 0.5 - 0.6 = -0.1
+		// total = 1.7 + (-0.1) = 1.6 >= 0 → buy 1.6, transfer max(0, -0.1) = 0 to futures
+		// futuresDeficit <= 0 and spotDeficit > 0 but we're in the "total >= 0" branch
+		// so transferAmount = max(0, futuresDeficit) = 0 → no transfer
+		s, mockExchange, mockService := setup(Number(0.3), Number(0.6))
+		rounds := makeRounds(Number(2.0), Number(0.5))
+
+		mockExchange.EXPECT().
+			SubmitOrder(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, order types.SubmitOrder) (*types.Order, error) {
+				assert.Equal(t, "BNBUSDT", order.Symbol)
+				assert.Equal(t, types.SideTypeBuy, order.Side)
+				assert.Equal(t, types.OrderTypeMarket, order.Type)
+				assert.Equal(t, Number(1.6), order.Quantity)
+				return &types.Order{}, nil
+			})
+
+		ctx := context.Background()
+		err := s.acquireFeeAssetAndTransfer(ctx, rounds)
+
+		assert.NoError(t, err)
+		// No transfer needed since bought assets land in spot and futuresDeficit <= 0
+		assert.False(t, mockService.transferCalled)
+	})
+}
+
+func newStreamOrderBookWithData(symbol string, bids, asks types.PriceVolumeSlice) *types.StreamOrderBook {
+	book := types.NewStreamBook(symbol, types.ExchangeBinance)
+	book.Load(types.SliceOrderBook{
+		Symbol: symbol,
+		Bids:   bids,
+		Asks:   asks,
+	})
+	return book
+}
+
+func TestStrategy_CalculateRoundFeeAsset(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("returns nil when fee order book is not found", func(t *testing.T) {
+		s := &Strategy{
+			FeeSymbol:      "BNBUSDT",
+			spotOrderBooks: map[string]*types.StreamOrderBook{},
+		}
+
+		nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+
+		err := s.calculateRoundFeeAsset(round)
+		assert.NoError(t, err)
+		assert.Equal(t, fixedpoint.Zero, round.SpotFeeAssetAmount())
+		assert.Equal(t, fixedpoint.Zero, round.FuturesFeeAssetAmount())
+	})
+
+	t.Run("returns error when order book data is not ready (positive target position)", func(t *testing.T) {
+		// Order books exist but have no data on the relevant side
+		spotOrderBooks := map[string]*types.StreamOrderBook{
+			"BNBUSDT": newStreamOrderBookWithData("BNBUSDT", nil,
+				types.PriceVolumeSlice{
+					{Price: Number(600), Volume: Number(100)},
+				}),
+			"BTCUSDT": newStreamOrderBookWithData("BTCUSDT", nil, nil), // empty ask side
+		}
+		futuresOrderBooks := map[string]*types.StreamOrderBook{
+			"BTCUSDT": newStreamOrderBookWithData("BTCUSDT", nil, nil), // empty bid side
+		}
+
+		s := &Strategy{
+			FeeSymbol:         "BNBUSDT",
+			spotSession:       &bbgo.ExchangeSession{},
+			futuresSession:    &bbgo.ExchangeSession{},
+			spotOrderBooks:    spotOrderBooks,
+			futuresOrderBooks: futuresOrderBooks,
+		}
+
+		nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		// spotWorker target = 1.0 (positive), so it enters the positive branch
+
+		err := s.calculateRoundFeeAsset(round)
+		assert.EqualError(t, err, "order book data is not ready yet")
+	})
+
+	t.Run("returns error when order book data is not ready (negative target position)", func(t *testing.T) {
+		spotOrderBooks := map[string]*types.StreamOrderBook{
+			"BNBUSDT": newStreamOrderBookWithData("BNBUSDT", nil,
+				types.PriceVolumeSlice{
+					{Price: Number(600), Volume: Number(100)},
+				}),
+			"BTCUSDT": newStreamOrderBookWithData("BTCUSDT", nil, nil), // empty bid side
+		}
+		futuresOrderBooks := map[string]*types.StreamOrderBook{
+			"BTCUSDT": newStreamOrderBookWithData("BTCUSDT", nil, nil), // empty ask side
+		}
+
+		s := &Strategy{
+			FeeSymbol:         "BNBUSDT",
+			spotSession:       &bbgo.ExchangeSession{},
+			futuresSession:    &bbgo.ExchangeSession{},
+			spotOrderBooks:    spotOrderBooks,
+			futuresOrderBooks: futuresOrderBooks,
+		}
+
+		nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+		config := TWAPWorkerConfig{
+			Duration:  10 * time.Minute,
+			NumSlices: 5,
+		}
+		spotWorker, _, _, _ := newTestTWAPWorker(t, ctrl, config)
+		spotWorker.SetTargetPosition(Number(-1.0)) // negative target position
+
+		futuresWorker, _, _, _ := newTestTWAPWorker(t, ctrl, config)
+		futuresWorker.SetTargetPosition(Number(1.0))
+
+		mockService := &mockFuturesService{}
+		fundingRate := &types.PremiumIndex{
+			LastFundingRate: Number(0.001),
+			NextFundingTime: nextFundingTime,
+		}
+		round := NewArbitrageRound(fundingRate, 3, 8, spotWorker, futuresWorker, mockService)
+
+		err := s.calculateRoundFeeAsset(round)
+		assert.EqualError(t, err, "order book data is not ready yet")
+	})
+
+	t.Run("calculates fee amounts correctly (positive target position)", func(t *testing.T) {
+		// Target position = 1.0 BTC (long spot, short futures)
+		// Spot ask price = 50000, Futures bid price = 50000
+		// Spot fee rate = 0.001, Futures fee rate = 0.001
+		// Spot fee in quote = 50000 * 1.0 * 0.001 = 50
+		// Futures fee in quote = 50000 * 1.0 * 0.001 = 50
+		// Total fee in quote = 100
+		// Fee asset (BNB) ask price for 100 USDT depth = 500
+		// Spot fee amount = 50 / 500 = 0.1
+		// Futures fee amount = 50 / 500 = 0.1
+		spotOrderBooks := map[string]*types.StreamOrderBook{
+			"BNBUSDT": newStreamOrderBookWithData("BNBUSDT", nil,
+				types.PriceVolumeSlice{
+					{Price: Number(500), Volume: Number(100)},
+				}),
+			"BTCUSDT": newStreamOrderBookWithData("BTCUSDT", nil,
+				types.PriceVolumeSlice{
+					{Price: Number(50000), Volume: Number(10)},
+				}),
+		}
+		futuresOrderBooks := map[string]*types.StreamOrderBook{
+			"BTCUSDT": newStreamOrderBookWithData("BTCUSDT",
+				types.PriceVolumeSlice{
+					{Price: Number(50000), Volume: Number(10)},
+				}, nil),
+		}
+
+		spotSession := &bbgo.ExchangeSession{}
+		spotSession.TakerFeeRate = Number(0.001)
+		futuresSession := &bbgo.ExchangeSession{}
+		futuresSession.TakerFeeRate = Number(0.001)
+
+		s := &Strategy{
+			FeeSymbol:         "BNBUSDT",
+			spotSession:       spotSession,
+			futuresSession:    futuresSession,
+			spotOrderBooks:    spotOrderBooks,
+			futuresOrderBooks: futuresOrderBooks,
+		}
+
+		nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+
+		err := s.calculateRoundFeeAsset(round)
+		assert.NoError(t, err)
+
+		// Both legs have the same price and fee rate, so fee amounts are equal
+		assert.Equal(t, Number(0.1), round.SpotFeeAssetAmount())
+		assert.Equal(t, Number(0.1), round.FuturesFeeAssetAmount())
+	})
+
+	t.Run("calculates fee amounts correctly (negative target position)", func(t *testing.T) {
+		// Target position = -1.0 BTC (short spot, long futures)
+		// Spot bid price = 50000, Futures ask price = 50000
+		// Spot fee rate = 0.001, Futures fee rate = 0.001
+		// Spot fee in quote = 50000 * 1.0 * 0.001 = 50
+		// Futures fee in quote = 50000 * 1.0 * 0.001 = 50
+		// Total fee in quote = 100
+		// Fee asset (BNB) ask price = 500
+		// Spot fee amount = 50 / 500 = 0.1
+		// Futures fee amount = 50 / 500 = 0.1
+		spotOrderBooks := map[string]*types.StreamOrderBook{
+			"BNBUSDT": newStreamOrderBookWithData("BNBUSDT", nil,
+				types.PriceVolumeSlice{
+					{Price: Number(500), Volume: Number(100)},
+				}),
+			"BTCUSDT": newStreamOrderBookWithData("BTCUSDT",
+				types.PriceVolumeSlice{
+					{Price: Number(50000), Volume: Number(10)},
+				}, nil),
+		}
+		futuresOrderBooks := map[string]*types.StreamOrderBook{
+			"BTCUSDT": newStreamOrderBookWithData("BTCUSDT", nil,
+				types.PriceVolumeSlice{
+					{Price: Number(50000), Volume: Number(10)},
+				}),
+		}
+
+		spotSession := &bbgo.ExchangeSession{}
+		spotSession.TakerFeeRate = Number(0.001)
+		futuresSession := &bbgo.ExchangeSession{}
+		futuresSession.TakerFeeRate = Number(0.001)
+
+		s := &Strategy{
+			FeeSymbol:         "BNBUSDT",
+			spotSession:       spotSession,
+			futuresSession:    futuresSession,
+			spotOrderBooks:    spotOrderBooks,
+			futuresOrderBooks: futuresOrderBooks,
+		}
+
+		nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+		config := TWAPWorkerConfig{
+			Duration:  10 * time.Minute,
+			NumSlices: 5,
+		}
+		spotWorker, _, _, _ := newTestTWAPWorker(t, ctrl, config)
+		spotWorker.SetTargetPosition(Number(-1.0))
+
+		futuresWorker, _, _, _ := newTestTWAPWorker(t, ctrl, config)
+		futuresWorker.SetTargetPosition(Number(1.0))
+
+		mockService := &mockFuturesService{}
+		fundingRate := &types.PremiumIndex{
+			LastFundingRate: Number(0.001),
+			NextFundingTime: nextFundingTime,
+		}
+		round := NewArbitrageRound(fundingRate, 3, 8, spotWorker, futuresWorker, mockService)
+
+		err := s.calculateRoundFeeAsset(round)
+		assert.NoError(t, err)
+
+		assert.Equal(t, Number(0.1), round.SpotFeeAssetAmount())
+		assert.Equal(t, Number(0.1), round.FuturesFeeAssetAmount())
+	})
+}

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -497,6 +497,17 @@ func (s *Strategy) transitClosingRound(ctx context.Context, round *ArbitrageRoun
 }
 
 func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time) {
+	var lastOpenTime time.Time
+	for _, round := range s.activeRounds {
+		if lastOpenTime.IsZero() {
+			lastOpenTime = round.StartTime()
+		}
+	}
+	if !lastOpenTime.IsZero() && currentTime.Sub(lastOpenTime) < s.OpenPositionInterval.Duration() {
+		// still within the open position cooldown time, do not try to open new round
+		return
+	}
+
 	if len(s.activeRounds) == 0 {
 		// Only open new round when there is no active round
 		// TODO: support multiple active rounds for different symbols concurrently (e.g BTCUSDT and ETHUSDT)

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -43,7 +43,9 @@ type Strategy struct {
 	TransitRoundInterval types.Duration `json:"transitRoundInterval"`
 
 	// TickSymbol is the symbol used for ticking the strategy, default to the first candidate symbol
-	TickSymbol string `json:"tickSymbol"`
+	TickSymbol    string `json:"tickSymbol"`
+	FeeSymbol     string `json:"feeSymbol"`
+	QuoteCurrency string `json:"quoteCurrency"`
 
 	TWAPWorkerConfig TWAPWorkerConfig `json:"twap"`
 
@@ -63,7 +65,8 @@ type Strategy struct {
 	costEstimator             *CostEstimator
 	preliminaryMarketSelector *MarketSelector
 
-	activeRounds map[string]*ArbitrageRound
+	pendingRounds map[string]*ArbitrageRound
+	activeRounds  map[string]*ArbitrageRound
 
 	coinmarketcapClient *coinmarketcap.DataSource
 
@@ -80,6 +83,8 @@ type Strategy struct {
 
 	logger     logrus.FieldLogger
 	logLimiter *rate.Limiter
+
+	lastTickTime time.Time
 }
 
 func (s *Strategy) ID() string {
@@ -110,6 +115,9 @@ func (s *Strategy) Defaults() error {
 		s.MarketSelectionConfig = &MarketSelectionConfig{}
 	}
 	s.MarketSelectionConfig.Defaults()
+	if s.QuoteCurrency == "" {
+		s.QuoteCurrency = "USDT"
+	}
 
 	return nil
 }
@@ -146,6 +154,8 @@ func (s *Strategy) Initialize() error {
 	if !bbgo.IsBackTesting {
 		s.logLimiter = rate.NewLimiter(rate.Every(time.Minute*10), 1)
 	}
+	s.activeRounds = make(map[string]*ArbitrageRound)
+	s.pendingRounds = make(map[string]*ArbitrageRound)
 	return nil
 }
 
@@ -230,7 +240,7 @@ func (s *Strategy) CrossRun(
 		return errors.New("no candidate symbols after filtering")
 	}
 
-	// setup the general order executors
+	// market checking and setup the general order executors
 	// NOTE: the executors should be created first before anything else to ensure the executors get updated first.
 	// The twap executors rely on the state of the general order executors to determine the filled quantity.
 	s.candidateSymbols = candidateSymbols
@@ -243,6 +253,16 @@ func (s *Strategy) CrossRun(
 		if !found {
 			return fmt.Errorf("market %s not found in futures session", symbol)
 		}
+		// check all symbols have the same quote currency
+		if spotMarket.QuoteCurrency != s.QuoteCurrency {
+			return fmt.Errorf("spot market %s quote currency %s does not match strategy quote currency %s",
+				symbol, spotMarket.QuoteCurrency, s.QuoteCurrency)
+		}
+		if futuresMarket.QuoteCurrency != s.QuoteCurrency {
+			return fmt.Errorf("futures market %s quote currency %s does not match strategy quote currency %s",
+				symbol, futuresMarket.QuoteCurrency, s.QuoteCurrency)
+		}
+
 		var spotPosition, futuresPosition *types.Position
 		if p, found := s.spotPositions[symbol]; found {
 			spotPosition = p
@@ -278,21 +298,6 @@ func (s *Strategy) CrossRun(
 		s.futuresGeneralOrderExecutors[symbol] = futuresExecutor
 	}
 
-	// subscribe BNB pairs for trading fee calculation
-	quoteCurrencies := make(map[string]struct{})
-	for _, symbol := range candidateSymbols {
-		market, ok := s.futuresSession.Market(symbol)
-		if !ok {
-			return fmt.Errorf("market %s not found in futures session", symbol)
-		}
-		quoteCurrencies[market.QuoteCurrency] = struct{}{}
-	}
-	for quoteCurrency := range quoteCurrencies {
-		bnbSymbol := fmt.Sprintf("BNB%s", quoteCurrency)
-		s.spotSession.Subscribe(types.KLineChannel, bnbSymbol, types.SubscribeOptions{Interval: types.Interval1m})
-		s.futuresSession.Subscribe(types.KLineChannel, bnbSymbol, types.SubscribeOptions{Interval: types.Interval1m})
-	}
-
 	// initialize depth books for model selection
 	// we create new stream here to save the bandwidth of the market data stream of the sessions
 	futureStream := s.futuresSession.Exchange.NewStream()
@@ -309,6 +314,13 @@ func (s *Strategy) CrossRun(
 		spotBook.BindStream(spotStream)
 		spotStream.Subscribe(types.BookChannel, symbol, types.SubscribeOptions{})
 		s.spotOrderBooks[symbol] = spotBook
+	}
+	// subscribe fee symbol order book for trading fee estimation
+	if s.FeeSymbol != "" {
+		spotBook := types.NewStreamBook(s.FeeSymbol, s.spotSession.ExchangeName)
+		spotBook.BindStream(spotStream)
+		spotStream.Subscribe(types.BookChannel, s.FeeSymbol, types.SubscribeOptions{})
+		s.spotOrderBooks[s.FeeSymbol] = spotBook
 	}
 	if err := futureStream.Connect(ctx); err != nil {
 		return fmt.Errorf("failed to connect future stream books: %w", err)
@@ -364,6 +376,11 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if !s.lastTickTime.IsZero() && (s.lastTickTime.Equal(tickTime) || tickTime.Before(s.lastTickTime)) {
+		return
+	}
+	s.lastTickTime = tickTime
+
 	// start processing
 	// 1. check if there is any active round needs to be closed
 	// transit round states
@@ -382,7 +399,10 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 	// 2. check if new round can be opened or existing round needs to be adjusted
 	s.checkOpenNewRound(ctx, tickTime)
 
-	// tick existing active rounds
+	// 3. process pending rounds that are waiting for fee asset preparation
+	s.processPendingRounds(ctx, tickTime)
+
+	// 4. tick existing active rounds
 	for _, round := range s.activeRounds {
 		spotOrderBook := s.spotOrderBooks[round.spotWorker.Symbol()].Copy()
 		futuresOrderBook := s.futuresOrderBooks[round.futuresWorker.Symbol()].Copy()
@@ -495,6 +515,12 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 			// no profitable candidate found, nothing to do
 			return
 		}
+		_, pending := s.pendingRounds[selectedCandidate.Symbol]
+		_, active := s.activeRounds[selectedCandidate.Symbol]
+		if pending || active {
+			// already has pending or active round for the symbol, skip
+			return
+		}
 		// open new round if the estimated break-even holding interval is within the max holding hours
 		if selectedCandidate.MinHoldingDuration <= s.MarketSelectionConfig.MaxHoldingHours.Duration() {
 			spotExecutor := s.spotGeneralOrderExecutors[selectedCandidate.Symbol]
@@ -523,7 +549,8 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 				s.logger.WithError(err).Errorf("failed to start arbitrage round: %s", selectedCandidate.Symbol)
 				return
 			}
-			s.activeRounds[selectedCandidate.Symbol] = round
+			// save as pending round for the fee asset preparation
+			s.pendingRounds[selectedCandidate.Symbol] = round
 		}
 	}
 }


### PR DESCRIPTION
Based on arbitrage rounds that are about to open:
1. calculate the total amount of fee asset that need to buy
2. transfer required fee asset between spot and futures accounts