### PR TITLE
FIX: [xfundingv2] fix deadlock, TWAP taker price, transfer logic, and typos

### DIFF
--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -421,6 +421,7 @@ func (r *ArbitrageRound) handleSpotTrade(trade types.Trade, currentTime time.Tim
 		return
 	}
 
+	r.logger.Infof("handling spot trade: %s", trade)
 	r.spotWorker.AddTrade(trade)
 	// no matter the transfer succeeds or not, we should update the futures position so that we can stay in delta-neutral
 	r.syncFuturesPosition(trade)
@@ -460,7 +461,7 @@ func (r *ArbitrageRound) HandleFuturesTrade(trade types.Trade, currentTime time.
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if trade.Symbol != r.futuresWorker.Symbol() || !trade.IsFutures {
+	if !trade.IsFutures || !r.hasOrder(trade.OrderID) {
 		return
 	}
 	r.logger.Infof("handling future trade: %s", trade)

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -567,7 +567,11 @@ func (r *ArbitrageRound) Tick(currentTime time.Time, spotOrderBook types.OrderBo
 		return
 	}
 
-	r.retryTransferTickC <- currentTime
+	select {
+	case r.retryTransferTickC <- currentTime:
+	default:
+		r.logger.Warnf("retry transfer tick channel is full, skipping retry tick at %s", currentTime.Format(time.RFC3339))
+	}
 
 	// it's opening or closing, tick the workers
 	r.spotWorker.Tick(currentTime, spotOrderBook)

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -196,10 +196,12 @@ func (r *ArbitrageRound) NumHoldingIntervals(currentTime time.Time) int {
 	if r.syncState.StartTime.IsZero() {
 		return 0
 	}
-	// the funding rate has not flipped, check if the minimum holding time has passed
 	intervalDuration := time.Duration(r.syncState.FundingIntervalHours) * time.Hour
-	lastIntervalEnd := currentTime.Truncate(intervalDuration)
-	return int(lastIntervalEnd.Sub(r.syncState.FundingIntervalStart) / intervalDuration)
+	elapsed := currentTime.Sub(r.syncState.FundingIntervalStart)
+	if elapsed < 0 {
+		return 0
+	}
+	return int(elapsed / intervalDuration)
 }
 
 func (r *ArbitrageRound) MinHoldingIntervals() int {

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -293,6 +293,10 @@ func (r *ArbitrageRound) HasOrder(orderID uint64) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	return r.hasOrder(orderID)
+}
+
+func (r *ArbitrageRound) hasOrder(orderID uint64) bool {
 	_, spotExists := r.spotWorker.Executor().GetOrder(orderID)
 	_, futuresExists := r.futuresWorker.Executor().GetOrder(orderID)
 
@@ -411,7 +415,7 @@ func (r *ArbitrageRound) HandleSpotTrade(trade types.Trade, currentTime time.Tim
 }
 
 func (r *ArbitrageRound) handleSpotTrade(trade types.Trade, currentTime time.Time) {
-	if trade.IsFutures || !r.HasOrder(trade.OrderID) {
+	if trade.IsFutures || !r.hasOrder(trade.OrderID) {
 		return
 	}
 

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -480,6 +480,14 @@ func (r *ArbitrageRound) FuturesSymbol() string {
 	return r.futuresWorker.Symbol()
 }
 
+func (r *ArbitrageRound) SpotWorker() *TWAPWorker {
+	return r.spotWorker
+}
+
+func (r *ArbitrageRound) FuturesWorker() *TWAPWorker {
+	return r.futuresWorker
+}
+
 func (r *ArbitrageRound) FuturesMarket() types.Market {
 	return r.futuresWorker.Market()
 }

--- a/pkg/strategy/xfundingv2/arb_round_fee.go
+++ b/pkg/strategy/xfundingv2/arb_round_fee.go
@@ -109,8 +109,12 @@ func (s *Strategy) acquireFeeAssetAndTransfer(ctx context.Context, rounds []*Arb
 		// this case means the total fee asset balance is not sufficient
 		// need to buy and transfer in the fee asset to cover the deficit
 		buyQuantity = spotDeficit.Add(futuresDeficit) // must be positive or zero
-		transferAmount = fixedpoint.Max(fixedpoint.Zero, futuresDeficit)
-		transferDirection = types.TransferIn
+		transferAmount = futuresDeficit.Abs()
+		if futuresDeficit.Sign() > 0 {
+			transferDirection = types.TransferIn
+		} else if futuresDeficit.Sign() < 0 {
+			transferDirection = types.TransferOut
+		}
 	} else {
 		// this case means the total fee asset balance is sufficient
 		if futuresDeficit.Sign() > 0 {

--- a/pkg/strategy/xfundingv2/arb_round_fee.go
+++ b/pkg/strategy/xfundingv2/arb_round_fee.go
@@ -154,6 +154,7 @@ func (s *Strategy) calculateRoundFeeAsset(round *ArbitrageRound) error {
 		return nil
 	}
 
+	// overestimate the fee asset amount with taker fee rate
 	spotFeeRate := s.spotSession.TakerFeeRate
 	futuresFeeRate := s.futuresSession.TakerFeeRate
 

--- a/pkg/strategy/xfundingv2/arb_round_fee_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_fee_test.go
@@ -221,8 +221,8 @@ func TestStrategy_AquireFeeAssetAndTransfer(t *testing.T) {
 		// Spot needs 2.0 BNB, has 0.3 BNB; Futures needs 0.5 BNB, has 0.6 BNB
 		// spotDeficit = 2.0 - 0.3 = 1.7, futuresDeficit = 0.5 - 0.6 = -0.1
 		// total = 1.7 + (-0.1) = 1.6 >= 0 → buy 1.6, transfer max(0, -0.1) = 0 to futures
-		// futuresDeficit <= 0 and spotDeficit > 0 but we're in the "total >= 0" branch
-		// so transferAmount = max(0, futuresDeficit) = 0 → no transfer
+		// futuresDeficit <= 0 and spotDeficit > 0
+		// so transferAmount = futuresDeficit.Neg() = 0.1 → transfer out
 		s, mockExchange, mockService := setup(Number(0.3), Number(0.6))
 		rounds := makeRounds(Number(2.0), Number(0.5))
 
@@ -240,8 +240,10 @@ func TestStrategy_AquireFeeAssetAndTransfer(t *testing.T) {
 		err := s.acquireFeeAssetAndTransfer(ctx, rounds)
 
 		assert.NoError(t, err)
-		// No transfer needed since bought assets land in spot and futuresDeficit <= 0
-		assert.False(t, mockService.transferCalled)
+		// transfer needed:
+		assert.True(t, mockService.transferCalled)
+		assert.Equal(t, Number(0.1), mockService.transferredAmount)
+		assert.Equal(t, types.TransferOut, mockService.transferredDirection)
 	})
 }
 

--- a/pkg/strategy/xfundingv2/arb_round_sync_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_sync_test.go
@@ -80,11 +80,11 @@ func TestArbitrageRound_MarshalUnmarshalJSON(t *testing.T) {
 		round := &ArbitrageRound{
 			syncState: ArbitrageRoundSyncState{
 				TriggeredFundingRate: fixedpoint.NewFromFloat(0.0005),
-				SpotExchangeName:    types.ExchangeBinance,
-				FuturesExchangeName: types.ExchangeBinance,
-				State:               RoundPending,
-				Asset:               "ETH",
-				FundingFeeRecords:   make(map[int64]FundingFee),
+				SpotExchangeName:     types.ExchangeBinance,
+				FuturesExchangeName:  types.ExchangeBinance,
+				State:                RoundPending,
+				Asset:                "ETH",
+				FundingFeeRecords:    make(map[int64]FundingFee),
 			},
 		}
 

--- a/pkg/strategy/xfundingv2/arb_round_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_test.go
@@ -64,6 +64,81 @@ func newTestArbitrageRound(t *testing.T, ctrl *gomock.Controller, fundingInterva
 	return round, mockService
 }
 
+func TestArbitrageRound_NumHoldingIntervals(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Funding at 08:00 UTC, 8h interval → FundingIntervalStart = 00:00 UTC
+	nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+
+	t.Run("returns_zero_when_start_time_is_zero", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		// StartTime is zero by default (round not started)
+		result := round.NumHoldingIntervals(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC))
+		assert.Equal(t, 0, result)
+	})
+
+	t.Run("returns_zero_when_current_time_before_funding_interval_start", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartTime = time.Date(2024, 1, 1, 0, 30, 0, 0, time.UTC)
+		// currentTime is before FundingIntervalStart (00:00 UTC)
+		result := round.NumHoldingIntervals(time.Date(2023, 12, 31, 23, 0, 0, 0, time.UTC))
+		assert.Equal(t, 0, result)
+	})
+
+	t.Run("returns_zero_within_first_interval", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartTime = time.Date(2024, 1, 1, 0, 30, 0, 0, time.UTC)
+		// 4 hours after FundingIntervalStart → still in first 8h interval
+		result := round.NumHoldingIntervals(time.Date(2024, 1, 1, 4, 0, 0, 0, time.UTC))
+		assert.Equal(t, 0, result)
+	})
+
+	t.Run("returns_one_after_first_interval", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartTime = time.Date(2024, 1, 1, 0, 30, 0, 0, time.UTC)
+		// exactly 8 hours after FundingIntervalStart
+		result := round.NumHoldingIntervals(time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC))
+		assert.Equal(t, 1, result)
+	})
+
+	t.Run("returns_three_after_24_hours_with_8h_interval", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartTime = time.Date(2024, 1, 1, 0, 30, 0, 0, time.UTC)
+		// 24 hours after FundingIntervalStart → 3 intervals
+		result := round.NumHoldingIntervals(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC))
+		assert.Equal(t, 3, result)
+	})
+
+	t.Run("rounds_down_partial_intervals", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartTime = time.Date(2024, 1, 1, 0, 30, 0, 0, time.UTC)
+		// 20 hours after FundingIntervalStart → 2.5 intervals → rounds down to 2
+		result := round.NumHoldingIntervals(time.Date(2024, 1, 1, 20, 0, 0, 0, time.UTC))
+		assert.Equal(t, 2, result)
+	})
+
+	t.Run("works_with_4h_funding_interval", func(t *testing.T) {
+		// Funding at 04:00 UTC, 4h interval → FundingIntervalStart = 00:00 UTC
+		nextFunding4h := time.Date(2024, 1, 1, 4, 0, 0, 0, time.UTC)
+		round, _ := newTestArbitrageRound(t, ctrl, 4, 3, nextFunding4h)
+		round.syncState.StartTime = time.Date(2024, 1, 1, 0, 30, 0, 0, time.UTC)
+		// 12 hours after FundingIntervalStart → 3 intervals of 4h
+		result := round.NumHoldingIntervals(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
+		assert.Equal(t, 3, result)
+	})
+
+	t.Run("works_with_non_epoch_aligned_funding_start", func(t *testing.T) {
+		// Funding at 10:00 UTC, 8h interval → FundingIntervalStart = 02:00 UTC
+		nextFundingOffset := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingOffset)
+		round.syncState.StartTime = time.Date(2024, 1, 1, 2, 30, 0, 0, time.UTC)
+		// FundingIntervalStart is 02:00; currentTime 18:00 → 16h elapsed → 2 intervals
+		result := round.NumHoldingIntervals(time.Date(2024, 1, 1, 18, 0, 0, 0, time.UTC))
+		assert.Equal(t, 2, result)
+	})
+}
+
 func TestArbitrageRound_TotalFundingIncome(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -215,7 +215,7 @@ func (s *Strategy) CrossRun(
 		return fmt.Errorf("spot session %s not found", s.SpotSession)
 	}
 	if futuresEx, ok := s.futuresSession.Exchange.(types.FuturesExchange); !ok {
-		return fmt.Errorf("sessioin %s does not support futures", s.futuresSession.Name)
+		return fmt.Errorf("session %s does not support futures", s.futuresSession.Name)
 	} else if !futuresEx.GetFuturesSettings().IsFutures {
 		return fmt.Errorf("session %s is not configured for futures trading", s.futuresSession.Name)
 	}
@@ -622,7 +622,7 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 			return
 		}
 
-		selectedCandidate := s.selectMostPorfitableMarket(candidates)
+		selectedCandidate := s.selectMostProfitableMarket(candidates)
 		if selectedCandidate == nil {
 			// no profitable candidate found, nothing to do
 			return
@@ -758,7 +758,7 @@ func (s *Strategy) filterMarketCollateralRate(ctx context.Context, symbols []str
 // selectMostProfitableMarket selects the most profitable market among the candidates based on the estimated break-even holding intervals
 // it will also return the target position for the futures trade
 // the most profitable market is the one with the shortest break-even holding intervals
-func (s *Strategy) selectMostPorfitableMarket(candidates []MarketCandidate) *MarketCandidate {
+func (s *Strategy) selectMostProfitableMarket(candidates []MarketCandidate) *MarketCandidate {
 	if len(candidates) == 0 {
 		return nil
 	}
@@ -849,13 +849,13 @@ func (s *Strategy) calculateMinHoldingIntervals(candidate MarketCandidate, bestP
 		return fixedpoint.Zero, errors.New("order book not found for candidate symbol")
 	}
 	spotOrderBookSnapshot := spotOrderBook.Copy()
-	futuresOrderBookShapshot := futuresOrderBook.Copy()
+	futuresOrderBookSnapshot := futuresOrderBook.Copy()
 
-	estimateEntryCost, err := s.costEstimator.EstimateEntryCost(true, spotOrderBookSnapshot, futuresOrderBookShapshot)
+	estimateEntryCost, err := s.costEstimator.EstimateEntryCost(true, spotOrderBookSnapshot, futuresOrderBookSnapshot)
 	if err != nil {
 		return fixedpoint.Zero, err
 	}
-	estimateExitCost, err := s.costEstimator.EstimateExitCost(true, spotOrderBookSnapshot, futuresOrderBookShapshot)
+	estimateExitCost, err := s.costEstimator.EstimateExitCost(true, spotOrderBookSnapshot, futuresOrderBookSnapshot)
 	if err != nil {
 		return fixedpoint.Zero, err
 	}

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -923,14 +923,11 @@ func (s *Strategy) handleClosedRound(ctx context.Context, round *ArbitrageRound,
 	}
 	// clean up open orders if there is any
 	var spotOpenOrders, futuresOpenOrders []types.Order
-	for _, order := range round.spotWorker.Executor().AllOrders() {
-		if !order.GetRemainingQuantity().IsZero() {
-			if order.IsFutures {
-				futuresOpenOrders = append(futuresOpenOrders, order)
-			} else {
-				spotOpenOrders = append(spotOpenOrders, order)
-			}
-		}
+	for _, order := range round.SpotWorker().Executor().OpenOrders() {
+		spotOpenOrders = append(spotOpenOrders, order)
+	}
+	for _, order := range round.FuturesWorker().Executor().OpenOrders() {
+		futuresOpenOrders = append(futuresOpenOrders, order)
 	}
 	if len(spotOpenOrders) > 0 {
 		err := s.spotSession.Exchange.CancelOrders(ctx, spotOpenOrders...)

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -904,6 +904,35 @@ func (s *Strategy) handleClosedRound(ctx context.Context, round *ArbitrageRound,
 		feeAvgCost := executor.Position().AverageCost
 		round.SetAvgFeeCost(s.FeeSymbol, feeAvgCost)
 	}
+	// clean up open orders if there is any
+	var spotOpenOrders, futuresOpenOrders []types.Order
+	for _, order := range round.spotWorker.Executor().AllOrders() {
+		if !order.GetRemainingQuantity().IsZero() {
+			if order.IsFutures {
+				futuresOpenOrders = append(futuresOpenOrders, order)
+			} else {
+				spotOpenOrders = append(spotOpenOrders, order)
+			}
+		}
+	}
+	if len(spotOpenOrders) > 0 {
+		err := s.spotSession.Exchange.CancelOrders(ctx, spotOpenOrders...)
+		if err != nil {
+			s.logger.WithError(err).Errorf(
+				"[roundExitWorker] failed to cancel open spot orders: %s",
+				round.SpotSymbol(),
+			)
+		}
+	}
+	if len(futuresOpenOrders) > 0 {
+		err := s.futuresSession.Exchange.CancelOrders(ctx, futuresOpenOrders...)
+		if err != nil {
+			s.logger.WithError(err).Errorf(
+				"[roundExitWorker] failed to cancel open futures orders: %s",
+				round.FuturesSymbol(),
+			)
+		}
+	}
 	round.SyncFundingFeeRecords(ctx, tickTime)
 	bbgo.Notify(round.PnL(ctx, tickTime))
 	// TODO: insert closed round records into database

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -779,7 +779,7 @@ func (s *Strategy) selectMostProfitableMarket(candidates []MarketCandidate) *Mar
 			tradeQuoteBalance := quoteBalance.Available.Mul(s.MarketSelectionConfig.TradeBalanceRatio)
 			// long spot -> trade on the sell side of the order book
 			sellBook := s.spotOrderBooks[candidate.Symbol].SideBook(types.SideTypeSell)
-			spotPrice := sellBook.AverageDepthPriceByQuote(quoteBalance.Available, 0)
+			spotPrice := sellBook.AverageDepthPriceByQuote(tradeQuoteBalance, 0)
 			targetSize := tradeQuoteBalance.Div(spotPrice)
 			// short futures -> trade on the buy side of the order book
 			buyBook := s.futuresOrderBooks[candidate.Symbol].SideBook(types.SideTypeBuy)
@@ -867,7 +867,7 @@ func (s *Strategy) calculateMinHoldingIntervals(candidate MarketCandidate, bestP
 	amount := targetPosition.Abs().Mul(bestPrice)
 	estimateFundingFeePerInterval := amount.Mul(candidate.PremiumIndex.LastFundingRate.Abs())
 	if estimateFundingFeePerInterval.IsZero() {
-		return fixedpoint.Zero, nil
+		return fixedpoint.Zero, fmt.Errorf("estimated funding fee per interval is zero for candidate %s", candidate.Symbol)
 	}
 	breakEvenIntervals := totalCost.Div(estimateFundingFeePerInterval).Round(0, fixedpoint.Up)
 	return breakEvenIntervals, nil

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -552,6 +552,13 @@ func (s *Strategy) transitOpeningOrReadyRound(ctx context.Context, round *Arbitr
 				currentTime.Format(time.RFC3339), round.State(), fundingRate.LastFundingRate, round)
 			round.SetClosing(currentTime, s.TWAPWorkerConfig.ClosingDuration)
 			return
+		} else if currentTime.Sub(round.StartTime()) >= s.MarketSelectionConfig.MaxHoldingHours.Duration() {
+			s.logger.Infof(
+				"[transitOpeningOrReadyRound %s] max holding hours reached, transit state %s -> closing, current funding rate %s: %s",
+				currentTime.Format(time.RFC3339), round.State(), fundingRate.LastFundingRate, round,
+			)
+			round.SetClosing(currentTime, s.TWAPWorkerConfig.ClosingDuration)
+			return
 		}
 		// the funding rate is not favorable anymore, check the exit cost to see if it's worth to transit to closing
 		s.costEstimator.SetTargetPosition(round.TargetPosition())

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -488,6 +488,8 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		if round.State() == RoundClosed {
 			s.logger.Infof("removing closed round: %s", round)
 			delete(s.activeRounds, round.SpotSymbol())
+			// TODO: implement a dedicated worker to handle the post-round processing
+			// So that we can prevent blocking the main ticking loop too long when there are multiple rounds get closed.
 			s.handleClosedRound(ctx, round, tickTime)
 		}
 	}

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -778,6 +778,10 @@ func (s *Strategy) selectMostProfitableMarket(candidates []MarketCandidate) *Mar
 			continue
 		}
 		if s.MarketSelectionConfig.FuturesDirection == types.PositionShort {
+			if candidate.PremiumIndex.LastFundingRate.Sign() <= 0 {
+				// the funding rate is not favorable for short futures, skip
+				continue
+			}
 			// long spot -> find the amount for the quote currency
 			quoteBalance, ok := spotAccount.Balance(spotMarket.QuoteCurrency)
 			if !ok {
@@ -799,6 +803,10 @@ func (s *Strategy) selectMostProfitableMarket(candidates []MarketCandidate) *Mar
 			breakevenIntervals[candidate.Symbol] = breakEvenIntervals
 			targetFuturePositions[candidate.Symbol] = targetSize.Neg()
 		} else if s.MarketSelectionConfig.FuturesDirection == types.PositionLong {
+			if candidate.PremiumIndex.LastFundingRate.Sign() >= 0 {
+				// the funding rate is not favorable for long futures, skip
+				continue
+			}
 			baseBalance, ok := spotAccount.Balance(spotMarket.BaseCurrency)
 			if !ok {
 				continue

--- a/pkg/strategy/xfundingv2/strategy_test.go
+++ b/pkg/strategy/xfundingv2/strategy_test.go
@@ -1,0 +1,439 @@
+package xfundingv2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/bbgo/pkg/bbgo"
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	. "github.com/c9s/bbgo/pkg/testing/testhelper"
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+// newTestStreamOrderBook creates a StreamOrderBook with loaded order book data for testing.
+// Both bids and asks must be provided for the cost estimator to calculate entry and exit costs.
+func newTestStreamOrderBook(symbol string, bids, asks []types.PriceVolume) *types.StreamOrderBook {
+	sob := types.NewStreamBook(symbol, types.ExchangeName("test"))
+	book := types.SliceOrderBook{
+		Symbol: symbol,
+		Bids:   bids,
+		Asks:   asks,
+		Time:   time.Now(),
+	}
+	sob.Load(book)
+	return sob
+}
+
+func newTestSession(markets types.MarketMap, balances types.BalanceMap) *bbgo.ExchangeSession {
+	session := &bbgo.ExchangeSession{
+		Account: types.NewAccount(),
+	}
+	session.Account.UpdateBalances(balances)
+	session.SetMarkets(markets)
+	return session
+}
+
+func newDefaultTestStrategy() *Strategy {
+	return &Strategy{
+		MarketSelectionConfig: &MarketSelectionConfig{
+			FuturesDirection:  types.PositionShort,
+			TradeBalanceRatio: Number("0.5"),
+		},
+		MaxPositionExposure: make(map[string]fixedpoint.Value),
+		costEstimator:       NewCostEstimator(),
+		logger:              logrus.StandardLogger(),
+	}
+}
+
+func TestSelectMostProfitableMarket(t *testing.T) {
+	btcMarket := Market("BTCUSDT")
+	ethMarket := Market("ETHUSDT")
+
+	t.Run("empty candidates returns nil", func(t *testing.T) {
+		s := newDefaultTestStrategy()
+		result := s.selectMostProfitableMarket(nil)
+		assert.Nil(t, result)
+
+		result = s.selectMostProfitableMarket([]MarketCandidate{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("short futures selects candidate with shortest breakeven interval", func(t *testing.T) {
+		s := newDefaultTestStrategy()
+		s.MarketSelectionConfig.FuturesDirection = types.PositionShort
+		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+
+		markets := types.MarketMap{
+			"BTCUSDT": btcMarket,
+			"ETHUSDT": ethMarket,
+		}
+		balances := types.BalanceMap{
+			"USDT": Balance("USDT", Number(10000)),
+		}
+		s.spotSession = newTestSession(markets, balances)
+
+		// Both bids and asks are needed: asks for entry (buy spot), bids for exit (sell spot)
+		s.spotOrderBooks = map[string]*types.StreamOrderBook{
+			"BTCUSDT": newTestStreamOrderBook("BTCUSDT",
+				[]types.PriceVolume{{Price: Number(49900), Volume: Number(10)}},
+				[]types.PriceVolume{{Price: Number(50000), Volume: Number(10)}}),
+			"ETHUSDT": newTestStreamOrderBook("ETHUSDT",
+				[]types.PriceVolume{{Price: Number(1990), Volume: Number(100)}},
+				[]types.PriceVolume{{Price: Number(2000), Volume: Number(100)}}),
+		}
+
+		// Both bids and asks are needed: bids for entry (short futures), asks for exit (close short)
+		s.futuresOrderBooks = map[string]*types.StreamOrderBook{
+			"BTCUSDT": newTestStreamOrderBook("BTCUSDT",
+				[]types.PriceVolume{{Price: Number(50100), Volume: Number(10)}},
+				[]types.PriceVolume{{Price: Number(50200), Volume: Number(10)}}),
+			"ETHUSDT": newTestStreamOrderBook("ETHUSDT",
+				[]types.PriceVolume{{Price: Number(2010), Volume: Number(100)}},
+				[]types.PriceVolume{{Price: Number(2020), Volume: Number(100)}}),
+		}
+
+		candidates := []MarketCandidate{
+			{
+				Symbol: "BTCUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "BTCUSDT",
+					LastFundingRate: Number("0.001"), // 0.1% per interval
+				},
+				FundingIntervalHours: 8,
+			},
+			{
+				Symbol: "ETHUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "ETHUSDT",
+					LastFundingRate: Number("0.005"), // 0.5% per interval -> higher rate, shorter breakeven
+				},
+				FundingIntervalHours: 8,
+			},
+		}
+
+		result := s.selectMostProfitableMarket(candidates)
+		assert.NotNil(t, result)
+		// ETH has a higher funding rate so it should break even faster
+		assert.Equal(t, "ETHUSDT", result.Symbol)
+		assert.True(t, result.TargetFuturesPosition.Sign() < 0, "target futures position should be negative for short")
+		assert.Greater(t, result.MinHoldingIntervals, 0)
+		assert.True(t, result.MinHoldingDuration > 0)
+	})
+
+	t.Run("long futures selects candidate with shortest breakeven interval", func(t *testing.T) {
+		s := newDefaultTestStrategy()
+		s.MarketSelectionConfig.FuturesDirection = types.PositionLong
+		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+
+		markets := types.MarketMap{
+			"BTCUSDT": btcMarket,
+			"ETHUSDT": ethMarket,
+		}
+		balances := types.BalanceMap{
+			"BTC": Balance("BTC", Number("0.1")),
+			"ETH": Balance("ETH", Number(5)),
+		}
+		s.spotSession = newTestSession(markets, balances)
+
+		s.spotOrderBooks = map[string]*types.StreamOrderBook{
+			"BTCUSDT": newTestStreamOrderBook("BTCUSDT",
+				[]types.PriceVolume{{Price: Number(49900), Volume: Number(10)}},
+				[]types.PriceVolume{{Price: Number(50000), Volume: Number(10)}}),
+			"ETHUSDT": newTestStreamOrderBook("ETHUSDT",
+				[]types.PriceVolume{{Price: Number(1990), Volume: Number(100)}},
+				[]types.PriceVolume{{Price: Number(2000), Volume: Number(100)}}),
+		}
+
+		s.futuresOrderBooks = map[string]*types.StreamOrderBook{
+			"BTCUSDT": newTestStreamOrderBook("BTCUSDT",
+				[]types.PriceVolume{{Price: Number(49800), Volume: Number(10)}},
+				[]types.PriceVolume{{Price: Number(49900), Volume: Number(10)}}),
+			"ETHUSDT": newTestStreamOrderBook("ETHUSDT",
+				[]types.PriceVolume{{Price: Number(1980), Volume: Number(100)}},
+				[]types.PriceVolume{{Price: Number(1990), Volume: Number(100)}}),
+		}
+
+		candidates := []MarketCandidate{
+			{
+				Symbol: "BTCUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "BTCUSDT",
+					LastFundingRate: Number("-0.001"),
+				},
+				FundingIntervalHours: 8,
+			},
+			{
+				Symbol: "ETHUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "ETHUSDT",
+					LastFundingRate: Number("-0.005"),
+				},
+				FundingIntervalHours: 8,
+			},
+		}
+
+		result := s.selectMostProfitableMarket(candidates)
+		assert.NotNil(t, result)
+		assert.True(t, result.TargetFuturesPosition.Sign() > 0, "target futures position should be positive for long")
+		assert.Greater(t, result.MinHoldingIntervals, 0)
+	})
+
+	t.Run("no quote balance returns nil for short futures", func(t *testing.T) {
+		s := newDefaultTestStrategy()
+		s.MarketSelectionConfig.FuturesDirection = types.PositionShort
+
+		markets := types.MarketMap{"BTCUSDT": btcMarket}
+		balances := types.BalanceMap{}
+		s.spotSession = newTestSession(markets, balances)
+
+		s.spotOrderBooks = map[string]*types.StreamOrderBook{
+			"BTCUSDT": newTestStreamOrderBook("BTCUSDT",
+				[]types.PriceVolume{{Price: Number(49900), Volume: Number(10)}},
+				[]types.PriceVolume{{Price: Number(50000), Volume: Number(10)}}),
+		}
+		s.futuresOrderBooks = map[string]*types.StreamOrderBook{
+			"BTCUSDT": newTestStreamOrderBook("BTCUSDT",
+				[]types.PriceVolume{{Price: Number(50100), Volume: Number(10)}},
+				[]types.PriceVolume{{Price: Number(50200), Volume: Number(10)}}),
+		}
+
+		candidates := []MarketCandidate{
+			{
+				Symbol: "BTCUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "BTCUSDT",
+					LastFundingRate: Number("0.001"),
+				},
+				FundingIntervalHours: 8,
+			},
+		}
+
+		result := s.selectMostProfitableMarket(candidates)
+		assert.Nil(t, result)
+	})
+
+	t.Run("unknown market symbol is skipped", func(t *testing.T) {
+		s := newDefaultTestStrategy()
+		s.MarketSelectionConfig.FuturesDirection = types.PositionShort
+
+		markets := types.MarketMap{}
+		balances := types.BalanceMap{
+			"USDT": Balance("USDT", Number(10000)),
+		}
+		s.spotSession = newTestSession(markets, balances)
+		s.spotOrderBooks = map[string]*types.StreamOrderBook{}
+		s.futuresOrderBooks = map[string]*types.StreamOrderBook{}
+
+		candidates := []MarketCandidate{
+			{
+				Symbol: "BTCUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "BTCUSDT",
+					LastFundingRate: Number("0.001"),
+				},
+				FundingIntervalHours: 8,
+			},
+		}
+
+		result := s.selectMostProfitableMarket(candidates)
+		assert.Nil(t, result)
+	})
+
+	t.Run("invalid futures direction returns nil", func(t *testing.T) {
+		s := newDefaultTestStrategy()
+		s.MarketSelectionConfig.FuturesDirection = types.PositionType("Invalid")
+
+		markets := types.MarketMap{"BTCUSDT": btcMarket}
+		balances := types.BalanceMap{
+			"USDT": Balance("USDT", Number(10000)),
+		}
+		s.spotSession = newTestSession(markets, balances)
+		s.spotOrderBooks = map[string]*types.StreamOrderBook{
+			"BTCUSDT": newTestStreamOrderBook("BTCUSDT",
+				[]types.PriceVolume{{Price: Number(49900), Volume: Number(10)}},
+				[]types.PriceVolume{{Price: Number(50000), Volume: Number(10)}}),
+		}
+		s.futuresOrderBooks = map[string]*types.StreamOrderBook{
+			"BTCUSDT": newTestStreamOrderBook("BTCUSDT",
+				[]types.PriceVolume{{Price: Number(50100), Volume: Number(10)}},
+				[]types.PriceVolume{{Price: Number(50200), Volume: Number(10)}}),
+		}
+
+		candidates := []MarketCandidate{
+			{
+				Symbol: "BTCUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "BTCUSDT",
+					LastFundingRate: Number("0.001"),
+				},
+				FundingIntervalHours: 8,
+			},
+		}
+
+		result := s.selectMostProfitableMarket(candidates)
+		assert.Nil(t, result)
+	})
+
+	t.Run("max position exposure caps short futures position", func(t *testing.T) {
+		s := newDefaultTestStrategy()
+		s.MarketSelectionConfig.FuturesDirection = types.PositionShort
+		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+		s.MaxPositionExposure = map[string]fixedpoint.Value{
+			"ETHUSDT": Number("0.5"),
+		}
+
+		markets := types.MarketMap{"ETHUSDT": ethMarket}
+		balances := types.BalanceMap{
+			"USDT": Balance("USDT", Number(10000)),
+		}
+		s.spotSession = newTestSession(markets, balances)
+
+		s.spotOrderBooks = map[string]*types.StreamOrderBook{
+			"ETHUSDT": newTestStreamOrderBook("ETHUSDT",
+				[]types.PriceVolume{{Price: Number(1990), Volume: Number(100)}},
+				[]types.PriceVolume{{Price: Number(2000), Volume: Number(100)}}),
+		}
+		s.futuresOrderBooks = map[string]*types.StreamOrderBook{
+			"ETHUSDT": newTestStreamOrderBook("ETHUSDT",
+				[]types.PriceVolume{{Price: Number(2010), Volume: Number(100)}},
+				[]types.PriceVolume{{Price: Number(2020), Volume: Number(100)}}),
+		}
+
+		candidates := []MarketCandidate{
+			{
+				Symbol: "ETHUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "ETHUSDT",
+					LastFundingRate: Number("0.005"),
+				},
+				FundingIntervalHours: 8,
+			},
+		}
+
+		result := s.selectMostProfitableMarket(candidates)
+		assert.NotNil(t, result)
+		assert.Equal(t, Number("0.5"), result.TargetFuturesPosition.Abs())
+		assert.True(t, result.TargetFuturesPosition.Sign() < 0)
+	})
+
+	t.Run("max position exposure caps long futures position", func(t *testing.T) {
+		s := newDefaultTestStrategy()
+		s.MarketSelectionConfig.FuturesDirection = types.PositionLong
+		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+		s.MaxPositionExposure = map[string]fixedpoint.Value{
+			"ETHUSDT": Number("0.5"),
+		}
+
+		markets := types.MarketMap{"ETHUSDT": ethMarket}
+		balances := types.BalanceMap{
+			"ETH": Balance("ETH", Number(5)),
+		}
+		s.spotSession = newTestSession(markets, balances)
+
+		s.spotOrderBooks = map[string]*types.StreamOrderBook{
+			"ETHUSDT": newTestStreamOrderBook("ETHUSDT",
+				[]types.PriceVolume{{Price: Number(1990), Volume: Number(100)}},
+				[]types.PriceVolume{{Price: Number(2000), Volume: Number(100)}}),
+		}
+		s.futuresOrderBooks = map[string]*types.StreamOrderBook{
+			"ETHUSDT": newTestStreamOrderBook("ETHUSDT",
+				[]types.PriceVolume{{Price: Number(1980), Volume: Number(100)}},
+				[]types.PriceVolume{{Price: Number(1990), Volume: Number(100)}}),
+		}
+
+		candidates := []MarketCandidate{
+			{
+				Symbol: "ETHUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "ETHUSDT",
+					LastFundingRate: Number("-0.005"),
+				},
+				FundingIntervalHours: 8,
+			},
+		}
+
+		result := s.selectMostProfitableMarket(candidates)
+		assert.NotNil(t, result)
+		assert.Equal(t, Number("0.5"), result.TargetFuturesPosition.Abs())
+		assert.True(t, result.TargetFuturesPosition.Sign() > 0)
+	})
+
+	t.Run("zero funding rate candidate is skipped", func(t *testing.T) {
+		s := newDefaultTestStrategy()
+		s.MarketSelectionConfig.FuturesDirection = types.PositionShort
+		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+
+		markets := types.MarketMap{"BTCUSDT": btcMarket}
+		balances := types.BalanceMap{
+			"USDT": Balance("USDT", Number(10000)),
+		}
+		s.spotSession = newTestSession(markets, balances)
+
+		s.spotOrderBooks = map[string]*types.StreamOrderBook{
+			"BTCUSDT": newTestStreamOrderBook("BTCUSDT",
+				[]types.PriceVolume{{Price: Number(49900), Volume: Number(10)}},
+				[]types.PriceVolume{{Price: Number(50000), Volume: Number(10)}}),
+		}
+		s.futuresOrderBooks = map[string]*types.StreamOrderBook{
+			"BTCUSDT": newTestStreamOrderBook("BTCUSDT",
+				[]types.PriceVolume{{Price: Number(50100), Volume: Number(10)}},
+				[]types.PriceVolume{{Price: Number(50200), Volume: Number(10)}}),
+		}
+
+		candidates := []MarketCandidate{
+			{
+				Symbol: "BTCUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "BTCUSDT",
+					LastFundingRate: Number(0),
+				},
+				FundingIntervalHours: 8,
+			},
+		}
+
+		result := s.selectMostProfitableMarket(candidates)
+		assert.Nil(t, result, "zero funding rate should cause candidate to be skipped")
+	})
+
+	t.Run("single candidate returns that candidate", func(t *testing.T) {
+		s := newDefaultTestStrategy()
+		s.MarketSelectionConfig.FuturesDirection = types.PositionShort
+		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+
+		markets := types.MarketMap{"ETHUSDT": ethMarket}
+		balances := types.BalanceMap{
+			"USDT": Balance("USDT", Number(10000)),
+		}
+		s.spotSession = newTestSession(markets, balances)
+
+		s.spotOrderBooks = map[string]*types.StreamOrderBook{
+			"ETHUSDT": newTestStreamOrderBook("ETHUSDT",
+				[]types.PriceVolume{{Price: Number(1990), Volume: Number(100)}},
+				[]types.PriceVolume{{Price: Number(2000), Volume: Number(100)}}),
+		}
+		s.futuresOrderBooks = map[string]*types.StreamOrderBook{
+			"ETHUSDT": newTestStreamOrderBook("ETHUSDT",
+				[]types.PriceVolume{{Price: Number(2010), Volume: Number(100)}},
+				[]types.PriceVolume{{Price: Number(2020), Volume: Number(100)}}),
+		}
+
+		candidates := []MarketCandidate{
+			{
+				Symbol: "ETHUSDT",
+				PremiumIndex: &types.PremiumIndex{
+					Symbol:          "ETHUSDT",
+					LastFundingRate: Number("0.005"),
+				},
+				FundingIntervalHours: 8,
+			},
+		}
+
+		result := s.selectMostProfitableMarket(candidates)
+		assert.NotNil(t, result)
+		assert.Equal(t, "ETHUSDT", result.Symbol)
+		assert.Equal(t, 8, result.FundingIntervalHours)
+	})
+}

--- a/pkg/strategy/xfundingv2/twap_order_executor.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor.go
@@ -124,6 +124,16 @@ func (o *TWAPExecutor) GetOrder(orderID uint64) (types.Order, bool) {
 	return o.executor.OrderStore().Get(orderID)
 }
 
+func (o *TWAPExecutor) OpenOrders() []types.Order {
+	var openOrders []types.Order
+	for _, order := range o.executor.ActiveMakerOrders().Orders() {
+		if _, found := o.syncState.Orders[order.OrderID]; found {
+			openOrders = append(openOrders, order)
+		}
+	}
+	return openOrders
+}
+
 func (o *TWAPExecutor) AllOrders() []types.Order {
 	var orders []types.Order
 

--- a/pkg/strategy/xfundingv2/twap_order_executor.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor.go
@@ -224,8 +224,7 @@ func (o *TWAPExecutor) getTakerPrice(side types.SideType, orderBook types.OrderB
 		}
 		price := ask.Price
 		if o.syncState.Config.MaxSlippage.Sign() > 0 {
-			maxPrice := price.Mul(fixedpoint.One.Add(o.syncState.Config.MaxSlippage))
-			price = fixedpoint.Min(price, maxPrice)
+			price = price.Mul(fixedpoint.One.Add(o.syncState.Config.MaxSlippage))
 		}
 		return price, nil
 
@@ -236,8 +235,7 @@ func (o *TWAPExecutor) getTakerPrice(side types.SideType, orderBook types.OrderB
 		}
 		price := bid.Price
 		if o.syncState.Config.MaxSlippage.Sign() > 0 {
-			minPrice := price.Mul(fixedpoint.One.Sub(o.syncState.Config.MaxSlippage))
-			price = fixedpoint.Max(price, minPrice)
+			price = price.Mul(fixedpoint.One.Sub(o.syncState.Config.MaxSlippage))
 		}
 		return price, nil
 

--- a/pkg/strategy/xfundingv2/twap_order_executor_sync.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor_sync.go
@@ -46,12 +46,13 @@ func (o *TWAPExecutor) Initialize(s *Strategy) error {
 		return errors.New("[TWAPExecutor] session exchange does not implement ExchangeOrderQueryService")
 	}
 	// sync orders
+	orderStore := executor.OrderStore()
 	for _, query := range o.syncState.Orders {
 		order, err := o.exchange.QueryOrder(o.ctx, query)
 		if err != nil || order == nil {
 			return fmt.Errorf("[TWAPExecutor] failed to query order %v: %w", query, err)
 		}
-		o.executor.OrderStore().Add(*order)
+		orderStore.Add(*order)
 	}
 	return nil
 }

--- a/pkg/strategy/xfundingv2/twap_order_executor_test.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor_test.go
@@ -163,19 +163,17 @@ func TestTWAPOrderExecutor_GetTakerPrice(t *testing.T) {
 	t.Run("buy with max slippage", func(t *testing.T) {
 		// ask=100.0, maxSlippage=0.01
 		// maxPrice = 100.0 * (1 + 0.01) = 101.0
-		// price = min(100.0, 101.0) = 100.0
 		price, err := executor.GetPrice(types.SideTypeBuy, orderBook)
 		assert.NoError(t, err)
-		assert.Equal(t, Number(100.0), price)
+		assert.Equal(t, Number(101.0), price)
 	})
 
 	t.Run("sell with max slippage", func(t *testing.T) {
 		// bid=99.0, maxSlippage=0.01
 		// minPrice = 99.0 * (1 - 0.01) = 98.01
-		// price = max(99.0, 98.01) = 99.0
 		price, err := executor.GetPrice(types.SideTypeSell, orderBook)
 		assert.NoError(t, err)
-		assert.Equal(t, Number(99.0), price)
+		assert.Equal(t, Number(98.01), price)
 	})
 
 	t.Run("empty order book returns error for buy", func(t *testing.T) {


### PR DESCRIPTION
- Fix deadlock (`HasOrder`)
- Fix TWAP taker price calculation
- Make transfer retry tick non-blocking
- Fix market selection to use the ratio-adjusted quote balance for depth price lookup
- Fix transfer direction when futures has surplus fee asset (transfer out instead of no-op)
- Simplify holding interval calculation
- Return error instead of silently succeeding when estimated funding fee is zero
- Fix typos