### PR TITLE
FIX: [xfundingv2] implement cleanup process for closed rounds and handle remaining positions

### DIFF
--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -246,21 +246,6 @@ func (r *ArbitrageRound) String() string {
 }
 
 func (r *ArbitrageRound) SlackAttachment() slack.Attachment {
-	var color string
-	switch r.syncState.State {
-	case RoundPending:
-		color = "#9C9494"
-	case RoundOpening:
-		color = "#6FCF97"
-	case RoundReady:
-		color = "#56CCF2"
-	case RoundClosing:
-		color = "#F2994A"
-	case RoundClosed:
-		color = "#B10202"
-	default:
-		color = "#9C9494"
-	}
 	title := fmt.Sprintf("Arbitrage Round %s (%s)", r.SpotSymbol(), r.syncState.State)
 	fields := []slack.AttachmentField{
 		{
@@ -323,9 +308,28 @@ func (r *ArbitrageRound) SlackAttachment() slack.Attachment {
 
 	return slack.Attachment{
 		Title:  title,
-		Color:  color,
+		Color:  r.stateColor(),
 		Fields: fields,
 	}
+}
+
+func (r *ArbitrageRound) stateColor() string {
+	var color string
+	switch r.syncState.State {
+	case RoundPending:
+		color = "#9C9494"
+	case RoundOpening:
+		color = "#6FCF97"
+	case RoundReady:
+		color = "#56CCF2"
+	case RoundClosing:
+		color = "#F2994A"
+	case RoundClosed:
+		color = "#B10202"
+	default:
+		color = "#9C9494"
+	}
+	return color
 }
 
 func (r *ArbitrageRound) TotalFundingIncome() fixedpoint.Value {

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 
 	"github.com/c9s/bbgo/pkg/bbgo"
 	"github.com/c9s/bbgo/pkg/exchange/batch"
@@ -242,6 +243,89 @@ func (r *ArbitrageRound) String() string {
 		r.syncState.ClosingTime.Format(time.RFC3339),
 		r.syncState.ClosingTime.Add(r.syncState.ClosingDuration).Format(time.RFC3339),
 	)
+}
+
+func (r *ArbitrageRound) SlackAttachment() slack.Attachment {
+	var color string
+	switch r.syncState.State {
+	case RoundPending:
+		color = "#9C9494"
+	case RoundOpening:
+		color = "#6FCF97"
+	case RoundReady:
+		color = "#56CCF2"
+	case RoundClosing:
+		color = "#F2994A"
+	case RoundClosed:
+		color = "#B10202"
+	default:
+		color = "#9C9494"
+	}
+	title := fmt.Sprintf("Arbitrage Round %s (%s)", r.SpotSymbol(), r.syncState.State)
+	fields := []slack.AttachmentField{
+		{
+			Title: "Target Spot Position",
+			Value: r.syncState.TriggeredSpotTargetPosition.String(),
+			Short: true,
+		},
+		{
+			Title: "Funding Interval in Hours",
+			Value: fmt.Sprintf("%d", r.syncState.FundingIntervalHours),
+			Short: true,
+		},
+		{
+			Title: "Triggered Funding Rate",
+			Value: r.syncState.TriggeredFundingRate.Percentage(),
+			Short: true,
+		},
+		{
+			Title: "Annualized Funding Rate",
+			Value: r.AnnualizedRate().Percentage(),
+			Short: true,
+		},
+	}
+	if r.State() == RoundClosing {
+		fields = append(fields,
+			slack.AttachmentField{
+				Title: "Closing Time",
+				Value: r.syncState.ClosingTime.Format(time.RFC3339),
+				Short: true,
+			},
+			slack.AttachmentField{
+				Title: "Expected Close Time",
+				Value: r.syncState.ClosingTime.Add(r.syncState.ClosingDuration).Format(time.RFC3339),
+				Short: true,
+			})
+	} else if r.HasStarted() {
+		fields = append(fields,
+			slack.AttachmentField{
+				Title: "Start Time",
+				Value: r.syncState.StartTime.Format(time.RFC3339),
+				Short: true,
+			},
+			slack.AttachmentField{
+				Title: "Min Holding Intervals",
+				Value: fmt.Sprintf("%d", r.syncState.MinHoldingIntervals),
+				Short: true,
+			})
+	}
+	fields = append(fields,
+		slack.AttachmentField{
+			Title: "Funding Interval Start",
+			Value: r.syncState.FundingIntervalStart.Format(time.RFC3339),
+			Short: true,
+		},
+		slack.AttachmentField{
+			Title: "Funding Interval End",
+			Value: r.syncState.FundingIntervalEnd.Format(time.RFC3339),
+			Short: true,
+		})
+
+	return slack.Attachment{
+		Title:  title,
+		Color:  color,
+		Fields: fields,
+	}
 }
 
 func (r *ArbitrageRound) TotalFundingIncome() fixedpoint.Value {

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -350,11 +350,11 @@ func (r *ArbitrageRound) totalFundingIncome() fixedpoint.Value {
 	return totalFunding
 }
 
-func (r *ArbitrageRound) SyncFundingFeeRecords(ctx context.Context, currentTime time.Time) {
+func (r *ArbitrageRound) SyncFundingFeeRecords(ctx context.Context, currentTime time.Time) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.syncFundingFeeRecords(ctx, currentTime)
+	return r.syncFundingFeeRecords(ctx, currentTime)
 }
 
 func (r *ArbitrageRound) Orders() map[string][]types.Order {
@@ -395,9 +395,9 @@ func (r *ArbitrageRound) hasOrder(orderID uint64) bool {
 	return spotExists || futuresExists
 }
 
-func (r *ArbitrageRound) syncFundingFeeRecords(ctx context.Context, currentTime time.Time) {
+func (r *ArbitrageRound) syncFundingFeeRecords(ctx context.Context, currentTime time.Time) error {
 	if r.syncState.StartTime.IsZero() || r.syncState.StartTime.After(currentTime) {
-		return
+		return nil
 	}
 
 	q := batch.BinanceFuturesIncomeBatchQuery{
@@ -408,11 +408,11 @@ func (r *ArbitrageRound) syncFundingFeeRecords(ctx context.Context, currentTime 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 
 		case income, ok := <-dataC:
 			if !ok {
-				return
+				return nil
 			}
 			switch income.IncomeType {
 			case binanceapi.FuturesIncomeFundingFee:
@@ -426,11 +426,11 @@ func (r *ArbitrageRound) syncFundingFeeRecords(ctx context.Context, currentTime 
 			}
 		case err, ok := <-errC:
 			if !ok {
-				return
+				return nil
 			}
 
 			r.logger.WithError(err).Errorf("unable to query futures income history")
-			return
+			return err
 
 		}
 	}

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -507,12 +507,10 @@ func (r *ArbitrageRound) HandleSpotTrade(trade types.Trade, currentTime time.Tim
 }
 
 func (r *ArbitrageRound) handleSpotTrade(trade types.Trade, currentTime time.Time) {
-	if trade.IsFutures || !r.hasOrder(trade.OrderID) {
+	if ok := r.spotWorker.AddTrade(trade); !ok {
 		return
 	}
-
 	r.logger.Infof("handling spot trade: %s", trade)
-	r.spotWorker.AddTrade(trade)
 	// no matter the transfer succeeds or not, we should update the futures position so that we can stay in delta-neutral
 	r.syncFuturesPosition(trade)
 
@@ -551,11 +549,9 @@ func (r *ArbitrageRound) HandleFuturesTrade(trade types.Trade, currentTime time.
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if !trade.IsFutures || !r.hasOrder(trade.OrderID) {
-		return
+	if ok := r.futuresWorker.AddTrade(trade); ok {
+		r.logger.Infof("handling future trade: %s", trade)
 	}
-	r.logger.Infof("handling future trade: %s", trade)
-	r.futuresWorker.AddTrade(trade)
 }
 
 func (r *ArbitrageRound) SetLogger(logger logrus.FieldLogger) {

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -11,6 +11,7 @@ import (
 	"github.com/c9s/bbgo/pkg/bbgo"
 	"github.com/c9s/bbgo/pkg/exchange/batch"
 	"github.com/c9s/bbgo/pkg/exchange/binance/binanceapi"
+	"github.com/c9s/bbgo/pkg/exchange/retry"
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
 )
@@ -28,10 +29,10 @@ const (
 
 type FuturesService interface {
 	batch.BinanceFuturesIncomeHistoryService
-	types.ExchangeRiskService
 
 	TransferFuturesAccountAsset(ctx context.Context, asset string, amount fixedpoint.Value, io types.TransferDirection) error
 	QueryPremiumIndex(ctx context.Context, symbol string) (*types.PremiumIndex, error)
+	QueryPositionRisk(ctx context.Context, symbol ...string) ([]types.PositionRisk, error)
 }
 
 type transferRetry struct {
@@ -512,6 +513,55 @@ func (r *ArbitrageRound) SetClosing(currentTime time.Time, duration time.Duratio
 	r.syncState.State = RoundClosing
 	r.syncState.ClosingTime = currentTime
 	r.syncState.ClosingDuration = duration
+}
+
+func (r *ArbitrageRound) Cleanup(ctx context.Context, orderBook types.OrderBook) error {
+	if r.syncState.State != RoundClosed {
+		return fmt.Errorf("round is not closed yet: %s", r)
+	}
+	w := r.futuresWorker
+	remaining := w.RemainingQuantity()
+	if remaining.IsZero() {
+		return nil
+	}
+
+	midPrice := getMidPrice(orderBook)
+	market := w.Market()
+	if market.IsDustQuantity(remaining.Abs(), midPrice) {
+		// if the remaining is dust, we adjust it to a much larger amount
+		// With `ReduceOnly` flag, theoretically it will reduce the position to zero without creating new position.
+		remaining = market.MinNotional.Mul(fixedpoint.Two).Div(midPrice).Round(0, fixedpoint.Up)
+	}
+
+	orderOptions := TWAPExecuteOrderOptions{
+		DeadlineExceeded: true,
+		ReduceOnly:       true,
+	}
+	createdOrder, err := w.Executor().PlaceOrder(
+		remaining.Abs(),
+		orderSide(remaining),
+		orderBook,
+		orderOptions,
+	)
+	if err != nil || createdOrder == nil {
+		return fmt.Errorf("[CloseFuturesPosition] failed to place order to close remaining quantity: %w", err)
+	}
+	// collect trades for this closing order
+	exchange := w.syncState.TWAPExecutor.exchange
+	timedCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	if _, err := retry.QueryOrderTradesUntilSuccessfulLite(timedCtx, exchange, createdOrder.AsQuery()); err != nil {
+		return fmt.Errorf("[CloseFuturesPosition] failed to wait for closing order trades: %w", err)
+	}
+	risks, err := r.futuresService.QueryPositionRisk(timedCtx, r.FuturesSymbol())
+	if err != nil || len(risks) == 0 {
+		return fmt.Errorf("[CloseFuturesPosition] failed to query position risk after closing order filled: %w", err)
+	}
+	risk := risks[0]
+	if !risk.PositionAmount.IsZero() {
+		return fmt.Errorf("[CloseFuturesPosition] position is not fully closed after closing order filled, remaining position: %s %s", risk.PositionAmount, risk.Symbol)
+	}
+	return nil
 }
 
 func (r *ArbitrageRound) AnnualizedRate() fixedpoint.Value {

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -656,41 +656,6 @@ func (r *ArbitrageRound) Tick(currentTime time.Time, spotOrderBook types.OrderBo
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	defer func() {
-		// get mid price
-		spotMidPrice := getMidPrice(spotOrderBook)
-		futuresMidPrice := getMidPrice(futuresOrderBook)
-
-		// the state is PositionOpening
-		// check if the spot and futures positions are fully filled -> PositionReady
-		if r.syncState.State == RoundOpening {
-			spotRemaining := r.spotWorker.RemainingQuantity()
-			futuresRemaining := r.futuresWorker.RemainingQuantity()
-			spotIsDust := r.spotWorker.Market().IsDustQuantity(spotRemaining.Abs(), spotMidPrice)
-			futuresIsDust := r.futuresWorker.Market().IsDustQuantity(futuresRemaining.Abs(), futuresMidPrice)
-
-			if spotIsDust && futuresIsDust {
-				r.syncState.State = RoundReady
-				return
-			}
-		}
-
-		// the state is PositionClosing
-		// check if the spot and futures positions are fully closed -> PositionClosed
-		if r.syncState.State == RoundClosing {
-			spotFilled := r.spotWorker.FilledPosition()
-			futuresFilled := r.futuresWorker.FilledPosition()
-			spotIsDust := r.spotWorker.Market().IsDustQuantity(spotFilled.Abs(), spotMidPrice)
-			futuresIsDust := r.futuresWorker.Market().IsDustQuantity(futuresFilled.Abs(), futuresMidPrice)
-
-			if spotIsDust && futuresIsDust {
-				r.syncState.State = RoundClosed
-				r.logger.Infof("positions closed, arbitrage round completed: %s", r.spotWorker.Symbol())
-			}
-			return
-		}
-	}()
-
 	if r.syncState.State == RoundPending {
 		// not started yet, do nothing
 		return
@@ -716,6 +681,39 @@ func (r *ArbitrageRound) Tick(currentTime time.Time, spotOrderBook types.OrderBo
 	// it's opening or closing, tick the workers
 	r.spotWorker.Tick(currentTime, spotOrderBook)
 	r.futuresWorker.Tick(currentTime, futuresOrderBook)
+
+	// get mid price
+	spotMidPrice := getMidPrice(spotOrderBook)
+	futuresMidPrice := getMidPrice(futuresOrderBook)
+
+	// the state is PositionOpening
+	// check if the spot and futures positions are fully filled -> PositionReady
+	if r.syncState.State == RoundOpening {
+		spotRemaining := r.spotWorker.RemainingQuantity()
+		futuresRemaining := r.futuresWorker.RemainingQuantity()
+		spotIsDust := r.spotWorker.Market().IsDustQuantity(spotRemaining.Abs(), spotMidPrice)
+		futuresIsDust := r.futuresWorker.Market().IsDustQuantity(futuresRemaining.Abs(), futuresMidPrice)
+
+		if spotIsDust && futuresIsDust {
+			r.syncState.State = RoundReady
+			return
+		}
+	}
+
+	// the state is PositionClosing
+	// check if the spot and futures positions are fully closed -> PositionClosed
+	if r.syncState.State == RoundClosing {
+		spotFilled := r.spotWorker.FilledPosition()
+		futuresFilled := r.futuresWorker.FilledPosition()
+		spotIsDust := r.spotWorker.Market().IsDustQuantity(spotFilled.Abs(), spotMidPrice)
+		futuresIsDust := r.futuresWorker.Market().IsDustQuantity(futuresFilled.Abs(), futuresMidPrice)
+
+		if spotIsDust && futuresIsDust {
+			r.syncState.State = RoundClosed
+			r.logger.Infof("positions closed, arbitrage round completed: %s", r.spotWorker.Symbol())
+		}
+		return
+	}
 }
 
 func (r *ArbitrageRound) syncFuturesPosition(trade types.Trade) {

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -28,6 +28,7 @@ const (
 
 type FuturesService interface {
 	batch.BinanceFuturesIncomeHistoryService
+	types.ExchangeRiskService
 
 	TransferFuturesAccountAsset(ctx context.Context, asset string, amount fixedpoint.Value, io types.TransferDirection) error
 	QueryPremiumIndex(ctx context.Context, symbol string) (*types.PremiumIndex, error)
@@ -523,12 +524,8 @@ func (r *ArbitrageRound) Tick(currentTime time.Time, spotOrderBook types.OrderBo
 
 	defer func() {
 		// get mid price
-		spotBid, _ := spotOrderBook.BestBid()
-		spotAsk, _ := spotOrderBook.BestAsk()
-		futuresBid, _ := futuresOrderBook.BestBid()
-		futuresAsk, _ := futuresOrderBook.BestAsk()
-		spotMidPrice := spotBid.Price.Add(spotAsk.Price).Div(fixedpoint.Two)
-		futuresMidPrice := futuresBid.Price.Add(futuresAsk.Price).Div(fixedpoint.Two)
+		spotMidPrice := getMidPrice(spotOrderBook)
+		futuresMidPrice := getMidPrice(futuresOrderBook)
 
 		// the state is PositionOpening
 		// check if the spot and futures positions are fully filled -> PositionReady

--- a/pkg/strategy/xfundingv2/arb_round_fee.go
+++ b/pkg/strategy/xfundingv2/arb_round_fee.go
@@ -16,10 +16,6 @@ type PendingRound struct {
 	LastRetryTime time.Time       `json:"lastRetryTime"`
 }
 
-func (r *PendingRound) Initialize(ctx context.Context, s *Strategy) error {
-	return r.Round.Initialize(ctx, s)
-}
-
 func (s *Strategy) processPendingRounds(ctx context.Context, currentTime time.Time) {
 	var pendingRounds []*PendingRound
 	for _, pendingRound := range s.pendingRounds {

--- a/pkg/strategy/xfundingv2/arb_round_pnl.go
+++ b/pkg/strategy/xfundingv2/arb_round_pnl.go
@@ -1,9 +1,7 @@
 package xfundingv2
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/style"
@@ -37,7 +35,7 @@ func (p *RoundPnL) SlackAttachment() slack.Attachment {
 		},
 	}
 }
-func (r *ArbitrageRound) PnL(ctx context.Context, currentTime time.Time) RoundPnL {
+func (r *ArbitrageRound) PnL() RoundPnL {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/pkg/strategy/xfundingv2/arb_round_pnl_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_pnl_test.go
@@ -1,7 +1,6 @@
 package xfundingv2
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -17,13 +16,11 @@ func TestArbitrageRound_TradePnL(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	ctx := context.Background()
-	currentTime := time.Date(2024, 1, 2, 12, 0, 0, 0, time.UTC)
 	nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
 	round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
 
 	t.Run("returns zero profit stats when no trades", func(t *testing.T) {
-		pnl := round.PnL(ctx, currentTime)
+		pnl := round.PnL()
 		assert.Equal(t, fixedpoint.Zero, pnl.SpotProfitStats.AccumulatedPnL)
 		assert.Equal(t, fixedpoint.Zero, pnl.SpotProfitStats.AccumulatedNetProfit)
 		assert.Equal(t, fixedpoint.Zero, pnl.FuturesProfitStats.AccumulatedPnL)
@@ -67,7 +64,7 @@ func TestArbitrageRound_TradePnL(t *testing.T) {
 		})
 
 		// Only opening trades — no realized profit yet
-		pnl := round.PnL(ctx, currentTime)
+		pnl := round.PnL()
 		assert.Equal(t, fixedpoint.Zero, pnl.SpotProfitStats.AccumulatedPnL)
 		assert.Equal(t, fixedpoint.Zero, pnl.FuturesProfitStats.AccumulatedPnL)
 	})
@@ -107,7 +104,7 @@ func TestArbitrageRound_TradePnL(t *testing.T) {
 			Time:          types.Time(time.Date(2024, 1, 2, 1, 0, 0, 0, time.UTC)),
 		})
 
-		pnl := round.PnL(ctx, currentTime)
+		pnl := round.PnL()
 
 		// Spot: bought 1 BTC at 40000 with 0.001 BTC fee → effective qty = 0.999
 		// Sold 1 BTC at 41000, fee 10 USDT

--- a/pkg/strategy/xfundingv2/arb_round_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_test.go
@@ -2,6 +2,8 @@ package xfundingv2
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,15 +19,34 @@ import (
 
 // mockFuturesService implements FuturesService for testing
 type mockFuturesService struct {
+	mu sync.Mutex
+
 	incomeHistory []binanceapi.FuturesIncome
+	incomeErr     error
 	transferErr   error
+}
+
+func (m *mockFuturesService) ResetIncomeError() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.incomeErr = nil
+}
+
+func (m *mockFuturesService) SetIncomeError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.incomeErr = err
 }
 
 func (m *mockFuturesService) QueryFuturesIncomeHistory(
 	ctx context.Context, symbol string, incomeType binanceapi.FuturesIncomeType,
 	startTime, endTime *time.Time,
 ) ([]binanceapi.FuturesIncome, error) {
-	return m.incomeHistory, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.incomeHistory, m.incomeErr
 }
 
 func (m *mockFuturesService) TransferFuturesAccountAsset(
@@ -153,7 +174,8 @@ func TestArbitrageRound_TotalFundingIncome(t *testing.T) {
 	t.Run("returns zero when startTime is zero", func(t *testing.T) {
 		ctx := context.Background()
 		currentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
-		round.SyncFundingFeeRecords(ctx, currentTime)
+		err := round.SyncFundingFeeRecords(ctx, currentTime)
+		assert.NoError(t, err)
 		result := round.TotalFundingIncome()
 		assert.Equal(t, fixedpoint.Zero, result)
 	})
@@ -183,7 +205,8 @@ func TestArbitrageRound_TotalFundingIncome(t *testing.T) {
 
 		ctx := context.Background()
 		currentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
-		round.SyncFundingFeeRecords(ctx, currentTime)
+		err := round.SyncFundingFeeRecords(ctx, currentTime)
+		assert.NoError(t, err)
 		result := round.TotalFundingIncome()
 
 		expected := Number(0.005).Add(Number(0.003))
@@ -194,7 +217,8 @@ func TestArbitrageRound_TotalFundingIncome(t *testing.T) {
 		// Call again with same income history - should not double-count
 		ctx := context.Background()
 		currentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
-		round.SyncFundingFeeRecords(ctx, currentTime)
+		err := round.SyncFundingFeeRecords(ctx, currentTime)
+		assert.NoError(t, err)
 		result := round.TotalFundingIncome()
 
 		expected := Number(0.005).Add(Number(0.003))
@@ -214,10 +238,23 @@ func TestArbitrageRound_TotalFundingIncome(t *testing.T) {
 
 		ctx := context.Background()
 		currentTime := time.Date(2024, 1, 2, 8, 0, 0, 0, time.UTC)
-		round.SyncFundingFeeRecords(ctx, currentTime)
+		err := round.SyncFundingFeeRecords(ctx, currentTime)
+		assert.NoError(t, err)
 		result := round.TotalFundingIncome()
 
 		expected := Number(0.005).Add(Number(0.003)).Add(Number(0.002))
 		assert.Equal(t, expected, result)
+	})
+
+	t.Run("returns error when income query fails", func(t *testing.T) {
+		queryErr := errors.New("income history query failed")
+		mockService.SetIncomeError(queryErr)
+		defer mockService.ResetIncomeError()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		currentTime := time.Date(2024, 1, 2, 8, 0, 0, 0, time.UTC)
+		err := round.SyncFundingFeeRecords(ctx, currentTime)
+		assert.Error(t, err)
 	})
 }

--- a/pkg/strategy/xfundingv2/arb_round_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_test.go
@@ -38,6 +38,10 @@ func (m *mockFuturesService) QueryPremiumIndex(ctx context.Context, symbol strin
 	return nil, nil
 }
 
+func (m *mockFuturesService) QueryPositionRisk(ctx context.Context, symbol ...string) ([]types.PositionRisk, error) {
+	return nil, nil
+}
+
 func newTestArbitrageRound(t *testing.T, ctrl *gomock.Controller, fundingIntervalHours, minHoldingIntervals int, nextFundingTime time.Time) (*ArbitrageRound, *mockFuturesService) {
 	config := TWAPWorkerConfig{
 		Duration:  10 * time.Minute,

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1055,7 +1055,9 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 		feeAvgCost := executor.Position().AverageCost
 		round.SetAvgFeeCost(s.FeeSymbol, feeAvgCost)
 	}
-	round.SyncFundingFeeRecords(ctx, tickTime)
+	timedCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	round.SyncFundingFeeRecords(timedCtx, tickTime)
 	bbgo.Notify(round.PnL(ctx, tickTime))
 	// TODO: insert closed round records into database
 	return nil

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -501,7 +501,7 @@ func (s *Strategy) CrossRun(
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
-		for _, round := range s.activeRounds {
+		for _, round := range s.allRounds() {
 			if round.HasOrder(trade.OrderID) {
 				round.HandleSpotTrade(trade, trade.Time.Time())
 			}
@@ -511,7 +511,7 @@ func (s *Strategy) CrossRun(
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
-		for _, round := range s.activeRounds {
+		for _, round := range s.allRounds() {
 			if round.HasOrder(trade.OrderID) {
 				round.HandleFuturesTrade(trade, trade.Time.Time())
 			}
@@ -528,6 +528,20 @@ func (s *Strategy) CrossRun(
 	})
 
 	return nil
+}
+
+func (s *Strategy) allRounds() []*ArbitrageRound {
+	var rounds []*ArbitrageRound
+	for _, round := range s.activeRounds {
+		rounds = append(rounds, round)
+	}
+	for _, pendingRound := range s.pendingRounds {
+		rounds = append(rounds, pendingRound.Round)
+	}
+	for _, closedRound := range s.closedRounds {
+		rounds = append(rounds, closedRound.Round)
+	}
+	return rounds
 }
 
 func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1058,7 +1058,7 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 	timedCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	round.SyncFundingFeeRecords(timedCtx, tickTime)
-	bbgo.Notify(round.PnL(ctx, tickTime))
+	bbgo.Notify(round.PnL())
 	// TODO: insert closed round records into database
 	return nil
 }

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -259,15 +259,15 @@ func (s *Strategy) CrossRun(
 	}
 	// if there is any open position, it should have a corresponding active round which is loaded via LoadState.
 	// Otherwise, it is a mismatch and should raise an error to stop the strategy from running.
-	var misMatchSymbols []string
+	var mismatchSymbols []string
 	for _, risk := range risks {
 		_, found := s.activeRounds[risk.Symbol]
 		if !risk.PositionAmount.IsZero() && !found {
-			misMatchSymbols = append(misMatchSymbols, risk.Symbol)
+			mismatchSymbols = append(mismatchSymbols, risk.Symbol)
 		}
 	}
-	if len(misMatchSymbols) > 0 {
-		return fmt.Errorf("found open positions without active rounds: %v on %s", misMatchSymbols, s.futuresSession.Exchange.Name())
+	if len(mismatchSymbols) > 0 {
+		return fmt.Errorf("found open positions without active rounds: %v on %s", mismatchSymbols, s.futuresSession.Exchange.Name())
 	}
 
 	// initialize cost estimator
@@ -549,17 +549,18 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 
 	// enque closed active rounds
 	for _, round := range s.activeRounds {
-		if round.State() == RoundClosed {
-			s.logger.Infof("move round to closed queue: %s", round)
-			// stop the round
-			round.Stop()
-			// remove from active round queue
-			delete(s.activeRounds, round.SpotSymbol())
-			// add to closed round queue for cleanup
-			s.closedRounds[round.SpotSymbol()] = &CloseRoundTask{
-				Round:    round,
-				RetryCnt: 0,
-			}
+		if round.State() != RoundClosed {
+			continue
+		}
+		s.logger.Infof("move round to closed queue: %s", round)
+		// stop the round
+		round.Stop()
+		// remove from active round queue
+		delete(s.activeRounds, round.SpotSymbol())
+		// add to closed round queue for cleanup
+		s.closedRounds[round.SpotSymbol()] = &CloseRoundTask{
+			Round:    round,
+			RetryCnt: 0,
 		}
 	}
 

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -578,6 +578,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		}
 	}
 
+	closeRoundCtx, cancelCloseRound := context.WithTimeout(ctx, 15*time.Second)
 	for _, closedRound := range s.closedRounds {
 		if closedRound.RetryCnt >= s.MaxClosedRetryCnt {
 			if !closedRound.Notified {
@@ -588,13 +589,15 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 			}
 			continue
 		}
-		if err := s.handleClosedRound(ctx, closedRound, tickTime); err != nil {
+
+		if err := s.handleClosedRound(closeRoundCtx, closedRound, tickTime); err != nil {
 			closedRound.RetryCnt++
 		} else {
 			s.logger.Infof("successfully handled closed round: %s", closedRound.Round)
 			delete(s.closedRounds, closedRound.Round.SpotSymbol())
 		}
 	}
+	cancelCloseRound()
 
 	// 2. check if new round can be opened or existing round needs to be adjusted
 	s.checkOpenNewRound(ctx, tickTime)
@@ -1069,9 +1072,7 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 		feeAvgCost := executor.Position().AverageCost
 		round.SetAvgFeeCost(s.FeeSymbol, feeAvgCost)
 	}
-	timedCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	round.SyncFundingFeeRecords(timedCtx, tickTime)
+	round.SyncFundingFeeRecords(ctx, tickTime)
 	bbgo.Notify(round.PnL())
 	// TODO: insert closed round records into database
 	return nil

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -24,6 +24,10 @@ func init() {
 	bbgo.RegisterStrategy(ID, &Strategy{})
 }
 
+type CriticalErrorConfig struct {
+	MaxRemainingNotional fixedpoint.Value `json:"maxRemainingNotional"`
+}
+
 type Strategy struct {
 	Environment *bbgo.Environment
 
@@ -54,8 +58,9 @@ type Strategy struct {
 	MarketSelectionConfig *MarketSelectionConfig      `json:"marketSelection,omitempty"`
 	MaxPositionExposure   map[string]fixedpoint.Value `json:"maxPositionExposure"`
 
-	CheckInterval       time.Duration `json:"checkInterval"`
-	ClosePositionOnExit bool          `json:"closePositionOnExit"`
+	CheckInterval       time.Duration       `json:"checkInterval"`
+	ClosePositionOnExit bool                `json:"closePositionOnExit"`
+	CriticalErrorConfig CriticalErrorConfig `json:"criticalErrorConfig"`
 
 	spotSession, futuresSession *bbgo.ExchangeSession
 	futuresService              FuturesService
@@ -73,6 +78,11 @@ type Strategy struct {
 	// pending rounds and active rounds
 	pendingRounds map[string]*PendingRound   `persistence:"pendingRounds"`
 	activeRounds  map[string]*ArbitrageRound `persistence:"activeRounds"`
+
+	// closed rounds that are waiting for cleanup
+	MaxClosedRetryCnt int                        `json:"maxClosedRetryCnt"`
+	closedRounds      map[string]*CloseRoundTask `persistence:"closedRounds"`
+
 	// the positions are shared across rounds and the executors of the same symbol.
 	spotPositions    map[string]*types.Position `persistence:"spotPositions,omitempty"`
 	futuresPositions map[string]*types.Position `persistence:"futuresPositions,omitempty"`
@@ -154,6 +164,7 @@ func (s *Strategy) Initialize() error {
 	if s.MaxPositionExposure == nil {
 		s.MaxPositionExposure = make(map[string]fixedpoint.Value)
 	}
+	s.MaxClosedRetryCnt = 3
 	return nil
 }
 
@@ -204,6 +215,9 @@ func (s *Strategy) CrossRun(
 	if s.pendingRounds == nil {
 		s.pendingRounds = make(map[string]*PendingRound)
 	}
+	if s.closedRounds == nil {
+		s.closedRounds = make(map[string]*CloseRoundTask)
+	}
 
 	s.spotSession = sessions[s.SpotSession]
 	s.futuresSession = sessions[s.FuturesSession]
@@ -231,6 +245,28 @@ func (s *Strategy) CrossRun(
 	}
 	if _, ok := s.futuresSession.Exchange.(types.ExchangeOrderQueryService); !ok {
 		return fmt.Errorf("futures session exchange does not support order query service: %s", s.futuresSession.ExchangeName)
+	}
+
+	// remaining open position check
+	risks, err := s.futuresService.QueryPositionRisk(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to query position risk from futures session exchange: %w", err)
+	}
+	risksMap := make(map[string]types.PositionRisk)
+	for _, risk := range risks {
+		risksMap[risk.Symbol] = risk
+	}
+	// if there is any open position, it should have a corresponding active round which is loaded via LoadState.
+	// Otherwise, it is a mismatch and should raise an error to stop the strategy from running.
+	var misMatchSymbols []string
+	for _, risk := range risks {
+		_, found := s.activeRounds[risk.Symbol]
+		if !risk.PositionAmount.IsZero() && !found {
+			misMatchSymbols = append(misMatchSymbols, risk.Symbol)
+		}
+	}
+	if len(misMatchSymbols) > 0 {
+		return fmt.Errorf("found open positions without active rounds: %v on %s", misMatchSymbols, s.futuresSession.Exchange.Name())
 	}
 
 	// initialize cost estimator
@@ -262,7 +298,6 @@ func (s *Strategy) CrossRun(
 	// NOTE: the executors should be created first before anything else to ensure the executors get updated first.
 	// The twap executors rely on the state of the general order executors to determine the filled quantity.
 	s.candidateSymbols = candidateSymbols
-	candidateSymbolsMap := make(map[string]struct{})
 	setupGeneralExecutorsForSymbol := func(symbol string) error {
 		spotMarket, found := s.spotSession.Market(symbol)
 		if !found {
@@ -304,6 +339,11 @@ func (s *Strategy) CrossRun(
 		)
 		spotExecutor.DisableNotify()
 		spotExecutor.Bind()
+		if openOrders, err := s.spotSession.Exchange.QueryOpenOrders(ctx, symbol); err != nil {
+			return fmt.Errorf("failed to query open orders for spot symbol %s: %w", symbol, err)
+		} else if len(openOrders) > 0 {
+			spotExecutor.ActiveMakerOrders().Add(openOrders...)
+		}
 		s.spotGeneralOrderExecutors[symbol] = spotExecutor
 		futuresExecutor := bbgo.NewGeneralOrderExecutor(
 			s.futuresSession,
@@ -312,13 +352,17 @@ func (s *Strategy) CrossRun(
 			s.InstanceID(),
 			futuresPosition,
 		)
+		if openOrders, err := s.futuresSession.Exchange.QueryOpenOrders(ctx, symbol); err != nil {
+			return fmt.Errorf("failed to query open orders for futures symbol %s: %w", symbol, err)
+		} else if len(openOrders) > 0 {
+			futuresExecutor.ActiveMakerOrders().Add(openOrders...)
+		}
 		futuresExecutor.DisableNotify()
 		futuresExecutor.Bind()
 		s.futuresGeneralOrderExecutors[symbol] = futuresExecutor
 		return nil
 	}
 	for _, symbol := range candidateSymbols {
-		candidateSymbolsMap[symbol] = struct{}{}
 		if err := setupGeneralExecutorsForSymbol(symbol); err != nil {
 			return err
 		}
@@ -388,32 +432,52 @@ func (s *Strategy) CrossRun(
 	// runtime init done, load pending and active rounds
 	for symbol, pendingRound := range s.pendingRounds {
 		// setup order executors
-		if _, found := candidateSymbolsMap[symbol]; !found {
+		if _, found := s.spotGeneralOrderExecutors[symbol]; !found {
 			if err := setupGeneralExecutorsForSymbol(symbol); err != nil {
 				return fmt.Errorf("failed to setup order executors for pending round symbol %s: %w", symbol, err)
 			}
 		}
 		// setup stream books for the symbols
-		if _, found := candidateSymbolsMap[symbol]; !found {
+		if _, found := s.spotOrderBooks[symbol]; !found {
 			setupStreamBooksForSymbol(symbol)
 		}
-		if err := pendingRound.Initialize(ctx, s); err != nil {
+		if err := pendingRound.Round.Initialize(ctx, s); err != nil {
 			return fmt.Errorf("failed to restore pending round (%s): %w", symbol, err)
 		}
 	}
 	for symbol, activeRound := range s.activeRounds {
 		// setup order executors
-		if _, found := candidateSymbolsMap[symbol]; !found {
+		if _, found := s.spotGeneralOrderExecutors[symbol]; !found {
 			if err := setupGeneralExecutorsForSymbol(symbol); err != nil {
 				return fmt.Errorf("failed to setup order executors for active round symbol %s: %w", symbol, err)
 			}
 		}
 		// setup stream books for the symbols
-		if _, found := candidateSymbolsMap[symbol]; !found {
+		if _, found := s.spotOrderBooks[symbol]; !found {
 			setupStreamBooksForSymbol(symbol)
 		}
 		if err := activeRound.Initialize(ctx, s); err != nil {
 			return fmt.Errorf("failed to restore active round (%s): %w", symbol, err)
+		}
+	}
+	for symbol, closedRound := range s.closedRounds {
+		// setup order executors
+		if _, found := s.spotGeneralOrderExecutors[symbol]; !found {
+			if err := setupGeneralExecutorsForSymbol(symbol); err != nil {
+				return fmt.Errorf("failed to setup order executors for active round symbol %s: %w", symbol, err)
+			}
+		}
+		// setup stream books for the symbols
+		if _, found := s.spotOrderBooks[symbol]; !found {
+			setupStreamBooksForSymbol(symbol)
+		}
+		if err := closedRound.Round.Initialize(ctx, s); err != nil {
+			return fmt.Errorf("failed to restore active round (%s): %w", symbol, err)
+		}
+		// give the restored closed round one more chance to be processed.
+		if closedRound.RetryCnt >= s.MaxClosedRetryCnt {
+			closedRound.RetryCnt--
+			closedRound.Notified = false
 		}
 	}
 
@@ -482,14 +546,37 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		s.transitRoundState(ctx, round, tickTime)
 	}
 
-	// remove closed active rounds
+	// enque closed active rounds
 	for _, round := range s.activeRounds {
 		if round.State() == RoundClosed {
-			s.logger.Infof("removing closed round: %s", round)
+			s.logger.Infof("move round to closed queue: %s", round)
+			// stop the round
+			round.Stop()
+			// remove from active round queue
 			delete(s.activeRounds, round.SpotSymbol())
-			// TODO: implement a dedicated worker to handle the post-round processing
-			// So that we can prevent blocking the main ticking loop too long when there are multiple rounds get closed.
-			s.handleClosedRound(ctx, round, tickTime)
+			// add to closed round queue for cleanup
+			s.closedRounds[round.SpotSymbol()] = &CloseRoundTask{
+				Round:    round,
+				RetryCnt: 0,
+			}
+		}
+	}
+
+	for _, closedRound := range s.closedRounds {
+		if closedRound.RetryCnt >= s.MaxClosedRetryCnt {
+			if !closedRound.Notified {
+				// send notification for rounds that failed to pass the cleanup process for 3 times.
+				// the symbol of the round will be blocked for opening new round until the issue is resolved.
+				closedRound.Notified = true
+				bbgo.Notify(closedRound)
+			}
+			continue
+		}
+		if err := s.handleClosedRound(ctx, closedRound.Round, tickTime); err != nil {
+			closedRound.RetryCnt++
+		} else {
+			s.logger.Infof("successfully handled closed round: %s", closedRound.Round)
+			delete(s.closedRounds, closedRound.Round.SpotSymbol())
 		}
 	}
 
@@ -635,9 +722,7 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 			// no profitable candidate found, nothing to do
 			return
 		}
-		_, pending := s.pendingRounds[selectedCandidate.Symbol]
-		_, active := s.activeRounds[selectedCandidate.Symbol]
-		if pending || active {
+		if !s.canOpenRound(selectedCandidate.Symbol) {
 			// already has pending or active round for the symbol, skip
 			return
 		}
@@ -889,9 +974,48 @@ func (s *Strategy) calculateMinHoldingIntervals(candidate MarketCandidate, bestP
 	return breakEvenIntervals, nil
 }
 
-func (s *Strategy) handleClosedRound(ctx context.Context, round *ArbitrageRound, tickTime time.Time) {
-	// stop the round
-	round.Stop()
+type CloseRoundTask struct {
+	Round    *ArbitrageRound `json:"round"`
+	RetryCnt int             `json:"retry_cnt"`
+	Notified bool            `json:"notified"`
+}
+
+func (s *Strategy) handleClosedRound(ctx context.Context, round *ArbitrageRound, tickTime time.Time) error {
+	futuresOrderbook := s.futuresOrderBooks[round.FuturesSymbol()].Copy()
+	futuresMidPrice := getMidPrice(futuresOrderbook)
+	// if the remaining quantity is too large, return an critical error and do not remove the round from active rounds, to prevent creating new round on the same symbol
+	remainingNotional := round.FuturesWorker().RemainingQuantity().Mul(futuresMidPrice)
+	if remainingNotional.Abs().Compare(s.CriticalErrorConfig.MaxRemainingNotional) >= 0 {
+		msg := fmt.Sprintf(
+			"[handleClosedRound] remaining notional %s > %s: %s",
+			remainingNotional,
+			s.CriticalErrorConfig.MaxRemainingNotional,
+			round,
+		)
+		bbgo.Notify(msg)
+		return errors.New(msg)
+	}
+
+	// clean up open orders if there is any
+	if err := round.SpotWorker().Executor().CancelOpenOrders(ctx); err != nil {
+		return fmt.Errorf(
+			"[handleClosedRound] failed to cancel open spot orders for %s: %w",
+			round.SpotSymbol(),
+			err,
+		)
+	}
+	if err := round.FuturesWorker().Executor().CancelOpenOrders(ctx); err != nil {
+		return fmt.Errorf(
+			"[handleClosedRound] failed to cancel open futures orders for %s: %w",
+			round.FuturesSymbol(),
+			err,
+		)
+	}
+
+	// close futures positions if there is any
+	if err := round.Cleanup(ctx, futuresOrderbook); err != nil {
+		return fmt.Errorf("[handleClosedRound] failed to close remaining positions for the futures: %w", err)
+	}
 
 	// transfer asset back to spot account
 	var asset string
@@ -906,47 +1030,30 @@ func (s *Strategy) handleClosedRound(ctx context.Context, round *ArbitrageRound,
 	account := s.futuresSession.GetAccount()
 	balance, ok := account.Balance(asset)
 	if !ok {
-		s.logger.Warnf("balance not found for asset %s when handling round exit: %s", asset, round)
+		return fmt.Errorf("[handleClosedRound] balance not found for asset %s when handling round exit: %s", asset, round)
 	} else if balance.Available.Sign() > 0 {
 		// transfer the remaining balance back to spot account if there is any
 		if err := s.futuresService.TransferFuturesAccountAsset(ctx, asset, balance.Available, types.TransferOut); err != nil {
-			s.logger.WithError(err).Errorf("failed to transfer %s during round exit: %s", asset, round)
+			return fmt.Errorf("[handleClosedRound] failed to transfer %s %s during round exit: %w", balance.Available, asset, err)
 		} else {
-			s.logger.Infof("transferred out %s during round exit: %s", asset, round)
+			s.logger.Infof("[handleClosedRound] transferred out %s %s success: %s", balance.Available, asset, round)
 		}
 	}
 
+	// PnL calculation and record keeping
 	if executor, ok := s.spotGeneralOrderExecutors[s.FeeSymbol]; ok {
 		feeAvgCost := executor.Position().AverageCost
 		round.SetAvgFeeCost(s.FeeSymbol, feeAvgCost)
 	}
-	// clean up open orders if there is any
-	var spotOpenOrders, futuresOpenOrders []types.Order
-	for _, order := range round.SpotWorker().Executor().OpenOrders() {
-		spotOpenOrders = append(spotOpenOrders, order)
-	}
-	for _, order := range round.FuturesWorker().Executor().OpenOrders() {
-		futuresOpenOrders = append(futuresOpenOrders, order)
-	}
-	if len(spotOpenOrders) > 0 {
-		err := s.spotSession.Exchange.CancelOrders(ctx, spotOpenOrders...)
-		if err != nil {
-			s.logger.WithError(err).Errorf(
-				"[roundExitWorker] failed to cancel open spot orders: %s",
-				round.SpotSymbol(),
-			)
-		}
-	}
-	if len(futuresOpenOrders) > 0 {
-		err := s.futuresSession.Exchange.CancelOrders(ctx, futuresOpenOrders...)
-		if err != nil {
-			s.logger.WithError(err).Errorf(
-				"[roundExitWorker] failed to cancel open futures orders: %s",
-				round.FuturesSymbol(),
-			)
-		}
-	}
 	round.SyncFundingFeeRecords(ctx, tickTime)
 	bbgo.Notify(round.PnL(ctx, tickTime))
 	// TODO: insert closed round records into database
+	return nil
+}
+
+func (s *Strategy) canOpenRound(symbol string) bool {
+	_, pending := s.pendingRounds[symbol]
+	_, active := s.activeRounds[symbol]
+	_, closed := s.closedRounds[symbol]
+	return !pending && !active && !closed
 }

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
 	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 	"golang.org/x/time/rate"
 )
 
@@ -572,7 +573,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 			}
 			continue
 		}
-		if err := s.handleClosedRound(ctx, closedRound.Round, tickTime); err != nil {
+		if err := s.handleClosedRound(ctx, closedRound, tickTime); err != nil {
 			closedRound.RetryCnt++
 		} else {
 			s.logger.Infof("successfully handled closed round: %s", closedRound.Round)
@@ -980,20 +981,28 @@ type CloseRoundTask struct {
 	Notified bool            `json:"notified"`
 }
 
-func (s *Strategy) handleClosedRound(ctx context.Context, round *ArbitrageRound, tickTime time.Time) error {
+func (c *CloseRoundTask) SlackAttachment() slack.Attachment {
+	roundAttachment := c.Round.SlackAttachment()
+	return slack.Attachment{
+		Title:  fmt.Sprintf("Round Cleanup Task %s", c.Round.FuturesSymbol()),
+		Color:  roundAttachment.Color,
+		Fields: roundAttachment.Fields,
+	}
+}
+
+func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, tickTime time.Time) error {
+	round := task.Round
 	futuresOrderbook := s.futuresOrderBooks[round.FuturesSymbol()].Copy()
 	futuresMidPrice := getMidPrice(futuresOrderbook)
 	// if the remaining quantity is too large, return an critical error and do not remove the round from active rounds, to prevent creating new round on the same symbol
 	remainingNotional := round.FuturesWorker().RemainingQuantity().Mul(futuresMidPrice)
 	if remainingNotional.Abs().Compare(s.CriticalErrorConfig.MaxRemainingNotional) >= 0 {
-		msg := fmt.Sprintf(
+		return fmt.Errorf(
 			"[handleClosedRound] remaining notional %s > %s: %s",
 			remainingNotional,
 			s.CriticalErrorConfig.MaxRemainingNotional,
 			round,
 		)
-		bbgo.Notify(msg)
-		return errors.New(msg)
 	}
 
 	// clean up open orders if there is any

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1072,7 +1072,9 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 		feeAvgCost := executor.Position().AverageCost
 		round.SetAvgFeeCost(s.FeeSymbol, feeAvgCost)
 	}
-	round.SyncFundingFeeRecords(ctx, tickTime)
+	if err := round.SyncFundingFeeRecords(ctx, tickTime); err != nil {
+		return fmt.Errorf("[handleClosedRound] failed to sync funding fee records for round %s: %w", round, err)
+	}
 	bbgo.Notify(round.PnL())
 	// TODO: insert closed round records into database
 	return nil

--- a/pkg/strategy/xfundingv2/twap.go
+++ b/pkg/strategy/xfundingv2/twap.go
@@ -130,8 +130,8 @@ func (w *TWAPWorker) AveragePrice() fixedpoint.Value {
 }
 
 // AddTrade adds a trade to the worker if it belongs to an order managed by this worker.
-func (w *TWAPWorker) AddTrade(trade types.Trade) {
-	w.syncState.TWAPExecutor.AddTrade(trade)
+func (w *TWAPWorker) AddTrade(trade types.Trade) bool {
+	return w.syncState.TWAPExecutor.AddTrade(trade)
 }
 
 func (w *TWAPWorker) FilledPosition() fixedpoint.Value {

--- a/pkg/strategy/xfundingv2/twap.go
+++ b/pkg/strategy/xfundingv2/twap.go
@@ -317,6 +317,11 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 
 	// check if deadline exceeded
 	deadlineExceeded := !currentTime.Before(w.syncState.EndTime)
+	closing := w.syncState.TargetPosition.IsZero()
+	orderOptions := TWAPExecuteOrderOptions{
+		DeadlineExceeded: deadlineExceeded,
+		ReduceOnly:       closing,
+	}
 	// if deadline exceeded, we want to place a final order for the remaining quantity
 	if deadlineExceeded {
 		if w.syncState.ActiveOrder != nil {
@@ -330,7 +335,7 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 			remaining.Abs(),
 			orderSide(remaining),
 			orderBook,
-			true,
+			orderOptions,
 		)
 		if err != nil || createdOrder == nil {
 			return fmt.Errorf("failed to place final order when deadline exceeded: %w", err)
@@ -343,7 +348,7 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 	// we don't have an active order, place a new one
 	if w.syncState.ActiveOrder == nil {
 		sliceQty := w.calculateSliceQuantity(currentTime, remaining, false)
-		createdOrder, err := w.syncState.TWAPExecutor.PlaceOrder(sliceQty, orderSide(remaining), orderBook, false)
+		createdOrder, err := w.syncState.TWAPExecutor.PlaceOrder(sliceQty, orderSide(remaining), orderBook, orderOptions)
 		if err != nil || createdOrder == nil {
 			return fmt.Errorf("failed to place order: %w", err)
 		}
@@ -369,7 +374,7 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 			w.syncState.ActiveOrder.GetRemainingQuantity(),
 			w.syncState.ActiveOrder.Side,
 			orderBook,
-			deadlineExceeded,
+			orderOptions,
 		)
 		if err != nil || createdOrder == nil {
 			return fmt.Errorf("failed to place replacement order: %w", err)

--- a/pkg/strategy/xfundingv2/twap.go
+++ b/pkg/strategy/xfundingv2/twap.go
@@ -348,7 +348,12 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 	// we don't have an active order, place a new one
 	if w.syncState.ActiveOrder == nil {
 		sliceQty := w.calculateSliceQuantity(currentTime, remaining, false)
-		createdOrder, err := w.syncState.TWAPExecutor.PlaceOrder(sliceQty, orderSide(remaining), orderBook, orderOptions)
+		createdOrder, err := w.syncState.TWAPExecutor.PlaceOrder(
+			sliceQty,
+			orderSide(remaining),
+			orderBook,
+			orderOptions,
+		)
 		if err != nil || createdOrder == nil {
 			return fmt.Errorf("failed to place order: %w", err)
 		}
@@ -401,7 +406,12 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 	// currentTime is after current interval end, time to place the next slice order
 	// calculate slice quantity
 	sliceQty := w.calculateSliceQuantity(currentTime, remaining, deadlineExceeded)
-	createdOrder, err := w.syncState.TWAPExecutor.PlaceOrder(sliceQty, orderSide(remaining), orderBook, deadlineExceeded)
+	createdOrder, err := w.syncState.TWAPExecutor.PlaceOrder(
+		sliceQty,
+		orderSide(remaining),
+		orderBook,
+		orderOptions,
+	)
 	if err != nil || createdOrder == nil {
 		return fmt.Errorf("failed to place order for next slice: %w", err)
 	}

--- a/pkg/strategy/xfundingv2/twap_order_executor.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor.go
@@ -129,14 +129,9 @@ func (o *TWAPExecutor) GetOrder(orderID uint64) (types.Order, bool) {
 	return o.executor.OrderStore().Get(orderID)
 }
 
-func (o *TWAPExecutor) OpenOrders() []types.Order {
-	var openOrders []types.Order
-	for _, order := range o.executor.ActiveMakerOrders().Orders() {
-		if _, found := o.syncState.Orders[order.OrderID]; found {
-			openOrders = append(openOrders, order)
-		}
-	}
-	return openOrders
+func (o *TWAPExecutor) CancelOpenOrders(ctx context.Context) error {
+	activeOrderBook := o.executor.ActiveMakerOrders()
+	return o.executor.GracefulCancelActiveOrderBook(ctx, activeOrderBook)
 }
 
 func (o *TWAPExecutor) AllOrders() []types.Order {
@@ -169,7 +164,7 @@ func (o *TWAPExecutor) PlaceOrder(quantity fixedpoint.Value, side types.SideType
 	}
 	price = o.syncState.Market.TruncatePrice(price)
 	order := o.buildSubmitOrder(quantity, price, side, options)
-	if o.syncState.Market.IsDustQuantity(order.Quantity, order.Price) {
+	if order.Type != types.OrderTypeMarket && o.syncState.Market.IsDustQuantity(order.Quantity, order.Price) {
 		return nil, fmt.Errorf("order is of dust quantity: %s", quantity)
 	}
 

--- a/pkg/strategy/xfundingv2/twap_order_executor.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor.go
@@ -70,10 +70,12 @@ func (o *TWAPExecutor) Start() {
 
 // AddTrade adds a trade to the executor's internal trade list if it belongs to
 // an order managed by this executor.
-func (o *TWAPExecutor) AddTrade(trade types.Trade) {
-	if _, exists := o.syncState.Orders[trade.OrderID]; exists {
+func (o *TWAPExecutor) AddTrade(trade types.Trade) bool {
+	_, exists := o.syncState.Orders[trade.OrderID]
+	if exists {
 		o.syncState.Trades[trade.ID] = trade
 	}
+	return exists
 }
 
 func (o *TWAPExecutor) Stop() error {

--- a/pkg/strategy/xfundingv2/twap_order_executor.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor.go
@@ -21,6 +21,11 @@ type TWAPExecutor struct {
 	logger logrus.FieldLogger
 }
 
+type TWAPExecuteOrderOptions struct {
+	DeadlineExceeded bool
+	ReduceOnly       bool
+}
+
 func NewTWAPExecutor(
 	ctx context.Context,
 	exchange types.ExchangeOrderQueryService,
@@ -154,7 +159,7 @@ func (o *TWAPExecutor) AllTrades() []types.Trade {
 }
 
 // place order
-func (o *TWAPExecutor) PlaceOrder(quantity fixedpoint.Value, side types.SideType, orderBook types.OrderBook, deadlineExceeded bool) (*types.Order, error) {
+func (o *TWAPExecutor) PlaceOrder(quantity fixedpoint.Value, side types.SideType, orderBook types.OrderBook, options TWAPExecuteOrderOptions) (*types.Order, error) {
 	// find the better price and submit new order
 	quantity = o.syncState.Market.TruncateQuantity(quantity)
 	price, err := o.GetPrice(side, orderBook)
@@ -163,7 +168,7 @@ func (o *TWAPExecutor) PlaceOrder(quantity fixedpoint.Value, side types.SideType
 		return nil, err
 	}
 	price = o.syncState.Market.TruncatePrice(price)
-	order := o.buildSubmitOrder(quantity, price, side, deadlineExceeded)
+	order := o.buildSubmitOrder(quantity, price, side, options)
 	if o.syncState.Market.IsDustQuantity(order.Quantity, order.Price) {
 		return nil, fmt.Errorf("order is of dust quantity: %s", quantity)
 	}
@@ -179,14 +184,15 @@ func (o *TWAPExecutor) PlaceOrder(quantity fixedpoint.Value, side types.SideType
 	return &createdOrders[0], nil
 }
 
-func (o *TWAPExecutor) buildSubmitOrder(quantity, price fixedpoint.Value, side types.SideType, deadlineExceeded bool) types.SubmitOrder {
-	if deadlineExceeded {
+func (o *TWAPExecutor) buildSubmitOrder(quantity, price fixedpoint.Value, side types.SideType, options TWAPExecuteOrderOptions) types.SubmitOrder {
+	if options.DeadlineExceeded {
 		return types.SubmitOrder{
-			Symbol:   o.syncState.Market.Symbol,
-			Market:   o.syncState.Market,
-			Side:     side,
-			Type:     types.OrderTypeMarket,
-			Quantity: quantity,
+			Symbol:     o.syncState.Market.Symbol,
+			Market:     o.syncState.Market,
+			Side:       side,
+			Type:       types.OrderTypeMarket,
+			Quantity:   quantity,
+			ReduceOnly: true,
 		}
 	}
 	orderType := types.OrderTypeLimitMaker
@@ -197,7 +203,7 @@ func (o *TWAPExecutor) buildSubmitOrder(quantity, price fixedpoint.Value, side t
 		timeInForce = types.TimeInForceIOC
 	}
 
-	return types.SubmitOrder{
+	orderForm := types.SubmitOrder{
 		Symbol:      o.syncState.Market.Symbol,
 		Market:      o.syncState.Market,
 		Side:        side,
@@ -205,7 +211,9 @@ func (o *TWAPExecutor) buildSubmitOrder(quantity, price fixedpoint.Value, side t
 		Quantity:    quantity,
 		Price:       price,
 		TimeInForce: timeInForce,
+		ReduceOnly:  options.ReduceOnly,
 	}
+	return orderForm
 }
 
 func (o *TWAPExecutor) GetPrice(side types.SideType, orderBook types.OrderBook) (price fixedpoint.Value, err error) {

--- a/pkg/strategy/xfundingv2/twap_order_executor_sync.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor_sync.go
@@ -45,7 +45,7 @@ func (o *TWAPExecutor) Initialize(s *Strategy) error {
 	} else {
 		return errors.New("[TWAPExecutor] session exchange does not implement ExchangeOrderQueryService")
 	}
-	// sync orders
+	// sync orders/trades
 	orderStore := executor.OrderStore()
 	for _, query := range o.syncState.Orders {
 		order, err := o.exchange.QueryOrder(o.ctx, query)
@@ -53,6 +53,14 @@ func (o *TWAPExecutor) Initialize(s *Strategy) error {
 			return fmt.Errorf("[TWAPExecutor] failed to query order %v: %w", query, err)
 		}
 		orderStore.Add(*order)
+
+		trades, err := o.exchange.QueryOrderTrades(o.ctx, query)
+		if err != nil {
+			return fmt.Errorf("[TWAPExecutor] failed to query trades for order %v: %w", query, err)
+		}
+		for _, trade := range trades {
+			o.syncState.Trades[trade.ID] = trade
+		}
 	}
 	return nil
 }

--- a/pkg/strategy/xfundingv2/twap_order_executor_test.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor_test.go
@@ -336,7 +336,9 @@ func TestTWAPOrderExecutor_PlaceOrder(t *testing.T) {
 			Return(&expectedOrder, nil).
 			Times(1)
 
-		createdOrder, err := executor.PlaceOrder(Number(1.0), types.SideTypeBuy, orderBook, false)
+		createdOrder, err := executor.PlaceOrder(Number(1.0), types.SideTypeBuy, orderBook, TWAPExecuteOrderOptions{
+			DeadlineExceeded: false,
+		})
 
 		assert.NoError(t, err)
 		assert.NotNil(t, createdOrder)
@@ -358,7 +360,9 @@ func TestTWAPOrderExecutor_PlaceOrder(t *testing.T) {
 		orderBook := newOrderBook(99.0, 10.0, 100.0, 10.0)
 
 		// Very small quantity that would be dust
-		_, err := executor.PlaceOrder(Number(0.00000001), types.SideTypeBuy, orderBook, false)
+		_, err := executor.PlaceOrder(Number(0.00000001), types.SideTypeBuy, orderBook, TWAPExecuteOrderOptions{
+			DeadlineExceeded: false,
+		})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "dust quantity")
 	})
@@ -383,7 +387,9 @@ func TestTWAPOrderExecutor_PlaceOrder(t *testing.T) {
 			Return(nil, expectedErr).
 			Times(1)
 
-		createdOrder, err := executor.PlaceOrder(Number(1.0), types.SideTypeBuy, orderBook, false)
+		createdOrder, err := executor.PlaceOrder(Number(1.0), types.SideTypeBuy, orderBook, TWAPExecuteOrderOptions{
+			DeadlineExceeded: false,
+		})
 
 		assert.Error(t, err)
 		assert.Nil(t, createdOrder)
@@ -664,7 +670,9 @@ func TestTWAPOrderExecutor_PlaceOrder_EmptyOrderBook(t *testing.T) {
 
 	emptyBook := &types.SliceOrderBook{}
 
-	_, err := executor.PlaceOrder(Number(1.0), types.SideTypeBuy, emptyBook, false)
+	_, err := executor.PlaceOrder(Number(1.0), types.SideTypeBuy, emptyBook, TWAPExecuteOrderOptions{
+		DeadlineExceeded: false,
+	})
 	assert.Error(t, err)
 }
 

--- a/pkg/strategy/xfundingv2/twap_order_executor_test.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor_test.go
@@ -259,7 +259,7 @@ func TestTWAPOrderExecutor_BuildSubmitOrder(t *testing.T) {
 		}
 		executor, _, _ := testExecutorSetup(t, ctrl, config)
 
-		order := executor.buildSubmitOrder(Number(1.0), Number(100.0), types.SideTypeBuy, true)
+		order := executor.buildSubmitOrder(Number(1.0), Number(100.0), types.SideTypeBuy, TWAPExecuteOrderOptions{DeadlineExceeded: true})
 
 		assert.Equal(t, market.Symbol, order.Symbol)
 		assert.Equal(t, types.SideTypeBuy, order.Side)
@@ -276,7 +276,7 @@ func TestTWAPOrderExecutor_BuildSubmitOrder(t *testing.T) {
 		}
 		executor, _, _ := testExecutorSetup(t, ctrl2, config)
 
-		order := executor.buildSubmitOrder(Number(1.5), Number(50000.0), types.SideTypeSell, false)
+		order := executor.buildSubmitOrder(Number(1.5), Number(50000.0), types.SideTypeSell, TWAPExecuteOrderOptions{})
 
 		assert.Equal(t, market.Symbol, order.Symbol)
 		assert.Equal(t, types.SideTypeSell, order.Side)
@@ -295,7 +295,7 @@ func TestTWAPOrderExecutor_BuildSubmitOrder(t *testing.T) {
 		}
 		executor, _, _ := testExecutorSetup(t, ctrl2, config)
 
-		order := executor.buildSubmitOrder(Number(2.0), Number(48000.0), types.SideTypeBuy, false)
+		order := executor.buildSubmitOrder(Number(2.0), Number(48000.0), types.SideTypeBuy, TWAPExecuteOrderOptions{})
 
 		assert.Equal(t, market.Symbol, order.Symbol)
 		assert.Equal(t, types.SideTypeBuy, order.Side)

--- a/pkg/strategy/xfundingv2/util.go
+++ b/pkg/strategy/xfundingv2/util.go
@@ -1,0 +1,12 @@
+package xfundingv2
+
+import (
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+func getMidPrice(orderBook types.OrderBook) fixedpoint.Value {
+	bestBid, _ := orderBook.BestBid()
+	bestAsk, _ := orderBook.BestAsk()
+	return bestBid.Price.Add(bestAsk.Price).Div(fixedpoint.Two)
+}


### PR DESCRIPTION
- Non-blocking cleanup for closed rounds
  - Retry up to 3 times; send Slack notification on persistent failure
  - Block new rounds from opening on the same symbol until cleanup succeeds
- Close remaining futures positions safely after round ends
  - Implement `Cleanup` method using reduce-only market orders verified via `QueryPositionRisk`
  - Add `ReduceOnly` flag to TWAP orders when closing positions to prevent opening new positions
  - cancel open orders using general executor `GracefulCancelActiveOrderBook` method.
- Detect orphaned positions on startup
  - Query all futures position risks and verify each has a corresponding active round
  - Fail startup if mismatched positions are found
- Restore open orders into executor state on startup
  - Query open orders for each symbol and add them to `ActiveMakerOrders`
- Add Slack attachment support for round status reporting
  - `SlackAttachment` on `ArbitrageRound` and `CloseRoundTask` with color-coded state display
- Refactor: extract `getMidPrice` utility and `canOpenRound` helper