### PR TITLE
FEATURE: [xfundingv2] add prometheus metrics for tracking round performance

### DIFF
--- a/pkg/strategy/xfundingv2/market_selector.go
+++ b/pkg/strategy/xfundingv2/market_selector.go
@@ -7,6 +7,7 @@ import (
 	"github.com/c9s/bbgo/pkg/exchange/binance/binanceapi"
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
@@ -166,6 +167,11 @@ func (s *MarketSelector) SelectMarkets(ctx context.Context, symbols []string) ([
 			continue
 		}
 		annualized := AnnualizedRate(idx.LastFundingRate, info.FundingIntervalHours)
+		labels := prometheus.Labels{
+			"symbol": idx.Symbol,
+		}
+		annualizedFundingRateMetrics.With(labels).Set(annualized.Float64())
+		fundingRateMetrics.With(labels).Set(idx.LastFundingRate.Float64())
 
 		if annualized.Abs().Compare(s.MinAnnualizedRate) < 0 {
 			continue

--- a/pkg/strategy/xfundingv2/metrics.go
+++ b/pkg/strategy/xfundingv2/metrics.go
@@ -1,0 +1,57 @@
+package xfundingv2
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// TODO: integrate `dynamic.InitializeConfigMetrics` for automatic metric labels generation based on the config struct fields.
+// see xmaker for example usage
+
+var fundingRateMetrics = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xfundingv2_funding_rate",
+		Help: "Funding rate of the symbol",
+	},
+	[]string{"symbol"},
+)
+
+var annualizedFundingRateMetrics = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xfundingv2_annualized_funding_rate",
+		Help: "Annualized funding rate of the symbol",
+	},
+	[]string{"symbol"},
+)
+
+var roundAnnualizedTriggerRateMetrics = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xfundingv2_round_annualized_trigger_rate",
+		Help: "Annualized triggering funding rate of the arbitrage round",
+	},
+	[]string{"strategy_type", "strategy_id", "symbol"},
+)
+
+var roundHoldingIntervalMetrics = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xfundingv2_round_holding_interval",
+		Help: "Holding interval of the arbitrage round in seconds",
+	},
+	[]string{"strategy_type", "strategy_id", "symbol"},
+)
+
+var roundNetPnLMetrics = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xfundingv2_round_net_pnl",
+		Help: "Net PnL of the arbitrage round",
+	},
+	[]string{"strategy_type", "strategy_id", "symbol"},
+)
+
+var roundPositionFilledRatioMetrics = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xfundingv2_round_position_filled_ratio",
+		Help: "Filled ratio of the position in the arbitrage round. It should be increasing up to 1 when round is opening and decreasing down to 0 when round is closing",
+	},
+	[]string{"strategy_type", "strategy_id", "symbol", "accountType"},
+)

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/c9s/bbgo/pkg/risk/circuitbreaker"
 	"github.com/c9s/bbgo/pkg/slack/slackalert"
 	"github.com/c9s/bbgo/pkg/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
 	"golang.org/x/time/rate"
@@ -500,6 +501,16 @@ func (s *Strategy) CrossRun(
 		return fmt.Errorf("failed to connect spot stream books: %w", err)
 	}
 
+	// setup metrics for positions
+	for _, position := range s.spotPositions {
+		position.Strategy = s.ID()
+		position.StrategyInstanceID = s.InstanceID()
+	}
+	for _, position := range s.futuresPositions {
+		position.Strategy = s.ID()
+		position.StrategyInstanceID = s.InstanceID()
+	}
+
 	// setup callbacks
 	s.spotSession.MarketDataStream.OnKLineClosed(types.KLineWith(s.TickSymbol, s.TickInterval, func(kline types.KLine) {
 		s.tick(ctx, kline.EndTime.Time())
@@ -513,6 +524,20 @@ func (s *Strategy) CrossRun(
 		for _, round := range s.allRounds() {
 			if round.HasOrder(trade.OrderID) {
 				round.HandleSpotTrade(trade, trade.Time.Time())
+
+				spotFilledPosition := round.SpotWorker().FilledPosition()
+				filledRatio := spotFilledPosition.Div(round.TriggeredFundingRate()).Abs()
+				if round.State() == RoundClosing {
+					filledRatio = fixedpoint.One.Sub(filledRatio)
+				}
+				roundPositionFilledRatioMetrics.With(
+					prometheus.Labels{
+						"strategy_type": s.ID(),
+						"strategy_id":   s.InstanceID(),
+						"symbol":        round.SpotSymbol(),
+						"accountType":   "spot",
+					},
+				).Set(filledRatio.Float64())
 			}
 		}
 	})
@@ -523,6 +548,20 @@ func (s *Strategy) CrossRun(
 		for _, round := range s.allRounds() {
 			if round.HasOrder(trade.OrderID) {
 				round.HandleFuturesTrade(trade, trade.Time.Time())
+
+				futuresFilledPosition := round.FuturesWorker().FilledPosition()
+				filledRatio := futuresFilledPosition.Div(round.TriggeredFundingRate()).Abs()
+				if round.State() == RoundClosing {
+					filledRatio = fixedpoint.One.Sub(filledRatio)
+				}
+				roundPositionFilledRatioMetrics.With(
+					prometheus.Labels{
+						"strategy_type": s.ID(),
+						"strategy_id":   s.InstanceID(),
+						"symbol":        round.SpotSymbol(),
+						"accountType":   "futures",
+					},
+				).Set(filledRatio.Float64())
 			}
 		}
 	})
@@ -827,6 +866,13 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 				},
 			)
 			round.SetSlackAlert(s.SlackAlert)
+			roundAnnualizedTriggerRateMetrics.With(
+				prometheus.Labels{
+					"strategy_type": s.ID(),
+					"strategy_id":   s.InstanceID(),
+					"symbol":        selectedCandidate.Symbol,
+				},
+			).Set(round.AnnualizedRate().Float64())
 			// save as pending round for the fee asset preparation
 			s.pendingRounds[selectedCandidate.Symbol] = &PendingRound{
 				Round: round,
@@ -1132,6 +1178,15 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 	} else {
 		s.logger.Warnf("circuit breaker not found for symbol %s when recording profit: %s", round.SpotSymbol(), pnl)
 	}
+	labels := prometheus.Labels{
+		"strategy_type": s.ID(),
+		"strategy_id":   s.InstanceID(),
+		"symbol":        round.SpotSymbol(),
+	}
+	roundHoldingIntervalMetrics.With(labels).Set(
+		float64(round.NumHoldingIntervals(tickTime)),
+	)
+	roundNetPnLMetrics.With(labels).Set(pnl.NetPnL().Float64())
 	// TODO: insert closed round records into database
 	return nil
 }

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -84,11 +84,19 @@ type Strategy struct {
 	coinmarketcapClient *coinmarketcap.DataSource
 
 	// persistence states
-	// pending rounds and active rounds
-	pendingRounds map[string]*PendingRound   `persistence:"pendingRounds"`
-	activeRounds  map[string]*ArbitrageRound `persistence:"activeRounds"`
+	// pendingRounds are the rounds that are waiting for the preparation work to be done
+	// before entering the active round list, such as fee asset preparation, transfer, etc.
+	pendingRounds map[string]*PendingRound `persistence:"pendingRounds"`
+
+	// activeRounds are the rounds that are actively trading or holding positions.
+	// rounds in the active list should be at the state of either RoundOpening, RoundReady or RoundClosing.
+	activeRounds map[string]*ArbitrageRound `persistence:"activeRounds"`
 
 	// closed rounds that are waiting for cleanup
+	// the cleanup process is to
+	// 1. ensure that the positions will restore to zero
+	// 2. all open orders are canceled.
+	// 3. collaterals are transferred back to the spot account.
 	MaxClosedRetryCnt int                        `json:"maxClosedRetryCnt"`
 	closedRoundTasks  map[string]*CloseRoundTask `persistence:"closedRounds"`
 


### PR DESCRIPTION
- `fundingRateMetrics`: the funding rate time series
- `annualizedFundingRateMetrics`: annualized funding rate
- `roundAnnualizedTriggerRateMetrics`: annualized rate of the triggering funding rate
- `roundHoldingIntervalMetrics`: the number of holding intervals of the round
- `roundNetPnLMetrics`: round net PnL
- `roundPositionFilledRatioMetrics`: round position filled ratio. it's designed to increasing up to 1 when the round is opening position and decreasing down to 0 when closing.