### PR TITLE
FEATURE: [xfundingv2] Add halt/resume on hedge deviation

### DIFF
--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -574,7 +574,7 @@ func (r *ArbitrageRound) HandleSpotTrade(trade types.Trade, currentTime time.Tim
 }
 
 func (r *ArbitrageRound) handleSpotTrade(trade types.Trade, currentTime time.Time) {
-	if ok := r.spotWorker.AddTrade(trade); !ok {
+	if ok := r.spotWorker.Executor().AddTrade(trade); !ok {
 		return
 	}
 	r.logger.Infof("handling spot trade: %s", trade)
@@ -625,7 +625,7 @@ func (r *ArbitrageRound) HandleFuturesTrade(trade types.Trade, currentTime time.
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if ok := r.futuresWorker.AddTrade(trade); ok {
+	if ok := r.futuresWorker.Executor().AddTrade(trade); ok {
 		r.logger.Infof("handling future trade: %s", trade)
 	}
 }

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -286,10 +286,17 @@ func (r *ArbitrageRound) SetSlackAlert(alert slackalert.SlackAlert) {
 	r.slackAlert = alert
 }
 
-func (r *ArbitrageRound) NewNotification(isCritical bool) *roundNotification {
+func (r *ArbitrageRound) NewCriticalNotification() *roundNotification {
 	return &roundNotification{
 		ArbitrageRound: r,
-		IsCritical:     isCritical,
+		IsCritical:     true,
+	}
+}
+
+func (r *ArbitrageRound) NewNotification() *roundNotification {
+	return &roundNotification{
+		ArbitrageRound: r,
+		IsCritical:     false,
 	}
 }
 

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -49,6 +49,7 @@ type ArbitrageRound struct {
 	syncState     ArbitrageRoundSyncState
 	spotWorker    *TWAPWorker
 	futuresWorker *TWAPWorker
+	haltedAt      time.Time
 
 	futuresService                                FuturesService
 	spotExchangeFeeRates, futuresExchangeFeeRates map[types.ExchangeName]types.ExchangeFee
@@ -99,6 +100,38 @@ func NewArbitrageRound(
 		futuresService:     futuresService,
 		retryTransferTickC: make(chan time.Time, 100),
 	}
+}
+
+func (r *ArbitrageRound) Halt(currentTime time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.haltedAt = currentTime
+}
+
+func (r *ArbitrageRound) HaltedAt() time.Time {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.haltedAt
+}
+
+func (r *ArbitrageRound) IsHalted() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.isHalted()
+}
+
+func (r *ArbitrageRound) isHalted() bool {
+	return !r.haltedAt.IsZero()
+}
+
+func (r *ArbitrageRound) Resume() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.haltedAt = time.Time{}
 }
 
 func (r *ArbitrageRound) SetSpotExchangeFeeRates(fee types.ExchangeFee) {
@@ -699,8 +732,8 @@ func (r *ArbitrageRound) Tick(currentTime time.Time, spotOrderBook types.OrderBo
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.syncState.State == RoundPending {
-		// not started yet, do nothing
+	if r.syncState.State == RoundPending || r.isHalted() {
+		// not started yet or halted, do nothing
 		return
 	}
 

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -575,6 +575,7 @@ func (r *ArbitrageRound) HandleSpotTrade(trade types.Trade, currentTime time.Tim
 
 func (r *ArbitrageRound) handleSpotTrade(trade types.Trade, currentTime time.Time) {
 	if ok := r.spotWorker.Executor().AddTrade(trade); !ok {
+		// the trade does not belong to the spot worker, skip
 		return
 	}
 	r.logger.Infof("handling spot trade: %s", trade)
@@ -665,9 +666,10 @@ func (r *ArbitrageRound) SetClosing(currentTime time.Time, duration time.Duratio
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// set spot target position to zero
+	// the futures target position will be synced as the spot position is closing
 	r.spotWorker.SetTargetPosition(fixedpoint.Zero)
 	r.spotWorker.ResetTime(currentTime, duration)
-	r.futuresWorker.SetTargetPosition(fixedpoint.Zero)
 	r.futuresWorker.ResetTime(currentTime, duration)
 
 	r.syncState.State = RoundClosing
@@ -792,18 +794,20 @@ func (r *ArbitrageRound) Tick(currentTime time.Time, spotOrderBook types.OrderBo
 	}
 }
 
-func (r *ArbitrageRound) syncFuturesPosition(trade types.Trade) {
-	if r.syncState.State != RoundOpening {
-		// only sync futures position when the round is opening
+func (r *ArbitrageRound) syncFuturesPosition(spotTrade types.Trade) {
+	// sanity check
+	if r.spotWorker.Symbol() != spotTrade.Symbol {
 		return
 	}
-	// the target spot position can be either positive or negative
-	futureTargetPosition := r.futuresWorker.TargetPosition()
-	if r.spotWorker.TargetPosition().Sign() > 0 {
-		futureTargetPosition = futureTargetPosition.Sub(trade.Quantity)
-	} else {
-		futureTargetPosition = futureTargetPosition.Add(trade.Quantity)
-	}
-	r.logger.Infof("syncing futures position to %s: %s", futureTargetPosition, trade)
+	// the filled spot position can be positive or negative
+	filledSpotPosition := r.spotWorker.FilledPosition()
+	// the futures target position should be always the negation of the spot filled position to maintain delta-neutral
+	oriFuturesTargetPosition := r.futuresWorker.TargetPosition()
+	futureTargetPosition := filledSpotPosition.Neg()
+	r.logger.Infof("syncing futures position %s -> %s: %s",
+		oriFuturesTargetPosition,
+		futureTargetPosition,
+		spotTrade,
+	)
 	r.futuresWorker.SetTargetPosition(futureTargetPosition)
 }

--- a/pkg/strategy/xfundingv2/arb_round_fee.go
+++ b/pkg/strategy/xfundingv2/arb_round_fee.go
@@ -82,7 +82,7 @@ func (s *Strategy) processPendingRounds(ctx context.Context, currentTime time.Ti
 		// move to active round list
 		s.activeRounds[round.SpotSymbol()] = round
 		delete(s.pendingRounds, round.SpotSymbol())
-		bbgo.Notify("🚀 Round started: %s", round.SpotSymbol(), round.NewNotification(false))
+		bbgo.Notify("🚀 Round started: %s", round.SpotSymbol(), round.NewNotification())
 	}
 }
 

--- a/pkg/strategy/xfundingv2/arb_round_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_test.go
@@ -7,12 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
 	"github.com/c9s/bbgo/pkg/exchange/binance/binanceapi"
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
+	"github.com/c9s/bbgo/pkg/types/mocks"
 
 	. "github.com/c9s/bbgo/pkg/testing/testhelper"
 )
@@ -257,4 +259,245 @@ func TestArbitrageRound_TotalFundingIncome(t *testing.T) {
 		err := round.SyncFundingFeeRecords(ctx, currentTime)
 		assert.Error(t, err)
 	})
+}
+
+func TestArbitrageRound_DeltaNeutral(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	config := TWAPWorkerConfig{
+		Duration:      10 * time.Minute,
+		NumSlices:     2,
+		OrderType:     TWAPOrderTypeMaker,
+		CheckInterval: 1 * time.Second,
+		NumOfTicks:    1,
+	}
+
+	nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+	startTime := time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	spotWorker, spotMockExchange, spotMockOrderQuery, spotGeneralExecutor := newTestTWAPWorker(t, ctrl, config)
+	futuresWorker, futuresMockExchange, futuresMockOrderQuery, futuresGeneralExecutor := newTestTWAPWorker(t, ctrl, config)
+
+	targetPosition := Number(10.0)
+	spotWorker.SetTargetPosition(targetPosition)
+
+	mockService := &mockFuturesService{}
+
+	fundingRate := &types.PremiumIndex{
+		LastFundingRate: Number(0.001),
+		NextFundingTime: nextFundingTime,
+	}
+
+	round := NewArbitrageRound(
+		fundingRate,
+		types.ExchangeBinance, types.ExchangeBinance,
+		3, 8, spotWorker, futuresWorker, mockService)
+	round.SetLogger(logrus.WithField("test", "delta_neutral"))
+
+	spotOrderID := uint64(1000)
+	setupDeltaNeutralMockExchange(spotMockExchange, spotMockOrderQuery, &spotOrderID)
+
+	futuresOrderID := uint64(2000)
+	setupDeltaNeutralMockExchange(futuresMockExchange, futuresMockOrderQuery, &futuresOrderID)
+
+	assertDeltaNeutral := func(t *testing.T, msg string) {
+		t.Helper()
+		spotFilled := spotWorker.FilledPosition()
+		futuresFilled := futuresWorker.FilledPosition()
+		netDelta := spotFilled.Add(futuresFilled)
+		assert.True(t, netDelta.IsZero(),
+			"%s: delta-neutral violated, spot=%s, futures=%s, net=%s",
+			msg, spotFilled, futuresFilled, netDelta)
+	}
+
+	assertFuturesTargetMatchesSpot := func(t *testing.T, msg string) {
+		t.Helper()
+		spotFilled := spotWorker.FilledPosition()
+		futuresTarget := futuresWorker.TargetPosition()
+		expected := spotFilled.Neg()
+		assert.Equal(t, expected, futuresTarget,
+			"%s: futures target should be negation of spot filled, spot=%s, futuresTarget=%s",
+			msg, spotFilled, futuresTarget)
+	}
+
+	orderBook := newOrderBook(76990.0, 100.0, 77010.0, 100.0)
+
+	// ==========================================
+	// Phase 1: Start the round (Opening)
+	// ==========================================
+	ctx := context.Background()
+	err := round.Start(ctx, startTime)
+	assert.NoError(t, err)
+	assert.Equal(t, RoundOpening, round.State())
+	assertDeltaNeutral(t, "after start")
+
+	// ==========================================
+	// Phase 2: Opening - buy spot in slices, verify futures stays delta-neutral
+	// ==========================================
+
+	// Tick spot worker -> places first slice order (10/2 = 5 BTC)
+	err = spotWorker.Tick(startTime, orderBook)
+	assert.NoError(t, err)
+	assert.NotNil(t, spotWorker.ActiveOrder())
+
+	// Spot trade 1: buy 5 BTC
+	spotTrade1 := makeTrade(1, spotWorker.ActiveOrder().OrderID, types.SideTypeBuy, Number(77010.0), Number(5.0))
+	processTrade(spotWorker, spotGeneralExecutor, spotTrade1)
+	round.HandleSpotTrade(spotTrade1, startTime)
+
+	assertFuturesTargetMatchesSpot(t, "after spot trade 1")
+	assert.Equal(t, Number(-5.0), futuresWorker.TargetPosition())
+
+	// Tick futures worker -> places order matching synced target
+	err = futuresWorker.Tick(startTime, orderBook)
+	assert.NoError(t, err)
+	assert.NotNil(t, futuresWorker.ActiveOrder())
+
+	// Futures trade 1: sell 5 BTC
+	futuresTrade1 := makeTrade(101, futuresWorker.ActiveOrder().OrderID, types.SideTypeSell, Number(77010.0), Number(5.0))
+	processTrade(futuresWorker, futuresGeneralExecutor, futuresTrade1)
+	round.HandleFuturesTrade(futuresTrade1, startTime)
+
+	assertDeltaNeutral(t, "after opening trade 1")
+	assert.Equal(t, Number(5.0), spotWorker.FilledPosition())
+	assert.Equal(t, Number(-5.0), futuresWorker.FilledPosition())
+
+	// Tick spot worker -> places second slice order (remaining 5/1 = 5 BTC)
+	tick2 := startTime.Add(5 * time.Minute)
+	err = spotWorker.Tick(tick2, orderBook)
+	assert.NoError(t, err)
+
+	// Spot trade 2: buy 5 BTC more
+	spotTrade2 := makeTrade(2, spotWorker.ActiveOrder().OrderID, types.SideTypeBuy, Number(77010.0), Number(5.0))
+	processTrade(spotWorker, spotGeneralExecutor, spotTrade2)
+	round.HandleSpotTrade(spotTrade2, tick2)
+
+	assertFuturesTargetMatchesSpot(t, "after spot trade 2")
+	assert.Equal(t, Number(-10.0), futuresWorker.TargetPosition())
+
+	// Tick futures worker -> fills remaining
+	err = futuresWorker.Tick(tick2, orderBook)
+	assert.NoError(t, err)
+
+	futuresTrade2 := makeTrade(102, futuresWorker.ActiveOrder().OrderID, types.SideTypeSell, Number(77010.0), Number(5.0))
+	processTrade(futuresWorker, futuresGeneralExecutor, futuresTrade2)
+	round.HandleFuturesTrade(futuresTrade2, tick2)
+
+	assertDeltaNeutral(t, "after opening trade 2 (fully opened)")
+	assert.Equal(t, Number(10.0), spotWorker.FilledPosition())
+	assert.Equal(t, Number(-10.0), futuresWorker.FilledPosition())
+
+	// ==========================================
+	// Phase 3: Tick round to transition to RoundReady
+	// ==========================================
+	tickReady := startTime.Add(6 * time.Minute)
+	round.Tick(tickReady, orderBook, orderBook)
+	assert.Equal(t, RoundReady, round.State())
+	assertDeltaNeutral(t, "at RoundReady")
+
+	// ==========================================
+	// Phase 4: Set closing
+	// ==========================================
+	closeTime := startTime.Add(20 * time.Minute)
+	closeDuration := 10 * time.Minute
+	round.SetClosing(closeTime, closeDuration)
+	assert.Equal(t, RoundClosing, round.State())
+	assert.Equal(t, fixedpoint.Zero, spotWorker.TargetPosition())
+	assertDeltaNeutral(t, "after SetClosing (before closing trades)")
+
+	// ==========================================
+	// Phase 5: Closing - sell spot, buy back futures
+	// ==========================================
+
+	// Tick spot worker -> places sell order (remaining = -10, slice = 10/2 = 5)
+	err = spotWorker.Tick(closeTime, orderBook)
+	assert.NoError(t, err)
+
+	// Spot close trade 1: sell 5 BTC
+	spotCloseTrade1 := makeTrade(3, spotWorker.ActiveOrder().OrderID, types.SideTypeSell, Number(76990.0), Number(5.0))
+	processTrade(spotWorker, spotGeneralExecutor, spotCloseTrade1)
+	round.HandleSpotTrade(spotCloseTrade1, closeTime)
+
+	assertFuturesTargetMatchesSpot(t, "after spot close trade 1")
+	assert.Equal(t, Number(5.0), spotWorker.FilledPosition())
+	assert.Equal(t, Number(-5.0), futuresWorker.TargetPosition())
+
+	// Tick futures worker -> places buy-back order
+	err = futuresWorker.Tick(closeTime, orderBook)
+	assert.NoError(t, err)
+
+	futuresCloseTrade1 := makeTrade(103, futuresWorker.ActiveOrder().OrderID, types.SideTypeBuy, Number(76990.0), Number(5.0))
+	processTrade(futuresWorker, futuresGeneralExecutor, futuresCloseTrade1)
+	round.HandleFuturesTrade(futuresCloseTrade1, closeTime)
+
+	assertDeltaNeutral(t, "after closing trade 1")
+
+	// Tick spot worker -> places second sell order
+	tick5 := closeTime.Add(5 * time.Minute)
+	err = spotWorker.Tick(tick5, orderBook)
+	assert.NoError(t, err)
+
+	// Spot close trade 2: sell remaining 5 BTC
+	spotCloseTrade2 := makeTrade(4, spotWorker.ActiveOrder().OrderID, types.SideTypeSell, Number(76990.0), Number(5.0))
+	processTrade(spotWorker, spotGeneralExecutor, spotCloseTrade2)
+	round.HandleSpotTrade(spotCloseTrade2, tick5)
+
+	assertFuturesTargetMatchesSpot(t, "after spot close trade 2")
+	assert.True(t, spotWorker.FilledPosition().IsZero())
+	assert.True(t, futuresWorker.TargetPosition().IsZero())
+
+	// Tick futures worker -> places final buy-back order
+	err = futuresWorker.Tick(tick5, orderBook)
+	assert.NoError(t, err)
+
+	futuresCloseTrade2 := makeTrade(104, futuresWorker.ActiveOrder().OrderID, types.SideTypeBuy, Number(76990.0), Number(5.0))
+	processTrade(futuresWorker, futuresGeneralExecutor, futuresCloseTrade2)
+	round.HandleFuturesTrade(futuresCloseTrade2, tick5)
+
+	assertDeltaNeutral(t, "after closing trade 2 (fully closed)")
+	assert.True(t, spotWorker.FilledPosition().IsZero())
+	assert.True(t, futuresWorker.FilledPosition().IsZero())
+
+	// ==========================================
+	// Phase 6: Tick round to transition to RoundClosed
+	// ==========================================
+	tickClosed := closeTime.Add(6 * time.Minute)
+	round.Tick(tickClosed, orderBook, orderBook)
+	assert.Equal(t, RoundClosed, round.State())
+	assertDeltaNeutral(t, "at RoundClosed")
+}
+
+func setupDeltaNeutralMockExchange(mockExchange *mocks.MockExchange, mockOrderQuery *mocks.MockExchangeOrderQueryService, orderID *uint64) {
+	mockExchange.EXPECT().
+		SubmitOrder(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, order types.SubmitOrder) (*types.Order, error) {
+			currentOrderID := *orderID
+			*orderID++
+			return &types.Order{
+				OrderID: currentOrderID,
+				SubmitOrder: types.SubmitOrder{
+					Symbol:   order.Symbol,
+					Side:     order.Side,
+					Type:     order.Type,
+					Quantity: order.Quantity,
+					Price:    order.Price,
+				},
+				Status: types.OrderStatusNew,
+			}, nil
+		}).AnyTimes()
+
+	mockExchange.EXPECT().
+		CancelOrders(gomock.Any(), gomock.Any()).
+		Return(nil).AnyTimes()
+
+	mockOrderQuery.EXPECT().
+		QueryOrder(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, q types.OrderQuery) (*types.Order, error) {
+			return &types.Order{OrderID: 1, Status: types.OrderStatusCanceled}, nil
+		}).AnyTimes()
+
+	mockOrderQuery.EXPECT().
+		QueryOrderTrades(gomock.Any(), gomock.Any()).
+		Return([]types.Trade{}, nil).AnyTimes()
 }

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -659,7 +659,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 			s.lastHaltNotificationTime[round.SpotSymbol()] = tickTime
 			bbgo.Notify("💥 Round %s halted due to large hedge deviation. Manual intervention is required.",
 				roundSymbol,
-				round.NewNotification(true),
+				round.NewCriticalNotification(),
 			)
 		} else if halted && !deviationTooLarge {
 			// the deviation is back to normal, resume the round
@@ -676,7 +676,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 			bbgo.Notify("✅ Round %s resumed as hedge deviation back to normal. It was halted at %s.",
 				roundSymbol,
 				haltedAt.Format(time.RFC3339),
-				round.NewNotification(false),
+				round.NewNotification(),
 			)
 		}
 
@@ -692,7 +692,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 					roundSymbol,
 					elapsed.String(),
 					haltedAt.Format(time.RFC3339),
-					round.NewNotification(true),
+					round.NewCriticalNotification(),
 				)
 			}
 			continue
@@ -726,7 +726,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 				task.Notified = true
 				bbgo.Notify("💥 Failed to handle closed round after %d retries. Manual intervention is required.",
 					s.MaxClosedRetryCnt,
-					round.NewNotification(true),
+					round.NewCriticalNotification(),
 				)
 			}
 			continue
@@ -737,7 +737,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		if err := s.handleClosedRound(closeRoundCtx, task, tickTime); err != nil {
 			s.logger.WithError(err).Errorf("failed to handle closed round: %s", task.Round)
 		} else {
-			bbgo.Notify("✅ Successfully handled closed round: %s", round.String(), round.NewNotification(false))
+			bbgo.Notify("✅ Successfully handled closed round: %s", round.String(), round.NewNotification())
 			s.logger.Infof("successfully handled closed round: %s", task.Round)
 			delete(s.closedRoundTasks, task.Round.SpotSymbol())
 		}
@@ -783,7 +783,7 @@ func (s *Strategy) transitRoundState(ctx context.Context, round *ArbitrageRound,
 		if round.State() == RoundReady {
 			bbgo.Notify("🟢 Round entered ready state: %s",
 				round.SpotSymbol(),
-				round.NewNotification(false),
+				round.NewNotification(),
 			)
 		}
 	case RoundReady:
@@ -791,7 +791,7 @@ func (s *Strategy) transitRoundState(ctx context.Context, round *ArbitrageRound,
 		if round.State() == RoundClosing {
 			bbgo.Notify("🔴 Round is closing: %s",
 				round.SpotSymbol(),
-				round.NewNotification(false),
+				round.NewNotification(),
 			)
 		}
 	case RoundClosing:
@@ -818,7 +818,7 @@ func (s *Strategy) transitOpeningOrReadyRound(ctx context.Context, round *Arbitr
 				round.TriggeredFundingRate(),
 				fundingRate.LastFundingRate,
 				s.CriticalErrorConfig.MaxFundingRateFlip,
-				round.NewNotification(true),
+				round.NewCriticalNotification(),
 			)
 		}
 		if round.NumHoldingIntervals(currentTime) >= round.MinHoldingIntervals() {
@@ -964,7 +964,7 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 			s.pendingRounds[selectedCandidate.Symbol] = &PendingRound{
 				Round: round,
 			}
-			bbgo.Notify("🆕 Created new pending round: %s", round.SpotSymbol(), round.NewNotification(false))
+			bbgo.Notify("🆕 Created new pending round: %s", round.SpotSymbol(), round.NewNotification())
 		}
 	}
 }
@@ -1244,7 +1244,7 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 			bbgo.Notify("⬅️ Transferred %s %s back to spot account",
 				balance.Available,
 				asset,
-				round.NewNotification(false),
+				round.NewNotification(),
 			)
 		}
 	}

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -30,6 +30,19 @@ func init() {
 type CriticalErrorConfig struct {
 	MaxRemainingNotional fixedpoint.Value `json:"maxRemainingNotional"`
 	MaxFundingRateFlip   fixedpoint.Value `json:"maxFundingRateFlip"`
+	MaxHedgeDeviation    fixedpoint.Value `json:"maxHedgeDeviation"`
+}
+
+func (c *CriticalErrorConfig) Defaults() {
+	if c.MaxRemainingNotional.IsZero() {
+		c.MaxRemainingNotional = fixedpoint.NewFromInt(500)
+	}
+	if c.MaxFundingRateFlip.IsZero() {
+		c.MaxFundingRateFlip = fixedpoint.NewFromFloat(0.0003) // 0.03%
+	}
+	if c.MaxHedgeDeviation.IsZero() {
+		c.MaxHedgeDeviation = fixedpoint.NewFromFloat(0.3) // 30%
+	}
 }
 
 type Strategy struct {
@@ -160,12 +173,7 @@ func (s *Strategy) Defaults() error {
 		s.MaxClosedRetryCnt = 3
 	}
 
-	if s.CriticalErrorConfig.MaxRemainingNotional.IsZero() {
-		s.CriticalErrorConfig.MaxRemainingNotional = fixedpoint.NewFromInt(500)
-	}
-	if s.CriticalErrorConfig.MaxFundingRateFlip.IsZero() {
-		s.CriticalErrorConfig.MaxFundingRateFlip = fixedpoint.NewFromFloat(0.0003) // 0.03%
-	}
+	s.CriticalErrorConfig.Defaults()
 
 	return nil
 }
@@ -619,7 +627,51 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 	// start processing
 	// 1. transit active rounds
 	for _, round := range s.activeRounds {
+		// check if the round is halted or should be halted
+		halted := round.IsHalted()
+		// spot and futures position should be close to each other at all time.
+		spotFilled := round.SpotWorker().FilledPosition()
+		futuresFilled := round.FuturesWorker().FilledPosition()
+		// calculate the deviation of the unhedged position
+		deviation := fixedpoint.One.Sub(futuresFilled.Div(spotFilled)).Abs()
+		deviationTooLarge := deviation.Compare(s.CriticalErrorConfig.MaxHedgeDeviation) > 0
+		if !halted && deviationTooLarge {
+			// the round is originally not halted but the deviation is too large -> we need to halt the round
+			round.Halt(tickTime)
+			s.logger.Warnf("round %s halted due to large hedge deviation: %s, spot filled: %s, futures filled: %s",
+				round.SpotSymbol(),
+				deviation,
+				spotFilled,
+				futuresFilled,
+			)
+			bbgo.Notify("💥 Round %s halted due to large hedge deviation. Manual intervention is required.",
+				round.SpotSymbol(),
+				round.NewNotification(true),
+			)
+		} else if halted && !deviationTooLarge {
+			// the deviation is back to normal, resume the round
+			haltedAt := round.HaltedAt()
+			round.Resume()
+			s.logger.Infof("round %s resumed as hedge deviation back to normal: %s, spot filled: %s, futures filled: %s",
+				round.SpotSymbol(),
+				deviation,
+				spotFilled,
+				futuresFilled,
+			)
+			bbgo.Notify("✅ Round %s resumed as hedge deviation back to normal. It was halted at %s.",
+				round.SpotSymbol(),
+				haltedAt.Format(time.RFC3339),
+				round.NewNotification(false),
+			)
+		}
+
+		// round is still halted, skip the rest of the processing
+		if round.IsHalted() {
+			continue
+		}
+
 		s.transitRoundState(ctx, round, tickTime)
+
 		// enque closed active rounds
 		if round.State() == RoundClosed {
 			s.logger.Infof("move round to closed queue: %s", round)
@@ -644,9 +696,9 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 				// send notification for rounds that failed to pass the cleanup process for 3 times.
 				// the symbol of the round will be blocked for opening new round until the issue is resolved.
 				task.Notified = true
-				bbgo.Notify("💥 Failed to handle closed round after %d retries. Manual intervention is required!",
+				bbgo.Notify("💥 Failed to handle closed round after %d retries. Manual intervention is required.",
 					s.MaxClosedRetryCnt,
-					round,
+					round.NewNotification(true),
 				)
 			}
 			continue
@@ -657,7 +709,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		if err := s.handleClosedRound(closeRoundCtx, task, tickTime); err != nil {
 			s.logger.WithError(err).Errorf("failed to handle closed round: %s", task.Round)
 		} else {
-			bbgo.Notify("✅ Successfully handled closed round: %s", round.String(), round)
+			bbgo.Notify("✅ Successfully handled closed round: %s", round.String(), round.NewNotification(false))
 			s.logger.Infof("successfully handled closed round: %s", task.Round)
 			delete(s.closedRoundTasks, task.Round.SpotSymbol())
 		}
@@ -703,7 +755,7 @@ func (s *Strategy) transitRoundState(ctx context.Context, round *ArbitrageRound,
 		if round.State() == RoundReady {
 			bbgo.Notify("🟢 Round entered ready state: %s",
 				round.SpotSymbol(),
-				round,
+				round.NewNotification(false),
 			)
 		}
 	case RoundReady:
@@ -711,7 +763,7 @@ func (s *Strategy) transitRoundState(ctx context.Context, round *ArbitrageRound,
 		if round.State() == RoundClosing {
 			bbgo.Notify("🔴 Round is closing: %s",
 				round.SpotSymbol(),
-				round,
+				round.NewNotification(false),
 			)
 		}
 	case RoundClosing:
@@ -738,7 +790,7 @@ func (s *Strategy) transitOpeningOrReadyRound(ctx context.Context, round *Arbitr
 				round.TriggeredFundingRate(),
 				fundingRate.LastFundingRate,
 				s.CriticalErrorConfig.MaxFundingRateFlip,
-				round,
+				round.NewNotification(true),
 			)
 		}
 		if round.NumHoldingIntervals(currentTime) >= round.MinHoldingIntervals() {
@@ -884,7 +936,7 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 			s.pendingRounds[selectedCandidate.Symbol] = &PendingRound{
 				Round: round,
 			}
-			bbgo.Notify("🆕 Created new pending round: %s", round.SpotSymbol(), round)
+			bbgo.Notify("🆕 Created new pending round: %s", round.SpotSymbol(), round.NewNotification(false))
 		}
 	}
 }
@@ -1161,7 +1213,7 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 			bbgo.Notify("⬅️ Transferred %s %s back to spot account",
 				balance.Available,
 				asset,
-				round,
+				round.NewNotification(false),
 			)
 		}
 	}

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1229,7 +1229,10 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 		// long futures -> transfer quote currency
 		asset = round.FuturesMarket().QuoteCurrency
 	}
-	account := s.futuresSession.GetAccount()
+	account, err := s.futuresSession.UpdateAccount(ctx)
+	if err != nil {
+		return fmt.Errorf("[handleClosedRound] failed to update futures account when handling round exit: %w", err)
+	}
 	balance, ok := account.Balance(asset)
 	if !ok {
 		return fmt.Errorf("[handleClosedRound] balance not found for asset %s when handling round exit: %s", asset, round)

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -77,8 +77,8 @@ type Strategy struct {
 	MarketSelectionConfig *MarketSelectionConfig      `json:"marketSelection,omitempty"`
 	MaxPositionExposure   map[string]fixedpoint.Value `json:"maxPositionExposure"`
 
-	HaltRoundNotificationInterval types.Duration       `json:"haltRoundNotificationInterval"`
-	lastHaltNotificationTime      map[string]time.Time `json:"lastHaltNotificationTime"`
+	HaltRoundNotificationInterval types.Duration `json:"haltRoundNotificationInterval"`
+	haltNotificationLimiters      map[string]*rate.Limiter
 
 	CriticalErrorConfig CriticalErrorConfig                            `json:"criticalErrorConfig"`
 	CircuitBreakers     map[string]*circuitbreaker.BasicCircuitBreaker `json:"circuitBreakers"`
@@ -210,7 +210,7 @@ func (s *Strategy) Initialize() error {
 	if s.CircuitBreakers == nil {
 		s.CircuitBreakers = make(map[string]*circuitbreaker.BasicCircuitBreaker)
 	}
-	s.lastHaltNotificationTime = make(map[string]time.Time)
+	s.haltNotificationLimiters = make(map[string]*rate.Limiter)
 	return nil
 }
 
@@ -401,7 +401,7 @@ func (s *Strategy) CrossRun(
 		s.futuresGeneralOrderExecutors[symbol] = futuresExecutor
 		return nil
 	}
-	for _, symbol := range candidateSymbols {
+	for _, symbol := range s.candidateSymbols {
 		if err := setupGeneralExecutorsForSymbol(symbol); err != nil {
 			return err
 		}
@@ -496,6 +496,7 @@ func (s *Strategy) CrossRun(
 		}
 		round.SetSlackAlert(s.SlackAlert)
 	}
+
 	for _, symbol := range s.candidateSymbols {
 		if breaker, found := s.CircuitBreakers[symbol]; !found {
 			s.CircuitBreakers[symbol] = s.defaultBreaker(symbol)
@@ -513,6 +514,22 @@ func (s *Strategy) CrossRun(
 		if closedRound.RetryCnt >= s.MaxClosedRetryCnt {
 			closedRound.RetryCnt--
 			closedRound.Notified = false
+		}
+	}
+
+	// setup halt notification limiters
+	for _, symbol := range s.candidateSymbols {
+		s.haltNotificationLimiters[symbol] = rate.NewLimiter(
+			rate.Every(s.HaltRoundNotificationInterval.Duration()),
+			1,
+		)
+	}
+	for _, round := range s.allRounds() {
+		if _, found := s.haltNotificationLimiters[round.SpotSymbol()]; !found {
+			s.haltNotificationLimiters[round.SpotSymbol()] = rate.NewLimiter(
+				rate.Every(s.HaltRoundNotificationInterval.Duration()),
+				1,
+			)
 		}
 	}
 
@@ -656,7 +673,6 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 				spotFilled,
 				futuresFilled,
 			)
-			s.lastHaltNotificationTime[round.SpotSymbol()] = tickTime
 			bbgo.Notify("💥 Round %s halted due to large hedge deviation. Manual intervention is required.",
 				roundSymbol,
 				round.NewCriticalNotification(),
@@ -665,8 +681,6 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 			// the deviation is back to normal, resume the round
 			haltedAt := round.HaltedAt()
 			round.Resume()
-			// remove the last notification time
-			delete(s.lastHaltNotificationTime, roundSymbol)
 			s.logger.Infof("round %s resumed as hedge deviation back to normal: %s, spot filled: %s, futures filled: %s",
 				roundSymbol,
 				deviation,
@@ -684,9 +698,8 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		if round.IsHalted() {
 			haltedAt := round.HaltedAt()
 			elapsed := tickTime.Sub(haltedAt)
-			lastNotifyTime, found := s.lastHaltNotificationTime[round.SpotSymbol()]
-			if !found || tickTime.Sub(lastNotifyTime) > s.HaltRoundNotificationInterval.Duration() {
-				s.lastHaltNotificationTime[roundSymbol] = tickTime
+			limiter, found := s.haltNotificationLimiters[round.SpotSymbol()]
+			if found && limiter.AllowN(tickTime, 1) {
 				// send notification for rounds that have been halted for a while.
 				bbgo.Notify("💥 Round %s halted for %s (since %s). Manual intervention is required",
 					roundSymbol,

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -77,6 +77,9 @@ type Strategy struct {
 	MarketSelectionConfig *MarketSelectionConfig      `json:"marketSelection,omitempty"`
 	MaxPositionExposure   map[string]fixedpoint.Value `json:"maxPositionExposure"`
 
+	HaltRoundNotificationInterval types.Duration       `json:"haltRoundNotificationInterval"`
+	lastHaltNotificationTime      map[string]time.Time `json:"lastHaltNotificationTime"`
+
 	CriticalErrorConfig CriticalErrorConfig                            `json:"criticalErrorConfig"`
 	CircuitBreakers     map[string]*circuitbreaker.BasicCircuitBreaker `json:"circuitBreakers"`
 
@@ -173,6 +176,9 @@ func (s *Strategy) Defaults() error {
 		s.MaxClosedRetryCnt = 3
 	}
 
+	if s.HaltRoundNotificationInterval.Duration() == 0 {
+		s.HaltRoundNotificationInterval = types.Duration(time.Minute * 30)
+	}
 	s.CriticalErrorConfig.Defaults()
 
 	return nil
@@ -204,6 +210,7 @@ func (s *Strategy) Initialize() error {
 	if s.CircuitBreakers == nil {
 		s.CircuitBreakers = make(map[string]*circuitbreaker.BasicCircuitBreaker)
 	}
+	s.lastHaltNotificationTime = make(map[string]time.Time)
 	return nil
 }
 
@@ -540,6 +547,10 @@ func (s *Strategy) CrossRun(
 			if round.HasOrder(trade.OrderID) {
 				round.HandleSpotTrade(trade, trade.Time.Time())
 
+				spotOrderBook := s.spotOrderBooks[round.SpotSymbol()].Copy()
+				futuresOrderBook := s.futuresOrderBooks[round.FuturesSymbol()].Copy()
+				round.Tick(trade.Time.Time(), spotOrderBook, futuresOrderBook)
+
 				spotFilledPosition := round.SpotWorker().FilledPosition()
 				filledRatio := spotFilledPosition.Div(round.TriggeredFundingRate()).Abs()
 				if round.State() == RoundClosing {
@@ -635,31 +646,35 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		// calculate the deviation of the unhedged position
 		deviation := fixedpoint.One.Sub(futuresFilled.Div(spotFilled)).Abs()
 		deviationTooLarge := deviation.Compare(s.CriticalErrorConfig.MaxHedgeDeviation) > 0
+		roundSymbol := round.SpotSymbol()
 		if !halted && deviationTooLarge {
 			// the round is originally not halted but the deviation is too large -> we need to halt the round
 			round.Halt(tickTime)
 			s.logger.Warnf("round %s halted due to large hedge deviation: %s, spot filled: %s, futures filled: %s",
-				round.SpotSymbol(),
+				roundSymbol,
 				deviation,
 				spotFilled,
 				futuresFilled,
 			)
+			s.lastHaltNotificationTime[round.SpotSymbol()] = tickTime
 			bbgo.Notify("💥 Round %s halted due to large hedge deviation. Manual intervention is required.",
-				round.SpotSymbol(),
+				roundSymbol,
 				round.NewNotification(true),
 			)
 		} else if halted && !deviationTooLarge {
 			// the deviation is back to normal, resume the round
 			haltedAt := round.HaltedAt()
 			round.Resume()
+			// remove the last notification time
+			delete(s.lastHaltNotificationTime, roundSymbol)
 			s.logger.Infof("round %s resumed as hedge deviation back to normal: %s, spot filled: %s, futures filled: %s",
-				round.SpotSymbol(),
+				roundSymbol,
 				deviation,
 				spotFilled,
 				futuresFilled,
 			)
 			bbgo.Notify("✅ Round %s resumed as hedge deviation back to normal. It was halted at %s.",
-				round.SpotSymbol(),
+				roundSymbol,
 				haltedAt.Format(time.RFC3339),
 				round.NewNotification(false),
 			)
@@ -667,6 +682,19 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 
 		// round is still halted, skip the rest of the processing
 		if round.IsHalted() {
+			haltedAt := round.HaltedAt()
+			elapsed := tickTime.Sub(haltedAt)
+			lastNotifyTime, found := s.lastHaltNotificationTime[round.SpotSymbol()]
+			if !found || tickTime.Sub(lastNotifyTime) > s.HaltRoundNotificationInterval.Duration() {
+				s.lastHaltNotificationTime[roundSymbol] = tickTime
+				// send notification for rounds that have been halted for a while.
+				bbgo.Notify("💥 Round %s halted for %s (since %s). Manual intervention is required",
+					roundSymbol,
+					elapsed.String(),
+					haltedAt.Format(time.RFC3339),
+					round.NewNotification(true),
+				)
+			}
 			continue
 		}
 

--- a/pkg/strategy/xfundingv2/twap.go
+++ b/pkg/strategy/xfundingv2/twap.go
@@ -129,11 +129,6 @@ func (w *TWAPWorker) AveragePrice() fixedpoint.Value {
 	return tradingutil.AveragePriceFromTrades(trades)
 }
 
-// AddTrade adds a trade to the worker if it belongs to an order managed by this worker.
-func (w *TWAPWorker) AddTrade(trade types.Trade) bool {
-	return w.syncState.TWAPExecutor.AddTrade(trade)
-}
-
 func (w *TWAPWorker) FilledPosition() fixedpoint.Value {
 	trades := w.syncState.TWAPExecutor.AllTrades()
 	position := fixedpoint.Zero

--- a/pkg/strategy/xfundingv2/twap_test.go
+++ b/pkg/strategy/xfundingv2/twap_test.go
@@ -72,7 +72,7 @@ func processTrade(worker *TWAPWorker, executor *bbgo.GeneralOrderExecutor, trade
 	// Process trade to update position
 	executor.TradeCollector().ProcessTrade(trade)
 	// Add trade to the worker (simulates the strategy-level OnTrade callback)
-	worker.AddTrade(trade)
+	worker.Executor().AddTrade(trade)
 }
 
 // makeTrade creates a trade with fee in BNB to avoid affecting base/quote quantity


### PR DESCRIPTION
- Halt rounds automatically when spot-futures hedge deviation is too large
    - Add halt and resume functionality to `ArbitrageRound` for pausing/resuming TWAP execution
- Refactor out trivial `TWAPWorker.AddTrade` in favor of `Executor().AddTrade()`
- Simplify the futures target position logics
    - the futures target position is always synced to the negation of the spot filled position to stay delta-neutral