### PR TITLE
fix: ExchangeSession.UnmarshalJSON infinite recursion

### DIFF
--- a/pkg/bbgo/session.go
+++ b/pkg/bbgo/session.go
@@ -356,8 +356,8 @@ func (session *ExchangeSession) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("unmarshal exchange session config: %w", err)
 	}
 
-	// then unmarshal the rest of the fields
-	if err := json.Unmarshal(data, session); err != nil {
+	type exchangeSessionAlias ExchangeSession
+	if err := json.Unmarshal(data, (*exchangeSessionAlias)(session)); err != nil {
 		return fmt.Errorf("unmarshal exchange session: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- `ExchangeSession.UnmarshalJSON` calls `json.Unmarshal(data, session)` which dispatches back to `UnmarshalJSON`, causing infinite recursion and a fatal stack overflow at runtime.
- Fix: use a type alias (`exchangeSessionAlias`) to break the recursion chain, so `json.Unmarshal` uses the default decoder.

## Root cause

Commit `844601fe4` introduced the `UnmarshalJSON` method. The second unmarshal call passes `session` (a `*ExchangeSession`) directly, which triggers the custom `UnmarshalJSON` again — infinite loop.

```go
// Before (bug):
json.Unmarshal(data, session)  // calls UnmarshalJSON → infinite recursion

// After (fix):
type exchangeSessionAlias ExchangeSession
json.Unmarshal(data, (*exchangeSessionAlias)(session))  // uses default decoder
```

## How it was found

The optimizer (`bbgo optimize`) crashes with `fatal error: stack overflow` when parsing YAML configs containing exchange session definitions.

## Test plan

- [x] Verified `bbgo-slim optimize` completes without stack overflow after fix
- [x] Verified `bbgo-slim backtest` runs correctly with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)