### PR TITLE
feat(dashboard): improve order flow widget rendering and add price aggregation

### DIFF
--- a/pkg/cmd/dashboard.go
+++ b/pkg/cmd/dashboard.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/c9s/bbgo/pkg/cmd/widget"
 	"github.com/c9s/bbgo/pkg/exchange"
+	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
 	ui "github.com/gizak/termui/v3"
 	"github.com/spf13/cobra"
@@ -19,6 +20,7 @@ func init() {
 	orderFlowCmd.MarkFlagRequired("exchange")
 	orderFlowCmd.Flags().String("symbol", "", "trading pair symbol")
 	orderFlowCmd.MarkFlagRequired("symbol")
+	orderFlowCmd.Flags().String("aggregate", "0", "aggregate price unit; 0 disables aggregation")
 	dashboardCmd.AddCommand(orderFlowCmd)
 	RootCmd.AddCommand(dashboardCmd)
 }
@@ -52,6 +54,15 @@ var orderFlowCmd = &cobra.Command{
 		if len(exName) == 0 || len(symbol) == 0 {
 			return errors.New("--exchange and --symbol are required")
 		}
+		aggregate, err := cmd.Flags().GetString("aggregate")
+		if err != nil {
+			return err
+		}
+		aggregateUnit, err := fixedpoint.NewFromString(aggregate)
+		if err != nil {
+			return err
+		}
+
 		// create a new public trade stream
 		exMin, err := exchange.NewWithEnvVarPrefix(types.ExchangeName(exName), strings.ToUpper(exName))
 		ex, ok := exMin.(types.Exchange)
@@ -64,6 +75,7 @@ var orderFlowCmd = &cobra.Command{
 		w := widget.NewOrderFlowWidget()
 		w.Title = " Order Flow Circles (總量正規化) "
 		stream.OnMarketTrade(types.TradeWith(symbol, func(trade types.Trade) {
+			trade.Price = aggregatePrice(trade.Price, aggregateUnit)
 			w.UpdateTrade(trade)
 		}))
 		stream.SetPublicOnly()
@@ -103,4 +115,11 @@ var orderFlowCmd = &cobra.Command{
 			}
 		}
 	},
+}
+
+func aggregatePrice(price, aggregateUnit fixedpoint.Value) fixedpoint.Value {
+	if aggregateUnit.Sign() <= 0 {
+		return price
+	}
+	return price.Div(aggregateUnit).Floor().Mul(aggregateUnit)
 }

--- a/pkg/cmd/dashboard.go
+++ b/pkg/cmd/dashboard.go
@@ -20,7 +20,7 @@ func init() {
 	orderFlowCmd.MarkFlagRequired("exchange")
 	orderFlowCmd.Flags().String("symbol", "", "trading pair symbol")
 	orderFlowCmd.MarkFlagRequired("symbol")
-	orderFlowCmd.Flags().String("aggregate", "0", "aggregate price unit; 0 disables aggregation")
+	orderFlowCmd.Flags().Float64("aggregate", 0, "aggregate price unit; 0 disables aggregation")
 	dashboardCmd.AddCommand(orderFlowCmd)
 	RootCmd.AddCommand(dashboardCmd)
 }
@@ -54,14 +54,11 @@ var orderFlowCmd = &cobra.Command{
 		if len(exName) == 0 || len(symbol) == 0 {
 			return errors.New("--exchange and --symbol are required")
 		}
-		aggregate, err := cmd.Flags().GetString("aggregate")
+		aggregate, err := cmd.Flags().GetFloat64("aggregate")
 		if err != nil {
 			return err
 		}
-		aggregateUnit, err := fixedpoint.NewFromString(aggregate)
-		if err != nil {
-			return err
-		}
+		aggregateUnit := fixedpoint.NewFromFloat(aggregate)
 
 		// create a new public trade stream
 		exMin, err := exchange.NewWithEnvVarPrefix(types.ExchangeName(exName), strings.ToUpper(exName))

--- a/pkg/cmd/dashboard_test.go
+++ b/pkg/cmd/dashboard_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	testifyassert "github.com/stretchr/testify/assert"
+)
+
+func TestAggregatePrice(t *testing.T) {
+	price := fixedpoint.MustNewFromString("63773.91")
+
+	tests := []struct {
+		name string
+		unit fixedpoint.Value
+		want fixedpoint.Value
+	}{
+		{
+			name: "zero disables aggregation",
+			unit: fixedpoint.Zero,
+			want: fixedpoint.MustNewFromString("63773.91"),
+		},
+		{
+			name: "negative disables aggregation",
+			unit: fixedpoint.MustNewFromString("-1"),
+			want: fixedpoint.MustNewFromString("63773.91"),
+		},
+		{
+			name: "one tenth",
+			unit: fixedpoint.MustNewFromString("0.1"),
+			want: fixedpoint.MustNewFromString("63773.9"),
+		},
+		{
+			name: "cent",
+			unit: fixedpoint.MustNewFromString("0.01"),
+			want: fixedpoint.MustNewFromString("63773.91"),
+		},
+		{
+			name: "one",
+			unit: fixedpoint.One,
+			want: fixedpoint.MustNewFromString("63773"),
+		},
+		{
+			name: "five",
+			unit: fixedpoint.NewFromInt(5),
+			want: fixedpoint.MustNewFromString("63770"),
+		},
+		{
+			name: "ten",
+			unit: fixedpoint.NewFromInt(10),
+			want: fixedpoint.MustNewFromString("63770"),
+		},
+		{
+			name: "larger fractional step",
+			unit: fixedpoint.MustNewFromString("2.5"),
+			want: fixedpoint.MustNewFromString("63772.5"),
+		},
+		{
+			name: "sub-unit floors down, not to nearest",
+			unit: fixedpoint.MustNewFromString("0.5"),
+			want: fixedpoint.MustNewFromString("63773.5"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testifyassert.Equal(t, tt.want, aggregatePrice(price, tt.unit))
+		})
+	}
+}

--- a/pkg/cmd/widget/orderflow.go
+++ b/pkg/cmd/widget/orderflow.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"image"
 	"math"
+	"sort"
+	"sync"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
@@ -11,6 +13,16 @@ import (
 )
 
 const brailleOffset = '\u2800'
+
+// maxOrderFlowSideLevels caps how many price levels are shown above and below
+// the POC. All traded prices are retained; only the display is windowed.
+const maxOrderFlowSideLevels = 10
+
+const (
+	priceColWidth = 13
+	deltaColWidth = 10
+	volColWidth   = 16
+)
 
 var brailleDots = [4][2]rune{
 	{0x01, 0x08},
@@ -35,62 +47,73 @@ func (p *PriceLevel) TotalVol() fixedpoint.Value {
 
 type OrderFlowWidget struct {
 	ui.Block
-	levels     []PriceLevel
-	indicesMap map[fixedpoint.Value]int
-}
-
-func (w *OrderFlowWidget) SetLevels(levels []PriceLevel) {
-	w.levels = levels
-	for i, lvl := range levels {
-		w.indicesMap[lvl.Price] = i
-	}
+	mu     sync.Mutex
+	levels []PriceLevel
 }
 
 func (w *OrderFlowWidget) UpdateTrade(trade types.Trade) {
-	idx, ok := w.indicesMap[trade.Price]
-	if !ok {
-		newLevel := PriceLevel{
-			Price: trade.Price,
-		}
-		if trade.Side == types.SideTypeBuy {
-			newLevel.BidVol = trade.Quantity
-		} else {
-			newLevel.AskVol = trade.Quantity
-		}
-		w.levels = append(w.levels, newLevel)
-		w.indicesMap[trade.Price] = len(w.levels) - 1
-	} else {
-		if trade.Side == types.SideTypeBuy {
-			w.levels[idx].BidVol = w.levels[idx].BidVol.Add(trade.Quantity)
-		} else {
-			w.levels[idx].AskVol = w.levels[idx].AskVol.Add(trade.Quantity)
-		}
+	level := PriceLevel{
+		Price: trade.Price,
 	}
+	if trade.Side == types.SideTypeBuy {
+		level.BidVol = trade.Quantity
+	} else {
+		level.AskVol = trade.Quantity
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.upsertLevel(level)
+}
+
+func (w *OrderFlowWidget) upsertLevel(level PriceLevel) {
+	for idx := range w.levels {
+		if !w.levels[idx].Price.Eq(level.Price) {
+			continue
+		}
+		w.levels[idx].BidVol = w.levels[idx].BidVol.Add(level.BidVol)
+		w.levels[idx].AskVol = w.levels[idx].AskVol.Add(level.AskVol)
+		return
+	}
+
+	w.levels = append(w.levels, level)
+}
+
+func (w *OrderFlowWidget) sortedLevelsSnapshot() []PriceLevel {
+	w.mu.Lock()
+	levels := append([]PriceLevel(nil), w.levels...)
+	w.mu.Unlock()
+
+	sort.Slice(levels, func(i, j int) bool {
+		return levels[i].Price.Compare(levels[j].Price) > 0
+	})
+
+	return levels
 }
 
 func NewOrderFlowWidget() *OrderFlowWidget {
 	return &OrderFlowWidget{
-		Block:      *ui.NewBlock(),
-		indicesMap: make(map[fixedpoint.Value]int),
+		Block: *ui.NewBlock(),
 	}
 }
 
 func (w *OrderFlowWidget) Draw(buf *ui.Buffer) {
 	w.Block.Draw(buf)
 
-	if len(w.levels) == 0 {
+	levels := w.sortedLevelsSnapshot()
+	if len(levels) == 0 {
 		return
 	}
 
 	maxVol := fixedpoint.Zero
 	totalDelta := fixedpoint.Zero
 	pocPrice := fixedpoint.Zero
-	pocVol := fixedpoint.Zero
-	for _, lvl := range w.levels {
+	pocIdx := 0
+	for idx, lvl := range levels {
 		if v := lvl.TotalVol(); v.Compare(maxVol) > 0 {
 			maxVol = v
 			pocPrice = lvl.Price
-			pocVol = v
+			pocIdx = idx
 		}
 		totalDelta = totalDelta.Add(lvl.Delta())
 	}
@@ -99,10 +122,8 @@ func (w *OrderFlowWidget) Draw(buf *ui.Buffer) {
 	}
 
 	inner := w.Inner
-	numLevels := len(w.levels)
 
-	priceColWidth := 8
-	infoColWidth := 16
+	infoColWidth := deltaColWidth + volColWidth
 	circleStart := inner.Min.X + priceColWidth
 	circleEnd := inner.Max.X - infoColWidth
 	circleWidth := circleEnd - circleStart
@@ -111,87 +132,126 @@ func (w *OrderFlowWidget) Draw(buf *ui.Buffer) {
 	}
 
 	availableHeight := inner.Max.Y - inner.Min.Y - 2
+
+	// Show at most maxOrderFlowSideLevels above and below the POC, shrinking
+	// further if the terminal cannot fit that many rows.
+	const minRowHeight = 2
+	maxVisible := availableHeight / minRowHeight
+	if maxVisible < 1 {
+		return
+	}
+
+	side := maxOrderFlowSideLevels
+	if half := (maxVisible - 1) / 2; half < side {
+		side = half
+	}
+
+	start := pocIdx - side
+	if start < 0 {
+		start = 0
+	}
+	end := pocIdx + side + 1
+	if end > len(levels) {
+		end = len(levels)
+	}
+	visibleLevels := levels[start:end]
+	hiddenBelow := len(levels) - end
+
+	numLevels := len(visibleLevels)
 	rowHeight := availableHeight / numLevels
-	if rowHeight < 2 {
-		rowHeight = 2
+	if rowHeight < minRowHeight {
+		rowHeight = minRowHeight
 	}
 
 	maxRadius := math.Min(float64(circleWidth), float64(rowHeight*2)) * 0.85
+	cyBraille := float64(rowHeight*4) / 2.0
 
-	for i, lvl := range w.levels {
-		rowTopY := inner.Min.Y + i*rowHeight
+	// Circles and the price/delta/volume columns occupy disjoint x-ranges, so a
+	// single pass in price order is enough; on overlap the lower price's circle
+	// paints over the higher one.
+	for idx, lvl := range visibleLevels {
+		rowTopY := inner.Min.Y + idx*rowHeight
 		rowCenterY := rowTopY + rowHeight/2
-		if rowCenterY >= inner.Max.Y-2 {
-			break
-		}
 
 		delta := lvl.Delta()
 		totalVol := lvl.TotalVol()
-		ratio := totalVol.Div(maxVol).Float64()
-		radius := ratio * maxRadius
+		radius := totalVol.Div(maxVol).Float64() * maxRadius
 		if radius < 1.5 {
 			radius = 1.5
 		}
 
 		color := ui.ColorGreen
-		if delta < 0 {
+		if delta.Sign() < 0 {
 			color = ui.ColorRed
-		} else if delta == 0 {
-			color = ui.ColorYellow
+		} else if delta.IsZero() {
+			color = ui.ColorWhite
 		}
-
-		priceStyle := ui.NewStyle(ui.ColorWhite)
-		if lvl.Price.Eq(pocPrice) {
-			priceStyle = ui.NewStyle(ui.ColorYellow, ui.ColorClear, ui.ModifierBold)
-		}
-		buf.SetString(fmt.Sprintf("%.5f", lvl.Price.Float64()), priceStyle, image.Pt(inner.Min.X, rowCenterY))
-
-		cxBraille := float64(circleWidth)
-		cyBraille := float64(rowHeight*4) / 2.0
 
 		for ty := 0; ty < rowHeight; ty++ {
 			termY := rowTopY + ty
+			if termY < inner.Min.Y {
+				continue
+			}
 			if termY >= inner.Max.Y-2 {
 				break
 			}
 			for tx := 0; tx < circleWidth; tx++ {
-				termX := circleStart + tx
 				var brailleRune rune
 				for sy := 0; sy < 4; sy++ {
 					for sx := 0; sx < 2; sx++ {
-						bx := float64(tx*2 + sx)
-						by := float64(ty*4 + sy)
-						dx := bx - cxBraille
-						dy := by - cyBraille
+						dx := float64(tx*2+sx) - float64(circleWidth)
+						dy := float64(ty*4+sy) - cyBraille
 						if dx*dx+dy*dy <= radius*radius {
 							brailleRune |= brailleDots[sy][sx]
 						}
 					}
 				}
 				if brailleRune != 0 {
+					pt := image.Pt(circleStart+tx, termY)
+					// Merge dots with any circle already drawn here so a smaller
+					// circle drawn later cannot erase a larger one's filled cell.
+					if existing := buf.GetCell(pt).Rune; existing >= brailleOffset && existing < brailleOffset+0x100 {
+						brailleRune |= existing - brailleOffset
+					}
 					buf.SetCell(ui.Cell{
 						Rune:  brailleOffset + brailleRune,
 						Style: ui.NewStyle(color),
-					}, image.Pt(termX, termY))
+					}, pt)
 				}
 			}
 		}
 
-		deltaStr := fmt.Sprintf(" %.4f", delta.Float64())
-		buf.SetString(deltaStr, ui.NewStyle(color), image.Pt(circleEnd-9, rowCenterY))
+		priceStyle := ui.NewStyle(ui.ColorWhite)
+		if lvl.Price.Eq(pocPrice) {
+			priceStyle = ui.NewStyle(ui.ColorYellow, ui.ColorClear, ui.ModifierBold)
+		}
+		setPaddedString(buf, fmt.Sprintf("%.5f", lvl.Price.Float64()), priceStyle, image.Pt(inner.Min.X, rowCenterY), priceColWidth)
+
+		deltaStr := fmt.Sprintf("% .4f", delta.Float64())
+		setPaddedString(buf, deltaStr, ui.NewStyle(color), image.Pt(circleEnd, rowCenterY), deltaColWidth)
 
 		volStr := fmt.Sprintf(" V:%.5f", totalVol.Float64())
-		buf.SetString(volStr, ui.NewStyle(ui.ColorCyan), image.Pt(circleEnd, rowCenterY))
+		setPaddedString(buf, volStr, ui.NewStyle(ui.ColorCyan), image.Pt(circleEnd+deltaColWidth, rowCenterY), volColWidth)
 	}
 
 	summaryY := inner.Max.Y - 1
 	deltaColor := ui.ColorGreen
-	if totalDelta < 0 {
+	if totalDelta.Sign() < 0 {
 		deltaColor = ui.ColorRed
 	}
 	summary := fmt.Sprintf(
 		" Total Δ: %.4f | POC: %.5f (Vol %.5f)",
-		totalDelta.Float64(), pocPrice.Float64(), pocVol.Float64())
+		totalDelta.Float64(), pocPrice.Float64(), maxVol.Float64())
+	if start > 0 || hiddenBelow > 0 {
+		summary += fmt.Sprintf(" | hidden ↑%d ↓%d", start, hiddenBelow)
+	}
 	buf.SetString(summary, ui.NewStyle(deltaColor), image.Pt(inner.Min.X, summaryY))
 	buf.SetString(" [q] quit", ui.NewStyle(ui.ColorWhite), image.Pt(inner.Max.X-10, summaryY))
+}
+
+func setPaddedString(buf *ui.Buffer, s string, style ui.Style, point image.Point, width int) {
+	if len(s) > width {
+		s = s[:width]
+	}
+	buf.SetString(fmt.Sprintf("%-*s", width, s), style, point)
 }

--- a/pkg/cmd/widget/orderflow.go
+++ b/pkg/cmd/widget/orderflow.go
@@ -163,15 +163,54 @@ func (w *OrderFlowWidget) Draw(buf *ui.Buffer) {
 		rowHeight = minRowHeight
 	}
 
+	// Position rows proportionally to price so the vertical gap between levels
+	// reflects the actual price distance, not just their rank.
+	minPrice := visibleLevels[0].Price
+	maxPrice := visibleLevels[0].Price
+	for _, lvl := range visibleLevels {
+		if lvl.Price.Compare(minPrice) < 0 {
+			minPrice = lvl.Price
+		}
+		if lvl.Price.Compare(maxPrice) > 0 {
+			maxPrice = lvl.Price
+		}
+	}
+	priceRange := maxPrice.Sub(minPrice)
+
+	drawMinY := inner.Min.Y + rowHeight/2
+	drawMaxY := inner.Max.Y - 3 - rowHeight/2
+	if drawMaxY < drawMinY {
+		drawMinY = inner.Min.Y
+		drawMaxY = inner.Max.Y - 3
+	}
+	if drawMaxY < drawMinY {
+		return
+	}
+
 	maxRadius := math.Min(float64(circleWidth), float64(rowHeight*2)) * 0.85
 	cyBraille := float64(rowHeight*4) / 2.0
 
 	// Circles and the price/delta/volume columns occupy disjoint x-ranges, so a
 	// single pass in price order is enough; on overlap the lower price's circle
 	// paints over the higher one.
-	for idx, lvl := range visibleLevels {
-		rowTopY := inner.Min.Y + idx*rowHeight
-		rowCenterY := rowTopY + rowHeight/2
+	lastRowCenterY := drawMinY - 1
+	for _, lvl := range visibleLevels {
+		// Map price → Y. Higher price sits nearer the top (smaller Y); equal
+		// prices share the mid-line. Nudge down by one row when two levels would
+		// collide so every visible level stays readable.
+		rowCenterY := (drawMinY + drawMaxY) / 2
+		if !priceRange.IsZero() {
+			priceOffset := maxPrice.Sub(lvl.Price).Div(priceRange).Float64()
+			rowCenterY = drawMinY + int(math.Round(priceOffset*float64(drawMaxY-drawMinY)))
+		}
+		if rowCenterY <= lastRowCenterY {
+			rowCenterY = lastRowCenterY + 1
+		}
+		if rowCenterY > drawMaxY || rowCenterY >= inner.Max.Y-2 {
+			break
+		}
+		lastRowCenterY = rowCenterY
+		rowTopY := rowCenterY - rowHeight/2
 
 		delta := lvl.Delta()
 		totalVol := lvl.TotalVol()

--- a/pkg/cmd/widget/orderflow.go
+++ b/pkg/cmd/widget/orderflow.go
@@ -163,8 +163,7 @@ func (w *OrderFlowWidget) Draw(buf *ui.Buffer) {
 		rowHeight = minRowHeight
 	}
 
-	// Position rows proportionally to price so the vertical gap between levels
-	// reflects the actual price distance, not just their rank.
+	// Price range of the visible levels, used to position rows proportionally.
 	minPrice := visibleLevels[0].Price
 	maxPrice := visibleLevels[0].Price
 	for _, lvl := range visibleLevels {
@@ -177,6 +176,8 @@ func (w *OrderFlowWidget) Draw(buf *ui.Buffer) {
 	}
 	priceRange := maxPrice.Sub(minPrice)
 
+	// Band the rows may occupy: half a row of margin top and bottom (so circles
+	// aren't clipped) and three rows reserved at the bottom for the summary.
 	drawMinY := inner.Min.Y + rowHeight/2
 	drawMaxY := inner.Max.Y - 3 - rowHeight/2
 	if drawMaxY < drawMinY {
@@ -187,29 +188,43 @@ func (w *OrderFlowWidget) Draw(buf *ui.Buffer) {
 		return
 	}
 
+	// Place every row at its proportional ideal, then de-overlap so clustered
+	// prices that round to the same Y keep a one-row gap. maxVisible caps the
+	// count so the gaps always fit: no level (the POC included) is ever dropped.
+	const minGap = 1
+	rowCenterYs := make([]int, numLevels)
+	for i, lvl := range visibleLevels {
+		y := (drawMinY + drawMaxY) / 2
+		if !priceRange.IsZero() {
+			priceOffset := maxPrice.Sub(lvl.Price).Div(priceRange).Float64()
+			y = drawMinY + int(math.Round(priceOffset*float64(drawMaxY-drawMinY)))
+		}
+		rowCenterYs[i] = y
+	}
+	// Pass 1 (top→bottom): push colliding rows down.
+	for i := 1; i < numLevels; i++ {
+		if lo := rowCenterYs[i-1] + minGap; rowCenterYs[i] < lo {
+			rowCenterYs[i] = lo
+		}
+	}
+	// Pass 2 (bottom→top): if the tail overran the band, pin it and pull back up.
+	if rowCenterYs[numLevels-1] > drawMaxY {
+		rowCenterYs[numLevels-1] = drawMaxY
+	}
+	for i := numLevels - 2; i >= 0; i-- {
+		if hi := rowCenterYs[i+1] - minGap; rowCenterYs[i] > hi {
+			rowCenterYs[i] = hi
+		}
+	}
+
 	maxRadius := math.Min(float64(circleWidth), float64(rowHeight*2)) * 0.85
 	cyBraille := float64(rowHeight*4) / 2.0
 
 	// Circles and the price/delta/volume columns occupy disjoint x-ranges, so a
 	// single pass in price order is enough; on overlap the lower price's circle
 	// paints over the higher one.
-	lastRowCenterY := drawMinY - 1
-	for _, lvl := range visibleLevels {
-		// Map price → Y. Higher price sits nearer the top (smaller Y); equal
-		// prices share the mid-line. Nudge down by one row when two levels would
-		// collide so every visible level stays readable.
-		rowCenterY := (drawMinY + drawMaxY) / 2
-		if !priceRange.IsZero() {
-			priceOffset := maxPrice.Sub(lvl.Price).Div(priceRange).Float64()
-			rowCenterY = drawMinY + int(math.Round(priceOffset*float64(drawMaxY-drawMinY)))
-		}
-		if rowCenterY <= lastRowCenterY {
-			rowCenterY = lastRowCenterY + 1
-		}
-		if rowCenterY > drawMaxY || rowCenterY >= inner.Max.Y-2 {
-			break
-		}
-		lastRowCenterY = rowCenterY
+	for i, lvl := range visibleLevels {
+		rowCenterY := rowCenterYs[i]
 		rowTopY := rowCenterY - rowHeight/2
 
 		delta := lvl.Delta()

--- a/pkg/cmd/widget/orderflow_test.go
+++ b/pkg/cmd/widget/orderflow_test.go
@@ -1,0 +1,199 @@
+package widget
+
+import (
+	"fmt"
+	"image"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+	ui "github.com/gizak/termui/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderFlowWidget_UpdateTradeAggregatesByPriceAndSide(t *testing.T) {
+	w := NewOrderFlowWidget()
+
+	const n = 50
+	for price := int64(1); price <= n; price++ {
+		w.UpdateTrade(types.Trade{
+			Price:    fixedpoint.NewFromInt(price),
+			Quantity: fixedpoint.One,
+			Side:     types.SideTypeBuy,
+		})
+	}
+
+	// A repeated price merges into the existing level instead of adding one.
+	w.UpdateTrade(types.Trade{
+		Price:    fixedpoint.NewFromInt(15),
+		Quantity: fixedpoint.One,
+		Side:     types.SideTypeBuy,
+	})
+	w.UpdateTrade(types.Trade{
+		Price:    fixedpoint.NewFromInt(15),
+		Quantity: fixedpoint.NewFromInt(3),
+		Side:     types.SideTypeSell,
+	})
+
+	levels := w.sortedLevelsSnapshot()
+	assert.Len(t, levels, n)
+	assert.True(t, hasPriceLevel(levels, fixedpoint.NewFromInt(1)))
+	assert.True(t, hasPriceLevel(levels, fixedpoint.NewFromInt(n)))
+
+	level := requirePriceLevel(t, levels, fixedpoint.NewFromInt(15))
+	assert.Equal(t, fixedpoint.NewFromInt(2), level.BidVol)
+	assert.Equal(t, fixedpoint.NewFromInt(3), level.AskVol)
+
+	// Sorting is a render-time concern; the sorted snapshot is ordered by
+	// descending price without mutating the collected levels.
+	for idx := 1; idx < len(levels); idx++ {
+		assert.GreaterOrEqual(t, levels[idx-1].Price.Compare(levels[idx].Price), 0)
+	}
+}
+
+// At most maxOrderFlowSideLevels levels are shown above and below the POC.
+func TestOrderFlowWidget_DrawWindowsAroundPOC(t *testing.T) {
+	w := NewOrderFlowWidget()
+
+	const pocIdx = 20
+	for i := 0; i < 41; i++ {
+		qty := fixedpoint.One
+		if i == pocIdx {
+			qty = fixedpoint.NewFromInt(50) // unambiguous POC
+		}
+		w.UpdateTrade(types.Trade{
+			Price:    priceFromIndex(i),
+			Quantity: qty,
+			Side:     types.SideTypeBuy,
+		})
+	}
+
+	// Tall enough that height is not the limiter (21 rows × 2).
+	w.SetRect(0, 0, 80, 46)
+	buf := ui.NewBuffer(image.Rect(0, 0, 80, 46))
+	w.Draw(buf)
+
+	text := bufferText(buf)
+	assert.Contains(t, text, priceLabelFromIndex(pocIdx-maxOrderFlowSideLevels))
+	assert.Contains(t, text, priceLabelFromIndex(pocIdx+maxOrderFlowSideLevels))
+	assert.NotContains(t, text, priceLabelFromIndex(pocIdx-maxOrderFlowSideLevels-1))
+	assert.NotContains(t, text, priceLabelFromIndex(pocIdx+maxOrderFlowSideLevels+1))
+
+	// 41 levels, POC centered: 10 windowed off each side of the visible range.
+	assert.Contains(t, text, "hidden ↑10 ↓10")
+}
+
+func TestOrderFlowWidget_DrawEmptyDoesNotPanic(t *testing.T) {
+	w := NewOrderFlowWidget()
+	w.SetRect(0, 0, 80, 40)
+
+	buf := ui.NewBuffer(image.Rect(0, 0, 80, 40))
+	assert.NotPanics(t, func() { w.Draw(buf) })
+}
+
+// UpdateTrade is fed from a stream callback while Draw runs on the render loop;
+// the mutex exists to make that safe. Run under -race to exercise it.
+func TestOrderFlowWidget_ConcurrentUpdateAndDraw(t *testing.T) {
+	w := NewOrderFlowWidget()
+	w.SetRect(0, 0, 80, 40)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			w.UpdateTrade(types.Trade{
+				Price:    priceFromIndex(i % 40),
+				Quantity: fixedpoint.One,
+				Side:     types.SideTypeBuy,
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		buf := ui.NewBuffer(image.Rect(0, 0, 80, 40))
+		for i := 0; i < 1000; i++ {
+			w.Draw(buf)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// The POC must stay on screen when the terminal cannot fit every level and
+// prices are clustered.
+func TestOrderFlowWidget_DrawKeepsPOCVisible(t *testing.T) {
+	w := NewOrderFlowWidget()
+
+	pocPrice := priceFromIndex(15)
+	for i := 0; i < 30; i++ {
+		price := priceFromIndex(i)
+		qty := fixedpoint.One
+		if price.Eq(pocPrice) {
+			qty = fixedpoint.NewFromInt(50) // unambiguous POC
+		}
+		w.UpdateTrade(types.Trade{Price: price, Quantity: qty, Side: types.SideTypeBuy})
+	}
+
+	// Too short for 30 levels at 2 rows each.
+	w.SetRect(0, 0, 80, 14)
+
+	buf := ui.NewBuffer(image.Rect(0, 0, 80, 14))
+	w.Draw(buf)
+
+	assert.Contains(t, bufferText(buf), priceLabelFromIndex(15),
+		"POC price must be rendered even when the terminal cannot fit every level")
+}
+
+func priceFromIndex(i int) fixedpoint.Value {
+	return fixedpoint.MustNewFromString(fmt.Sprintf("100.%02d", i))
+}
+
+func priceLabelFromIndex(i int) string {
+	return fmt.Sprintf("100.%02d000", i)
+}
+
+// bufferText flattens a termui buffer into one line per row.
+func bufferText(buf *ui.Buffer) string {
+	r := buf.Rectangle
+	var lines []string
+	for y := r.Min.Y; y < r.Max.Y; y++ {
+		var sb strings.Builder
+		for x := r.Min.X; x < r.Max.X; x++ {
+			cell := buf.GetCell(image.Pt(x, y))
+			if cell.Rune == 0 {
+				sb.WriteRune(' ')
+				continue
+			}
+			sb.WriteRune(cell.Rune)
+		}
+		lines = append(lines, sb.String())
+	}
+	return strings.Join(lines, "\n")
+}
+
+func hasPriceLevel(levels []PriceLevel, price fixedpoint.Value) bool {
+	for _, lvl := range levels {
+		if lvl.Price.Eq(price) {
+			return true
+		}
+	}
+	return false
+}
+
+func requirePriceLevel(t *testing.T, levels []PriceLevel, price fixedpoint.Value) PriceLevel {
+	t.Helper()
+
+	for _, lvl := range levels {
+		if lvl.Price.Eq(price) {
+			return lvl
+		}
+	}
+
+	t.Fatalf("missing price level %s", price.String())
+	return PriceLevel{}
+}


### PR DESCRIPTION
### Summary
Improves the order flow dashboard's readability, adds a configurable
price-aggregation unit, and scales the price axis proportionally.

### Changes
- **Price aggregation (`--aggregate` flag):** New `--aggregate` flag sets the
  minimum price unit for grouping trades into levels (e.g. `0.1`, `5`). Prices
  are floored to the nearest unit before being bucketed; `0` (default) disables
  aggregation.
- **Proportional price axis:** Each level's vertical position maps linearly to
  its price within the visible range, so the gap between rows mirrors the real
  price distance instead of being evenly spaced. Levels whose prices round to
  the same row are de-overlapped (kept one row apart) rather than dropped, so
  every visible level — the POC included — always gets a row.
- **Sorted levels:** Price levels are rendered in descending order (high → low),
  matching how a typical order book / footprint chart reads.
- **Display limit:** Caps the visible rows to at most 10 levels above and below
  the POC (point of control). A `hidden ↑N ↓N` indicator shows how many levels
  are windowed off each side; the window shrinks with terminal height and the
  POC stays visible even when the terminal is too short to fit every level.
- **Aligned columns:** Fixed-width price / delta / volume columns with padded
  strings so values line up cleanly regardless of length.
- **Thread safety:** `UpdateTrade` (fed from the trade stream) and `Draw`
  (render loop) share a mutex with a sorted snapshot, fixing concurrent
  map/slice access.

### Usage Examples

```bash
go run ./cmd/bbgo dashboard orderflow --exchange binance --symbol BTCUSDT
go run ./cmd/bbgo dashboard orderflow --exchange binance --symbol BTCUSDT --aggregate 0
go run ./cmd/bbgo dashboard orderflow --exchange binance --symbol BTCUSDT --aggregate 0.1
```

### Tests
- `TestAggregatePrice` — flooring behavior across units (zero/negative disable, sub-unit, integer, fractional steps).
- Widget tests — per-price/side aggregation, descending sort, POC windowing + hidden counts, empty draw, and a `-race` concurrency test for `UpdateTrade`/`Draw`.
