### PR TITLE
REFACTOR: [xfundingv2] implement leader-follower pattern for round opening and closing

### DIFF
--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -39,8 +39,9 @@ type FuturesService interface {
 }
 
 type transferRetry struct {
-	Trade     types.Trade `json:"trade"`
-	LastTried time.Time   `json:"lastTried"`
+	Trade     types.Trade             `json:"trade"`
+	LastTried time.Time               `json:"lastTried"`
+	Direction types.TransferDirection `json:"direction"`
 }
 
 type ArbitrageRound struct {
@@ -65,14 +66,12 @@ func NewArbitrageRound(
 	spotExchangeName, futuresExchangeName types.ExchangeName,
 	minHoldingIntervals, fundingIntervalHours int,
 	spotTwap, futuresTwap *TWAPWorker,
-	futuresService FuturesService) *ArbitrageRound {
-	var asset string
-	if spotTwap.TargetPosition().Sign() > 0 {
-		// long spot, short futures -> collateral is base asset
-		asset = spotTwap.Market().BaseCurrency
-	} else {
-		// short spot, long futures -> collateral is quote asset
-		asset = spotTwap.Market().QuoteCurrency
+	futuresService FuturesService,
+	direction types.PositionType,
+) *ArbitrageRound {
+	policy, err := newDirectionPolicy(direction, spotTwap.Market())
+	if err != nil {
+		panic(fmt.Sprintf("NewArbitrageRound: %v", err))
 	}
 	fundingIntervalStart := fundingRate.NextFundingTime.Add(-time.Duration(fundingIntervalHours) * time.Hour)
 	fundingIntervalEnd := fundingRate.NextFundingTime.Add(-time.Second)
@@ -89,10 +88,11 @@ func NewArbitrageRound(
 
 			SpotExchangeName:    spotExchangeName,
 			FuturesExchangeName: futuresExchangeName,
-			Asset:               asset,
+			DirectionPolicy:     policy,
 			State:               RoundPending,
 			RetryTransfers:      make(map[uint64]*transferRetry),
 			SyncedSpotTrades:    make(map[uint64]struct{}),
+			SyncedFuturesTrades: make(map[uint64]struct{}),
 		},
 
 		spotWorker:         spotTwap,
@@ -551,7 +551,7 @@ func (r *ArbitrageRound) doRetryTransfers(currentTime time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.syncState.State != RoundOpening {
+	if r.syncState.State != RoundOpening && r.syncState.State != RoundClosing {
 		return
 	}
 
@@ -564,7 +564,16 @@ func (r *ArbitrageRound) doRetryTransfers(currentTime time.Time) {
 			continue
 		}
 		r.logger.Infof("retry transfer (last tried: %s): %s", transfer.LastTried.Format(time.RFC3339), transfer.Trade)
-		r.handleSpotTrade(transfer.Trade, currentTime)
+		switch transfer.Direction {
+		case types.TransferOut:
+			// the round should be in closing state
+			r.handleFuturesTradeForClose(transfer.Trade, currentTime)
+		case types.TransferIn:
+			// the round should be in opening state
+			r.handleSpotTradeForOpen(transfer.Trade, currentTime)
+		default:
+			r.logger.Warnf("unknown transfer direction for retry: %s", transfer.Direction)
+		}
 	}
 }
 
@@ -577,36 +586,51 @@ func (r *ArbitrageRound) HandleSpotTrade(trade types.Trade, currentTime time.Tim
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.handleSpotTrade(trade, currentTime)
-}
-
-func (r *ArbitrageRound) handleSpotTrade(trade types.Trade, currentTime time.Time) {
 	if ok := r.spotWorker.Executor().AddTrade(trade); !ok {
 		// the trade does not belong to the spot worker, skip
 		return
 	}
-	r.logger.Infof("handling spot trade: %s", trade)
+	if r.syncState.State == RoundOpening {
+		r.logger.Infof("handling spot trade (open): %s", trade)
+		r.handleSpotTradeForOpen(trade, currentTime)
+	} else {
+		// the round is ready or closing, just log the spot trade
+		r.logger.Infof("received spot trade: %s", trade)
+	}
+}
+
+// handleSpotTradeForOpen is the mirror of handleFuturesTradeForClose: during opening, spot is the leader.
+// After each spot fill, the futures position is synced to keep delta-neutral and the collateral asset is
+// transferred to futures so the futures leg can use it as collateral for its offsetting trade.
+func (r *ArbitrageRound) handleSpotTradeForOpen(trade types.Trade, currentTime time.Time) {
 	// no matter the transfer succeeds or not, we should update the futures position so that we can stay in delta-neutral
 	if _, found := r.syncState.SyncedSpotTrades[trade.ID]; !found {
 		// the trade is not synced to futures yet
 		r.syncFuturesPosition(trade)
+		r.syncState.SyncedSpotTrades[trade.ID] = struct{}{}
 	}
-	r.syncState.SyncedSpotTrades[trade.ID] = struct{}{}
 
-	// try to transfer asset from spot to futures as collateral.
-	// if transfer fails, retry in the next tick until it succeeds
+	// move the collateral asset received from the spot fill onto the futures
+	// account so the futures leg can use it as margin.
+	transferAmount := r.syncState.DirectionPolicy.TransferAmountFromSpotTrade(trade)
+	if transferAmount.Sign() <= 0 {
+		// nothing left to transfer (e.g. fees ate the entire fill); still record sync
+		delete(r.syncState.RetryTransfers, trade.ID)
+		return
+	}
 	timedCtx, cancel := context.WithTimeout(
 		r.spotWorker.ctx,
 		time.Second*20,
 	)
 	defer cancel()
+	asset := r.syncState.DirectionPolicy.CollateralAsset()
 	if err := r.futuresService.TransferFuturesAccountAsset(
-		timedCtx, r.syncState.Asset, trade.Quantity, types.TransferIn,
+		timedCtx, asset, transferAmount, types.TransferIn,
 	); err != nil {
 		if transfer, found := r.syncState.RetryTransfers[trade.ID]; !found {
 			bbgo.Notify("🚨 Round spot transfer %s %s failed (%s), retrying: %s",
-				trade.Quantity.String(),
-				r.syncState.Asset,
+				transferAmount.String(),
+				asset,
 				currentTime.Format(time.RFC3339),
 				err.Error(),
 				trade,
@@ -614,6 +638,7 @@ func (r *ArbitrageRound) handleSpotTrade(trade types.Trade, currentTime time.Tim
 			r.syncState.RetryTransfers[trade.ID] = &transferRetry{
 				Trade:     trade,
 				LastTried: currentTime,
+				Direction: types.TransferIn,
 			}
 		} else {
 			transfer.LastTried = currentTime
@@ -623,8 +648,8 @@ func (r *ArbitrageRound) handleSpotTrade(trade types.Trade, currentTime time.Tim
 	// transfer succeeded, remove from retry list if exists
 	delete(r.syncState.RetryTransfers, trade.ID)
 	bbgo.Notify("➡️ Transfered %s %s from spot to futures",
-		trade.Quantity.String(),
-		r.syncState.Asset,
+		transferAmount.String(),
+		asset,
 		trade,
 	)
 }
@@ -633,8 +658,73 @@ func (r *ArbitrageRound) HandleFuturesTrade(trade types.Trade, currentTime time.
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if ok := r.futuresWorker.Executor().AddTrade(trade); ok {
-		r.logger.Infof("handling future trade: %s", trade)
+	if ok := r.futuresWorker.Executor().AddTrade(trade); !ok {
+		// the trade does not belong to the futures worker, skip
+		return
+	}
+
+	if r.syncState.State == RoundClosing {
+		r.logger.Infof("handling future trade (closing): %s", trade)
+		r.handleFuturesTradeForClose(trade, currentTime)
+	} else {
+		// the round is opening or ready, just log the futures trade
+		r.logger.Infof("received futures trade: %s", trade)
+	}
+}
+
+// handleFuturesTradeForClose is the mirror of handleSpotTradeForOpen: during
+// closing, futures is the leader. After each futures fill reduces the position,
+// the freed collateral asset is transferred back to spot and the spot worker's
+// target is advanced so it can execute its offsetting trade with that asset.
+func (r *ArbitrageRound) handleFuturesTradeForClose(trade types.Trade, currentTime time.Time) {
+	// transfer the freed collateral asset back to spot so the spot leg can use it to close its position.
+	transferAmount := r.syncState.DirectionPolicy.TransferAmountFromFuturesTrade(trade)
+	asset := r.syncState.DirectionPolicy.CollateralAsset()
+	if transferAmount.Sign() <= 0 {
+		// nothing left to transfer
+		// remove from retry list if exists
+		delete(r.syncState.RetryTransfers, trade.ID)
+		return
+	}
+
+	timedCtx, cancel := context.WithTimeout(
+		r.futuresWorker.ctx,
+		time.Second*20,
+	)
+	defer cancel()
+	if err := r.futuresService.TransferFuturesAccountAsset(
+		timedCtx, asset, transferAmount, types.TransferOut,
+	); err != nil {
+		if transfer, found := r.syncState.RetryTransfers[trade.ID]; !found {
+			bbgo.Notify("🚨 Round futures transfer %s %s failed (%s), retrying: %s",
+				transferAmount.String(),
+				asset,
+				currentTime.Format(time.RFC3339),
+				err.Error(),
+				trade,
+			)
+			r.syncState.RetryTransfers[trade.ID] = &transferRetry{
+				Trade:     trade,
+				LastTried: currentTime,
+				Direction: types.TransferOut,
+			}
+		} else {
+			transfer.LastTried = currentTime
+		}
+		return
+	}
+	// transfer succeeded, remove from retry list if exists
+	delete(r.syncState.RetryTransfers, trade.ID)
+	bbgo.Notify("⬅️ Transferred %s %s from futures to spot",
+		transferAmount.String(),
+		asset,
+		trade,
+	)
+
+	// sync the spot position only after the transfer succeeds.
+	if _, found := r.syncState.SyncedFuturesTrades[trade.ID]; !found {
+		r.syncSpotPosition(trade)
+		r.syncState.SyncedFuturesTrades[trade.ID] = struct{}{}
 	}
 }
 
@@ -673,15 +763,23 @@ func (r *ArbitrageRound) SetClosing(currentTime time.Time, duration types.Durati
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// set spot target position to zero
-	// the futures target position will be synced as the spot position is closing
-	r.spotWorker.SetTargetPosition(fixedpoint.Zero)
+	// During close, futures is the leader: drive its target to zero so it
+	// starts reducing the position. The spot target stays where it is and is
+	// re-synced after each futures fill in handleFuturesTradeForClose, so spot
+	// only trades once the collateral has been transferred back from futures.
+	r.futuresWorker.SetTargetPosition(fixedpoint.Zero)
 	r.spotWorker.ResetTime(currentTime, duration)
 	r.futuresWorker.ResetTime(currentTime, duration)
 
 	r.syncState.State = RoundClosing
 	r.syncState.ClosingTime = currentTime
 	r.syncState.ClosingDuration = duration
+}
+
+// CollateralAsset returns the asset that this round parks on the futures
+// account (base for Short, quote for Long).
+func (r *ArbitrageRound) CollateralAsset() string {
+	return r.syncState.DirectionPolicy.CollateralAsset()
 }
 
 func (r *ArbitrageRound) Cleanup(ctx context.Context, orderBook types.OrderBook) error {
@@ -803,7 +901,7 @@ func (r *ArbitrageRound) Tick(currentTime time.Time, spotOrderBook types.OrderBo
 
 func (r *ArbitrageRound) syncFuturesPosition(spotTrade types.Trade) {
 	// sanity check
-	if r.spotWorker.Symbol() != spotTrade.Symbol {
+	if r.spotWorker.Symbol() != spotTrade.Symbol || spotTrade.IsFutures {
 		return
 	}
 	// the filled spot position can be positive or negative
@@ -817,4 +915,19 @@ func (r *ArbitrageRound) syncFuturesPosition(spotTrade types.Trade) {
 		spotTrade,
 	)
 	r.futuresWorker.SetTargetPosition(futureTargetPosition)
+}
+
+func (r *ArbitrageRound) syncSpotPosition(futuresTrade types.Trade) {
+	// sanity check
+	if r.futuresWorker.Symbol() != futuresTrade.Symbol || !futuresTrade.IsFutures {
+		return
+	}
+
+	// advance the spot worker's target to mirror the futures filled position.
+	// This unblocks the spot leg to execute its offsetting slice on the next Tick.
+	futuresFilled := r.futuresWorker.FilledPosition()
+	spotTarget := futuresFilled.Neg()
+	oriSpotTarget := r.spotWorker.TargetPosition()
+	r.logger.Infof("syncing spot target on close %s -> %s: %s", oriSpotTarget, spotTarget, futuresTrade)
+	r.spotWorker.SetTargetPosition(spotTarget)
 }

--- a/pkg/strategy/xfundingv2/arb_round_fee_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_fee_test.go
@@ -345,7 +345,8 @@ func TestStrategy_CalculateRoundFeeAsset(t *testing.T) {
 			fundingRate,
 			types.ExchangeBinance, types.ExchangeBinance,
 			3, 8,
-			spotWorker, futuresWorker, mockService)
+			spotWorker, futuresWorker, mockService,
+			types.PositionLong)
 
 		err := s.calculateRoundFeeAsset(round)
 		assert.EqualError(t, err, "order book data is not ready yet")
@@ -461,7 +462,8 @@ func TestStrategy_CalculateRoundFeeAsset(t *testing.T) {
 		round := NewArbitrageRound(
 			fundingRate,
 			types.ExchangeBinance, types.ExchangeBinance,
-			3, 8, spotWorker, futuresWorker, mockService)
+			3, 8, spotWorker, futuresWorker, mockService,
+			types.PositionShort)
 
 		err := s.calculateRoundFeeAsset(round)
 		assert.NoError(t, err)

--- a/pkg/strategy/xfundingv2/arb_round_sync.go
+++ b/pkg/strategy/xfundingv2/arb_round_sync.go
@@ -79,16 +79,17 @@ type ArbitrageRoundSyncState struct {
 	Symbol              string             `json:"symbol"`
 	SpotExchangeName    types.ExchangeName `json:"spotExchangeName"`
 	FuturesExchangeName types.ExchangeName `json:"futuresExchangeName"`
-	Asset               string             `json:"asset"` // base asset, e.g. "BTC"
+	DirectionPolicy     directionPolicy    `json:"directionPolicy"`
 
 	SpotFeeAssetAmount    fixedpoint.Value `json:"spotFeeAssetAmount"`
 	FuturesFeeAssetAmount fixedpoint.Value `json:"futuresFeeAssetAmount"`
 	FeeSymbol             string           `json:"feeSymbol"`
 	AvgFeeCost            fixedpoint.Value `json:"avgFeeCost"`
 
-	RetryDuration    time.Duration             `json:"retryDuration"`
-	RetryTransfers   map[uint64]*transferRetry `json:"retryTransfers"`
-	SyncedSpotTrades map[uint64]struct{}       `json:"syncedSpotTrades"`
+	RetryDuration       time.Duration             `json:"retryDuration"`
+	RetryTransfers      map[uint64]*transferRetry `json:"retryTransfers"`
+	SyncedSpotTrades    map[uint64]struct{}       `json:"syncedSpotTrades"`
+	SyncedFuturesTrades map[uint64]struct{}       `json:"syncedFuturesTrades"`
 
 	State RoundState `json:"state"`
 

--- a/pkg/strategy/xfundingv2/arb_round_sync_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_sync_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	"github.com/c9s/bbgo/pkg/types"
+
+	. "github.com/c9s/bbgo/pkg/testing/testhelper"
 )
 
 func TestArbitrageRound_MarshalUnmarshalJSON(t *testing.T) {
@@ -39,7 +41,10 @@ func TestArbitrageRound_MarshalUnmarshalJSON(t *testing.T) {
 				Symbol:              "BTCUSDT",
 				SpotExchangeName:    types.ExchangeBinance,
 				FuturesExchangeName: types.ExchangeBinance,
-				Asset:               "BTC",
+				DirectionPolicy: directionPolicy{
+					Direction: types.PositionShort,
+					Market:    Market("BTCUSDT"),
+				},
 
 				SpotFeeAssetAmount:    fixedpoint.NewFromFloat(0.01),
 				FuturesFeeAssetAmount: fixedpoint.NewFromFloat(0.02),
@@ -83,8 +88,11 @@ func TestArbitrageRound_MarshalUnmarshalJSON(t *testing.T) {
 				SpotExchangeName:     types.ExchangeBinance,
 				FuturesExchangeName:  types.ExchangeBinance,
 				State:                RoundPending,
-				Asset:                "ETH",
-				FundingFeeRecords:    make(map[int64]FundingFee),
+				DirectionPolicy: directionPolicy{
+					Direction: types.PositionShort,
+					Market:    Market("ETHUSDT"),
+				},
+				FundingFeeRecords: make(map[int64]FundingFee),
 			},
 		}
 

--- a/pkg/strategy/xfundingv2/arb_round_test.go
+++ b/pkg/strategy/xfundingv2/arb_round_test.go
@@ -26,6 +26,21 @@ type mockFuturesService struct {
 	incomeHistory []binanceapi.FuturesIncome
 	incomeErr     error
 	transferErr   error
+	transfers     []transferCall
+}
+
+type transferCall struct {
+	Asset     string
+	Amount    fixedpoint.Value
+	Direction types.TransferDirection
+}
+
+func (m *mockFuturesService) Transfers() []transferCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]transferCall, len(m.transfers))
+	copy(out, m.transfers)
+	return out
 }
 
 func (m *mockFuturesService) ResetIncomeError() {
@@ -54,7 +69,13 @@ func (m *mockFuturesService) QueryFuturesIncomeHistory(
 func (m *mockFuturesService) TransferFuturesAccountAsset(
 	ctx context.Context, asset string, amount fixedpoint.Value, direction types.TransferDirection,
 ) error {
-	return m.transferErr
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.transferErr != nil {
+		return m.transferErr
+	}
+	m.transfers = append(m.transfers, transferCall{Asset: asset, Amount: amount, Direction: direction})
+	return nil
 }
 
 func (m *mockFuturesService) QueryPremiumIndex(ctx context.Context, symbol string) (*types.PremiumIndex, error) {
@@ -87,7 +108,8 @@ func newTestArbitrageRound(t *testing.T, ctrl *gomock.Controller, fundingInterva
 	round := NewArbitrageRound(
 		fundingRate,
 		types.ExchangeBinance, types.ExchangeBinance,
-		minHoldingIntervals, fundingIntervalHours, spotWorker, futuresWorker, mockService)
+		minHoldingIntervals, fundingIntervalHours, spotWorker, futuresWorker, mockService,
+		types.PositionShort)
 	return round, mockService
 }
 
@@ -261,7 +283,95 @@ func TestArbitrageRound_TotalFundingIncome(t *testing.T) {
 	})
 }
 
-func TestArbitrageRound_DeltaNeutral(t *testing.T) {
+// arbSpotTrade builds a spot trade for arb-round tests, populating QuoteQuantity
+// from price*quantity so that LONG-direction transfers (which use QuoteQuantity)
+// behave realistically.
+func arbSpotTrade(id, orderID uint64, side types.SideType, price, quantity fixedpoint.Value) types.Trade {
+	t := makeTrade(id, orderID, side, price, quantity)
+	t.QuoteQuantity = price.Mul(quantity)
+	return t
+}
+
+// arbFuturesTrade is the futures counterpart of arbSpotTrade. The IsFutures
+// flag is required for syncSpotPosition (called on the closing leg) to update
+// the spot target instead of bailing out early.
+func arbFuturesTrade(id, orderID uint64, side types.SideType, price, quantity fixedpoint.Value) types.Trade {
+	t := arbSpotTrade(id, orderID, side, price, quantity)
+	t.IsFutures = true
+	return t
+}
+
+type directionScenario struct {
+	name         string
+	direction    types.PositionType
+	collateral   string
+	spotTarget   fixedpoint.Value
+	spotOpenSide types.SideType // side spot uses to open the position
+	// futuresCloseSide is the side futures uses to close (opposite of its open).
+	futuresCloseSide types.SideType
+	// expectedFuturesTargetAfterFirstSpotFill is the target the round syncs onto
+	// the futures leg after the first spot fill of half the position.
+	expectedFuturesTargetAfterFirstSpotFill fixedpoint.Value
+	// expectedSpotTargetAfterFirstFuturesClose is the target the round syncs onto
+	// the spot leg after the first futures-close fill.
+	expectedSpotTargetAfterFirstFuturesClose fixedpoint.Value
+	// expectedTransferAmount returns the asset amount the round should transfer
+	// when given the trade's price and quantity. For SHORT it's the base
+	// quantity; for LONG it's the quote notional.
+	expectedTransferAmount func(price, quantity fixedpoint.Value) fixedpoint.Value
+}
+
+// TestArbitrageRound_DirectionalLeaderFollower exercises both SHORT and LONG
+// futures directions and verifies the leader/follower contract:
+//
+//	Opening: the spot leg is the leader. Each spot fill triggers a TransferIn
+//	         of the collateral asset to futures, and only afterwards is the
+//	         futures target advanced so it can place its offsetting slice.
+//	Closing: the futures leg is the leader. Each futures-close fill triggers
+//	         a TransferOut of the freed collateral back to spot, and only
+//	         afterwards is the spot target advanced so it can place its
+//	         offsetting slice.
+func TestArbitrageRound_DirectionalLeaderFollower(t *testing.T) {
+	scenarios := []directionScenario{
+		{
+			name:                                     "ShortFutures",
+			direction:                                types.PositionShort,
+			collateral:                               "BTC",
+			spotTarget:                               Number(10.0),
+			spotOpenSide:                             types.SideTypeBuy,
+			futuresCloseSide:                         types.SideTypeBuy,
+			expectedFuturesTargetAfterFirstSpotFill:  Number(-5.0),
+			expectedSpotTargetAfterFirstFuturesClose: Number(5.0),
+			expectedTransferAmount: func(_, quantity fixedpoint.Value) fixedpoint.Value {
+				return quantity
+			},
+		},
+		{
+			name:                                     "LongFutures",
+			direction:                                types.PositionLong,
+			collateral:                               "USDT",
+			spotTarget:                               Number(-10.0),
+			spotOpenSide:                             types.SideTypeSell,
+			futuresCloseSide:                         types.SideTypeSell,
+			expectedFuturesTargetAfterFirstSpotFill:  Number(5.0),
+			expectedSpotTargetAfterFirstFuturesClose: Number(-5.0),
+			expectedTransferAmount: func(price, quantity fixedpoint.Value) fixedpoint.Value {
+				// Fees are paid in BNB in these tests, so the transfer amount
+				// is exactly the quote notional (no fee deduction).
+				return price.Mul(quantity)
+			},
+		},
+	}
+
+	for _, sc := range scenarios {
+		sc := sc
+		t.Run(sc.name, func(t *testing.T) {
+			runLeaderFollowerScenario(t, sc)
+		})
+	}
+}
+
+func runLeaderFollowerScenario(t *testing.T, sc directionScenario) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -279,11 +389,9 @@ func TestArbitrageRound_DeltaNeutral(t *testing.T) {
 	spotWorker, spotMockExchange, spotMockOrderQuery, spotGeneralExecutor := newTestTWAPWorker(t, ctrl, config)
 	futuresWorker, futuresMockExchange, futuresMockOrderQuery, futuresGeneralExecutor := newTestTWAPWorker(t, ctrl, config)
 
-	targetPosition := Number(10.0)
-	spotWorker.SetTargetPosition(targetPosition)
+	spotWorker.SetTargetPosition(sc.spotTarget)
 
 	mockService := &mockFuturesService{}
-
 	fundingRate := &types.PremiumIndex{
 		LastFundingRate: Number(0.001),
 		NextFundingTime: nextFundingTime,
@@ -292,180 +400,182 @@ func TestArbitrageRound_DeltaNeutral(t *testing.T) {
 	round := NewArbitrageRound(
 		fundingRate,
 		types.ExchangeBinance, types.ExchangeBinance,
-		3, 8, spotWorker, futuresWorker, mockService)
-	round.SetLogger(logrus.WithField("test", "delta_neutral"))
+		3, 8, spotWorker, futuresWorker, mockService,
+		sc.direction)
+	round.SetLogger(logrus.WithField("test", sc.name))
+
+	assert.Equal(t, sc.collateral, round.CollateralAsset())
+	assert.Equal(t, sc.direction, round.syncState.DirectionPolicy.Direction)
 
 	spotOrderID := uint64(1000)
 	setupDeltaNeutralMockExchange(spotMockExchange, spotMockOrderQuery, &spotOrderID)
-
 	futuresOrderID := uint64(2000)
 	setupDeltaNeutralMockExchange(futuresMockExchange, futuresMockOrderQuery, &futuresOrderID)
 
 	assertDeltaNeutral := func(t *testing.T, msg string) {
 		t.Helper()
-		spotFilled := spotWorker.FilledPosition()
-		futuresFilled := futuresWorker.FilledPosition()
-		netDelta := spotFilled.Add(futuresFilled)
-		assert.True(t, netDelta.IsZero(),
+		net := spotWorker.FilledPosition().Add(futuresWorker.FilledPosition())
+		assert.True(t, net.IsZero(),
 			"%s: delta-neutral violated, spot=%s, futures=%s, net=%s",
-			msg, spotFilled, futuresFilled, netDelta)
-	}
-
-	assertFuturesTargetMatchesSpot := func(t *testing.T, msg string) {
-		t.Helper()
-		spotFilled := spotWorker.FilledPosition()
-		futuresTarget := futuresWorker.TargetPosition()
-		expected := spotFilled.Neg()
-		assert.Equal(t, expected, futuresTarget,
-			"%s: futures target should be negation of spot filled, spot=%s, futuresTarget=%s",
-			msg, spotFilled, futuresTarget)
+			msg, spotWorker.FilledPosition(), futuresWorker.FilledPosition(), net)
 	}
 
 	orderBook := newOrderBook(76990.0, 100.0, 77010.0, 100.0)
+	openPrice := Number(77010.0)
+	closePrice := Number(76990.0)
+	sliceQty := Number(5.0)
+	futuresOpenSide := oppositeSide(sc.spotOpenSide)
+	futuresCloseSide := sc.futuresCloseSide
+	spotCloseSide := oppositeSide(sc.spotOpenSide)
 
-	// ==========================================
-	// Phase 1: Start the round (Opening)
-	// ==========================================
 	ctx := context.Background()
-	err := round.Start(ctx, startTime)
-	assert.NoError(t, err)
+	assert.NoError(t, round.Start(ctx, startTime))
 	assert.Equal(t, RoundOpening, round.State())
 	assertDeltaNeutral(t, "after start")
 
-	// ==========================================
-	// Phase 2: Opening - buy spot in slices, verify futures stays delta-neutral
-	// ==========================================
+	// =========================================================================
+	// Opening: spot is the leader.
+	//   1. Spot worker places & fills a slice.
+	//   2. HandleSpotTrade transfers collateral spot -> futures (TransferIn).
+	//   3. Futures target is synced *after* the transfer succeeds; only then
+	//      can the futures worker tick its own slice.
+	// =========================================================================
 
-	// Tick spot worker -> places first slice order (10/2 = 5 BTC)
-	err = spotWorker.Tick(startTime, orderBook)
-	assert.NoError(t, err)
+	assert.True(t, futuresWorker.TargetPosition().IsZero(),
+		"futures target should be zero before any spot fill")
+
+	// --- opening slice 1 ---
+	assert.NoError(t, spotWorker.Tick(startTime, orderBook))
 	assert.NotNil(t, spotWorker.ActiveOrder())
 
-	// Spot trade 1: buy 5 BTC
-	spotTrade1 := makeTrade(1, spotWorker.ActiveOrder().OrderID, types.SideTypeBuy, Number(77010.0), Number(5.0))
+	transfersBefore := len(mockService.Transfers())
+	spotTrade1 := arbSpotTrade(1, spotWorker.ActiveOrder().OrderID, sc.spotOpenSide, openPrice, sliceQty)
 	processTrade(spotWorker, spotGeneralExecutor, spotTrade1)
 	round.HandleSpotTrade(spotTrade1, startTime)
 
-	assertFuturesTargetMatchesSpot(t, "after spot trade 1")
-	assert.Equal(t, Number(-5.0), futuresWorker.TargetPosition())
+	transfers := mockService.Transfers()
+	if assert.Len(t, transfers, transfersBefore+1, "spot fill must trigger exactly one transfer") {
+		call := transfers[len(transfers)-1]
+		assert.Equal(t, sc.collateral, call.Asset)
+		assert.Equal(t, types.TransferIn, call.Direction)
+		assert.Equal(t, sc.expectedTransferAmount(openPrice, sliceQty), call.Amount)
+	}
+	assert.Equal(t, sc.expectedFuturesTargetAfterFirstSpotFill, futuresWorker.TargetPosition(),
+		"futures target must be advanced after the spot->futures transfer")
 
-	// Tick futures worker -> places order matching synced target
-	err = futuresWorker.Tick(startTime, orderBook)
-	assert.NoError(t, err)
+	// Futures (the follower) can now place and fill its slice.
+	assert.NoError(t, futuresWorker.Tick(startTime, orderBook))
 	assert.NotNil(t, futuresWorker.ActiveOrder())
 
-	// Futures trade 1: sell 5 BTC
-	futuresTrade1 := makeTrade(101, futuresWorker.ActiveOrder().OrderID, types.SideTypeSell, Number(77010.0), Number(5.0))
+	futuresTrade1 := arbFuturesTrade(101, futuresWorker.ActiveOrder().OrderID, futuresOpenSide, openPrice, sliceQty)
 	processTrade(futuresWorker, futuresGeneralExecutor, futuresTrade1)
 	round.HandleFuturesTrade(futuresTrade1, startTime)
 
-	assertDeltaNeutral(t, "after opening trade 1")
-	assert.Equal(t, Number(5.0), spotWorker.FilledPosition())
-	assert.Equal(t, Number(-5.0), futuresWorker.FilledPosition())
+	assert.Len(t, mockService.Transfers(), transfersBefore+1,
+		"futures fill during opening must not trigger a transfer (spot is the leader)")
+	assertDeltaNeutral(t, "after opening slice 1")
 
-	// Tick spot worker -> places second slice order (remaining 5/1 = 5 BTC)
+	// --- opening slice 2 ---
 	tick2 := startTime.Add(5 * time.Minute)
-	err = spotWorker.Tick(tick2, orderBook)
-	assert.NoError(t, err)
+	assert.NoError(t, spotWorker.Tick(tick2, orderBook))
 
-	// Spot trade 2: buy 5 BTC more
-	spotTrade2 := makeTrade(2, spotWorker.ActiveOrder().OrderID, types.SideTypeBuy, Number(77010.0), Number(5.0))
+	spotTrade2 := arbSpotTrade(2, spotWorker.ActiveOrder().OrderID, sc.spotOpenSide, openPrice, sliceQty)
 	processTrade(spotWorker, spotGeneralExecutor, spotTrade2)
 	round.HandleSpotTrade(spotTrade2, tick2)
 
-	assertFuturesTargetMatchesSpot(t, "after spot trade 2")
-	assert.Equal(t, Number(-10.0), futuresWorker.TargetPosition())
+	assert.Len(t, mockService.Transfers(), transfersBefore+2)
+	assert.Equal(t, sc.spotTarget.Neg(), futuresWorker.TargetPosition())
 
-	// Tick futures worker -> fills remaining
-	err = futuresWorker.Tick(tick2, orderBook)
-	assert.NoError(t, err)
-
-	futuresTrade2 := makeTrade(102, futuresWorker.ActiveOrder().OrderID, types.SideTypeSell, Number(77010.0), Number(5.0))
+	assert.NoError(t, futuresWorker.Tick(tick2, orderBook))
+	futuresTrade2 := arbFuturesTrade(102, futuresWorker.ActiveOrder().OrderID, futuresOpenSide, openPrice, sliceQty)
 	processTrade(futuresWorker, futuresGeneralExecutor, futuresTrade2)
 	round.HandleFuturesTrade(futuresTrade2, tick2)
+	assertDeltaNeutral(t, "after opening slice 2 (fully opened)")
 
-	assertDeltaNeutral(t, "after opening trade 2 (fully opened)")
-	assert.Equal(t, Number(10.0), spotWorker.FilledPosition())
-	assert.Equal(t, Number(-10.0), futuresWorker.FilledPosition())
-
-	// ==========================================
-	// Phase 3: Tick round to transition to RoundReady
-	// ==========================================
-	tickReady := startTime.Add(6 * time.Minute)
-	round.Tick(tickReady, orderBook, orderBook)
+	// Transition to RoundReady.
+	round.Tick(startTime.Add(6*time.Minute), orderBook, orderBook)
 	assert.Equal(t, RoundReady, round.State())
 	assertDeltaNeutral(t, "at RoundReady")
+	assert.Equal(t, sc.spotTarget, spotWorker.FilledPosition(),
+		"spot leg should be fully opened to its target")
+	assert.Equal(t, sc.spotTarget.Neg(), futuresWorker.FilledPosition(),
+		"futures leg should fully mirror the spot fill")
 
-	// ==========================================
-	// Phase 4: Set closing
-	// ==========================================
+	// =========================================================================
+	// Closing: futures is the leader.
+	//   1. Futures worker places & fills a buy-back/sell-back slice.
+	//   2. HandleFuturesTrade transfers freed collateral futures -> spot
+	//      (TransferOut).
+	//   3. Spot target is synced *after* the transfer succeeds; only then can
+	//      the spot worker tick its own closing slice.
+	// =========================================================================
 	closeTime := startTime.Add(20 * time.Minute)
-	closeDuration := types.Duration(10 * time.Minute)
-	round.SetClosing(closeTime, closeDuration)
+	round.SetClosing(closeTime, types.Duration(10*time.Minute))
 	assert.Equal(t, RoundClosing, round.State())
-	assert.Equal(t, fixedpoint.Zero, spotWorker.TargetPosition())
+	assert.Equal(t, fixedpoint.Zero, futuresWorker.TargetPosition(),
+		"SetClosing drives the futures target to zero so it leads the close")
+	assert.Equal(t, sc.spotTarget, spotWorker.TargetPosition(),
+		"spot target stays put until syncSpotPosition advances it per fill")
 	assertDeltaNeutral(t, "after SetClosing (before closing trades)")
 
-	// ==========================================
-	// Phase 5: Closing - sell spot, buy back futures
-	// ==========================================
+	transfersBeforeClose := len(mockService.Transfers())
 
-	// Tick spot worker -> places sell order (remaining = -10, slice = 10/2 = 5)
-	err = spotWorker.Tick(closeTime, orderBook)
-	assert.NoError(t, err)
+	// --- closing slice 1 ---
+	assert.NoError(t, futuresWorker.Tick(closeTime, orderBook))
+	assert.NotNil(t, futuresWorker.ActiveOrder())
 
-	// Spot close trade 1: sell 5 BTC
-	spotCloseTrade1 := makeTrade(3, spotWorker.ActiveOrder().OrderID, types.SideTypeSell, Number(76990.0), Number(5.0))
-	processTrade(spotWorker, spotGeneralExecutor, spotCloseTrade1)
-	round.HandleSpotTrade(spotCloseTrade1, closeTime)
-
-	assertFuturesTargetMatchesSpot(t, "after spot close trade 1")
-	assert.Equal(t, Number(5.0), spotWorker.FilledPosition())
-	assert.Equal(t, Number(-5.0), futuresWorker.TargetPosition())
-
-	// Tick futures worker -> places buy-back order
-	err = futuresWorker.Tick(closeTime, orderBook)
-	assert.NoError(t, err)
-
-	futuresCloseTrade1 := makeTrade(103, futuresWorker.ActiveOrder().OrderID, types.SideTypeBuy, Number(76990.0), Number(5.0))
+	futuresCloseTrade1 := arbFuturesTrade(103, futuresWorker.ActiveOrder().OrderID, futuresCloseSide, closePrice, sliceQty)
 	processTrade(futuresWorker, futuresGeneralExecutor, futuresCloseTrade1)
 	round.HandleFuturesTrade(futuresCloseTrade1, closeTime)
 
-	assertDeltaNeutral(t, "after closing trade 1")
+	transfers = mockService.Transfers()
+	if assert.Len(t, transfers, transfersBeforeClose+1, "futures close fill must trigger exactly one transfer") {
+		call := transfers[len(transfers)-1]
+		assert.Equal(t, sc.collateral, call.Asset)
+		assert.Equal(t, types.TransferOut, call.Direction)
+		assert.Equal(t, sc.expectedTransferAmount(closePrice, sliceQty), call.Amount)
+	}
+	assert.Equal(t, sc.expectedSpotTargetAfterFirstFuturesClose, spotWorker.TargetPosition(),
+		"spot target must be advanced after the futures->spot transfer")
+	// Spot (the follower) can now place and fill its closing slice.
+	assert.NoError(t, spotWorker.Tick(closeTime, orderBook))
+	spotCloseTrade1 := arbSpotTrade(3, spotWorker.ActiveOrder().OrderID, spotCloseSide, closePrice, sliceQty)
+	processTrade(spotWorker, spotGeneralExecutor, spotCloseTrade1)
+	round.HandleSpotTrade(spotCloseTrade1, closeTime)
 
-	// Tick spot worker -> places second sell order
+	assert.Len(t, mockService.Transfers(), transfersBeforeClose+1,
+		"spot fill during closing must not trigger a transfer (futures is the leader)")
+	assertDeltaNeutral(t, "after closing slice 1")
+
+	// --- closing slice 2 ---
 	tick5 := closeTime.Add(5 * time.Minute)
-	err = spotWorker.Tick(tick5, orderBook)
-	assert.NoError(t, err)
-
-	// Spot close trade 2: sell remaining 5 BTC
-	spotCloseTrade2 := makeTrade(4, spotWorker.ActiveOrder().OrderID, types.SideTypeSell, Number(76990.0), Number(5.0))
-	processTrade(spotWorker, spotGeneralExecutor, spotCloseTrade2)
-	round.HandleSpotTrade(spotCloseTrade2, tick5)
-
-	assertFuturesTargetMatchesSpot(t, "after spot close trade 2")
-	assert.True(t, spotWorker.FilledPosition().IsZero())
-	assert.True(t, futuresWorker.TargetPosition().IsZero())
-
-	// Tick futures worker -> places final buy-back order
-	err = futuresWorker.Tick(tick5, orderBook)
-	assert.NoError(t, err)
-
-	futuresCloseTrade2 := makeTrade(104, futuresWorker.ActiveOrder().OrderID, types.SideTypeBuy, Number(76990.0), Number(5.0))
+	assert.NoError(t, futuresWorker.Tick(tick5, orderBook))
+	futuresCloseTrade2 := arbFuturesTrade(104, futuresWorker.ActiveOrder().OrderID, futuresCloseSide, closePrice, sliceQty)
 	processTrade(futuresWorker, futuresGeneralExecutor, futuresCloseTrade2)
 	round.HandleFuturesTrade(futuresCloseTrade2, tick5)
 
-	assertDeltaNeutral(t, "after closing trade 2 (fully closed)")
+	assert.True(t, futuresWorker.FilledPosition().IsZero())
+	assert.True(t, spotWorker.TargetPosition().IsZero())
+
+	assert.NoError(t, spotWorker.Tick(tick5, orderBook))
+	spotCloseTrade2 := arbSpotTrade(4, spotWorker.ActiveOrder().OrderID, spotCloseSide, closePrice, sliceQty)
+	processTrade(spotWorker, spotGeneralExecutor, spotCloseTrade2)
+	round.HandleSpotTrade(spotCloseTrade2, tick5)
+
+	assertDeltaNeutral(t, "after closing slice 2 (fully closed)")
 	assert.True(t, spotWorker.FilledPosition().IsZero())
 	assert.True(t, futuresWorker.FilledPosition().IsZero())
 
-	// ==========================================
-	// Phase 6: Tick round to transition to RoundClosed
-	// ==========================================
-	tickClosed := closeTime.Add(6 * time.Minute)
-	round.Tick(tickClosed, orderBook, orderBook)
+	round.Tick(closeTime.Add(6*time.Minute), orderBook, orderBook)
 	assert.Equal(t, RoundClosed, round.State())
 	assertDeltaNeutral(t, "at RoundClosed")
+}
+
+func oppositeSide(s types.SideType) types.SideType {
+	if s == types.SideTypeBuy {
+		return types.SideTypeSell
+	}
+	return types.SideTypeBuy
 }
 
 func setupDeltaNeutralMockExchange(mockExchange *mocks.MockExchange, mockOrderQuery *mocks.MockExchangeOrderQueryService, orderID *uint64) {

--- a/pkg/strategy/xfundingv2/direction_policy.go
+++ b/pkg/strategy/xfundingv2/direction_policy.go
@@ -1,0 +1,84 @@
+package xfundingv2
+
+import (
+	"fmt"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+// directionPolicy encapsulates the per-direction decisions for a funding-rate
+// arbitrage round so the rest of the round code can stay direction-agnostic.
+//
+// For PositionShort: long spot, short futures, collateral = base.
+// For PositionLong:  short spot, long futures, collateral = quote.
+type directionPolicy struct {
+	Direction types.PositionType `json:"direction"`
+	Market    types.Market       `json:"market"`
+}
+
+func newDirectionPolicy(direction types.PositionType, market types.Market) (directionPolicy, error) {
+	switch direction {
+	case types.PositionShort, types.PositionLong:
+		return directionPolicy{Direction: direction, Market: market}, nil
+	default:
+		return directionPolicy{}, fmt.Errorf("unsupported futures direction: %q", direction)
+	}
+}
+
+// CollateralAsset is the asset that gets parked on the futures account to
+// support the futures leg of the round.
+func (p directionPolicy) CollateralAsset() string {
+	if p.Direction == types.PositionLong {
+		return p.Market.QuoteCurrency
+	}
+	return p.Market.BaseCurrency
+}
+
+// TransferAmountFromSpotTrade returns how much CollateralAsset should be
+// transferred from spot to futures after a spot fill during opening.
+//
+//	Short open: spot BUYs base -> transfer trade.Quantity of base.
+//	Long  open: spot SELLs base for quote -> transfer net quote received
+//	            (trade.QuoteQuantity minus fee when fee is paid in quote).
+func (p directionPolicy) TransferAmountFromSpotTrade(t types.Trade) fixedpoint.Value {
+	if p.Direction == types.PositionLong {
+		amount := t.QuoteQuantity
+		if t.FeeCurrency == p.Market.QuoteCurrency {
+			amount = amount.Sub(t.Fee)
+		}
+		if amount.Sign() < 0 {
+			return fixedpoint.Zero
+		}
+		return amount
+	}
+	return t.Quantity
+}
+
+// TransferAmountFromFuturesTrade returns how much CollateralAsset should be
+// transferred from futures back to spot after a futures fill during closing.
+//
+//	Short close: futures BUYs to reduce short -> free trade.Quantity of base.
+//	Long  close: futures SELLs to reduce long -> free trade.QuoteQuantity of quote.
+func (p directionPolicy) TransferAmountFromFuturesTrade(t types.Trade) fixedpoint.Value {
+	if p.Direction == types.PositionLong {
+		return t.QuoteQuantity
+	}
+	return t.Quantity
+}
+
+// SpotSign / FuturesSign give the sign multipliers a caller should apply to a
+// raw position size when constructing signed target positions for each leg.
+//
+//	Short: spot=+1 (long spot),  futures=-1 (short futures)
+//	Long:  spot=-1 (short spot), futures=+1 (long futures)
+func (p directionPolicy) SpotSign() int {
+	if p.Direction == types.PositionLong {
+		return -1
+	}
+	return 1
+}
+
+func (p directionPolicy) FuturesSign() int {
+	return -p.SpotSign()
+}

--- a/pkg/strategy/xfundingv2/direction_policy_test.go
+++ b/pkg/strategy/xfundingv2/direction_policy_test.go
@@ -1,0 +1,117 @@
+package xfundingv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/types"
+
+	. "github.com/c9s/bbgo/pkg/testing/testhelper"
+)
+
+func TestNewDirectionPolicy(t *testing.T) {
+	market := Market("BTCUSDT")
+
+	t.Run("rejects unsupported direction", func(t *testing.T) {
+		_, err := newDirectionPolicy(types.PositionClosed, market)
+		assert.Error(t, err)
+	})
+
+	t.Run("accepts short", func(t *testing.T) {
+		p, err := newDirectionPolicy(types.PositionShort, market)
+		assert.NoError(t, err)
+		assert.Equal(t, types.PositionShort, p.Direction)
+	})
+
+	t.Run("accepts long", func(t *testing.T) {
+		p, err := newDirectionPolicy(types.PositionLong, market)
+		assert.NoError(t, err)
+		assert.Equal(t, types.PositionLong, p.Direction)
+	})
+}
+
+func TestDirectionPolicy_CollateralAsset(t *testing.T) {
+	market := Market("BTCUSDT")
+
+	short, _ := newDirectionPolicy(types.PositionShort, market)
+	long, _ := newDirectionPolicy(types.PositionLong, market)
+
+	assert.Equal(t, market.BaseCurrency, short.CollateralAsset())
+	assert.Equal(t, market.QuoteCurrency, long.CollateralAsset())
+}
+
+func TestDirectionPolicy_TransferAmountFromSpotTrade(t *testing.T) {
+	market := Market("BTCUSDT")
+
+	t.Run("short returns trade.Quantity (base)", func(t *testing.T) {
+		p, _ := newDirectionPolicy(types.PositionShort, market)
+		trade := types.Trade{
+			Quantity:      Number(0.5),
+			QuoteQuantity: Number(25000),
+			Fee:           Number(25),
+			FeeCurrency:   "USDT",
+		}
+		assert.Equal(t, Number(0.5), p.TransferAmountFromSpotTrade(trade))
+	})
+
+	t.Run("long deducts quote fee", func(t *testing.T) {
+		p, _ := newDirectionPolicy(types.PositionLong, market)
+		trade := types.Trade{
+			Quantity:      Number(0.5),
+			QuoteQuantity: Number(25000),
+			Fee:           Number(25),
+			FeeCurrency:   "USDT",
+		}
+		assert.Equal(t, Number(24975), p.TransferAmountFromSpotTrade(trade))
+	})
+
+	t.Run("long with non-quote fee returns full quote", func(t *testing.T) {
+		p, _ := newDirectionPolicy(types.PositionLong, market)
+		trade := types.Trade{
+			Quantity:      Number(0.5),
+			QuoteQuantity: Number(25000),
+			Fee:           Number(0.01),
+			FeeCurrency:   "BNB",
+		}
+		assert.Equal(t, Number(25000), p.TransferAmountFromSpotTrade(trade))
+	})
+
+	t.Run("long clamps negative result to zero", func(t *testing.T) {
+		p, _ := newDirectionPolicy(types.PositionLong, market)
+		trade := types.Trade{
+			QuoteQuantity: Number(1),
+			Fee:           Number(5),
+			FeeCurrency:   "USDT",
+		}
+		assert.Equal(t, fixedpoint.Zero, p.TransferAmountFromSpotTrade(trade))
+	})
+}
+
+func TestDirectionPolicy_TransferAmountFromFuturesTrade(t *testing.T) {
+	market := Market("BTCUSDT")
+
+	t.Run("short returns base quantity", func(t *testing.T) {
+		p, _ := newDirectionPolicy(types.PositionShort, market)
+		trade := types.Trade{Quantity: Number(0.5), QuoteQuantity: Number(25000)}
+		assert.Equal(t, Number(0.5), p.TransferAmountFromFuturesTrade(trade))
+	})
+
+	t.Run("long returns quote quantity", func(t *testing.T) {
+		p, _ := newDirectionPolicy(types.PositionLong, market)
+		trade := types.Trade{Quantity: Number(0.5), QuoteQuantity: Number(25000)}
+		assert.Equal(t, Number(25000), p.TransferAmountFromFuturesTrade(trade))
+	})
+}
+
+func TestDirectionPolicy_Signs(t *testing.T) {
+	market := Market("BTCUSDT")
+	short, _ := newDirectionPolicy(types.PositionShort, market)
+	long, _ := newDirectionPolicy(types.PositionLong, market)
+
+	assert.Equal(t, 1, short.SpotSign())
+	assert.Equal(t, -1, short.FuturesSign())
+	assert.Equal(t, -1, long.SpotSign())
+	assert.Equal(t, 1, long.FuturesSign())
+}

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -953,6 +953,7 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 				spotTwap,
 				futuresTwap,
 				s.futuresService,
+				s.MarketSelectionConfig.FuturesDirection,
 			)
 			round.SetLogger(s.logger)
 			round.SetSpotExchangeFeeRates(
@@ -1234,16 +1235,11 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 		return fmt.Errorf("[handleClosedRound] failed to close remaining positions for the futures: %w", err)
 	}
 
-	// transfer asset back to spot account
-	var asset string
-	switch s.MarketSelectionConfig.FuturesDirection {
-	case types.PositionShort:
-		// short futures -> transfer base currency
-		asset = round.FuturesMarket().BaseCurrency
-	case types.PositionLong:
-		// long futures -> transfer quote currency
-		asset = round.FuturesMarket().QuoteCurrency
-	}
+	// transfer any residual collateral back to the spot account. The bulk of
+	// the collateral is moved per-trade in handleFuturesTradeForClose; this
+	// block is a safety sweep for any leftover (e.g. PnL on the futures leg or
+	// residual after dust handling).
+	asset := round.CollateralAsset()
 	account, err := s.futuresSession.UpdateAccount(ctx)
 	if err != nil {
 		return fmt.Errorf("[handleClosedRound] failed to update futures account when handling round exit: %w", err)

--- a/pkg/strategy/xfundingv2/twap.go
+++ b/pkg/strategy/xfundingv2/twap.go
@@ -330,10 +330,10 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 
 	// check if deadline exceeded
 	deadlineExceeded := !currentTime.Before(w.syncState.EndTime)
-	closing := w.syncState.TargetPosition.IsZero()
 	orderOptions := TWAPExecuteOrderOptions{
 		DeadlineExceeded: deadlineExceeded,
-		ReduceOnly:       closing,
+		// use reduce-only if we are closing the position
+		ReduceOnly: w.syncState.TargetPosition.Compare(w.FilledPosition()) < 0,
 	}
 	// if deadline exceeded, we want to place a final order for the remaining quantity
 	if deadlineExceeded {


### PR DESCRIPTION
- Leader-Follower pattern: introducing directional policy struct
    - when opening, spot leg is the leader and the futures leg will creating position after spot trades.
    - when closing, futures leg is the leader and the spot leg will closing position after futures trades.
- Update tests