### PR TITLE
FIX: [xfundingv2] add logging for tick error and enhance dust slice logic for TWAP

### DIFF
--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -862,8 +862,22 @@ func (r *ArbitrageRound) Tick(currentTime time.Time, spotOrderBook types.OrderBo
 	}
 
 	// it's opening or closing, tick the workers
-	r.spotWorker.Tick(currentTime, spotOrderBook)
-	r.futuresWorker.Tick(currentTime, futuresOrderBook)
+	if err := r.spotWorker.Tick(currentTime, spotOrderBook); err != nil {
+		r.logger.
+			WithError(err).
+			Warnf(
+				"failed to tick %s spot worker at %s",
+				r.SpotSymbol(), currentTime.Format(time.RFC3339),
+			)
+	}
+	if err := r.futuresWorker.Tick(currentTime, futuresOrderBook); err != nil {
+		r.logger.
+			WithError(err).
+			Warnf(
+				"failed to tick %s futures worker at %s",
+				r.FuturesSymbol(), currentTime.Format(time.RFC3339),
+			)
+	}
 
 	// get mid price
 	spotMidPrice := getMidPrice(spotOrderBook)

--- a/pkg/strategy/xfundingv2/twap.go
+++ b/pkg/strategy/xfundingv2/twap.go
@@ -328,6 +328,9 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 		return nil
 	}
 
+	market := w.Market()
+	midPrice := getMidPrice(orderBook)
+
 	// check if deadline exceeded
 	deadlineExceeded := !currentTime.Before(w.syncState.EndTime)
 	orderOptions := TWAPExecuteOrderOptions{
@@ -343,6 +346,10 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 				return nil
 			}
 			w.syncAndResetActiveOrder()
+		}
+		// the remaining quantity is dust, do nothing
+		if !midPrice.IsZero() && market.IsDustQuantity(remaining, midPrice) {
+			return nil
 		}
 		createdOrder, err := w.syncState.TWAPExecutor.PlaceOrder(
 			remaining.Abs(),
@@ -360,7 +367,11 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 
 	// we don't have an active order, place a new one
 	if w.syncState.ActiveOrder == nil {
-		sliceQty := w.calculateSliceQuantity(currentTime, remaining, false)
+		sliceQty := w.calculateSliceQuantity(currentTime, remaining, false, market, midPrice)
+		// the slice quantity is dust, do nothing
+		if !midPrice.IsZero() && market.IsDustQuantity(sliceQty, midPrice) {
+			return nil
+		}
 		createdOrder, err := w.syncState.TWAPExecutor.PlaceOrder(
 			sliceQty,
 			orderSide(remaining),
@@ -382,6 +393,11 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 			return nil
 		}
 		w.syncState.LastCheckTime = currentTime
+
+		// the remaining quantity of the active order is dust, no need to update
+		if !midPrice.IsZero() && market.IsDustQuantity(w.syncState.ActiveOrder.GetRemainingQuantity(), midPrice) {
+			return nil
+		}
 
 		if err := w.syncState.TWAPExecutor.CancelOrder(w.ctx, *w.syncState.ActiveOrder); err != nil {
 			w.logger.WithError(err).Warn("[TWAP tick] failed to cancel active order")
@@ -424,7 +440,11 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 	w.syncAndResetActiveOrder()
 
 	// calculate slice quantity
-	sliceQty := w.calculateSliceQuantity(currentTime, remaining, deadlineExceeded)
+	sliceQty := w.calculateSliceQuantity(currentTime, remaining, deadlineExceeded, market, midPrice)
+	// the slice quantity is dust, do nothing
+	if !midPrice.IsZero() && market.IsDustQuantity(sliceQty, midPrice) {
+		return nil
+	}
 	createdOrder, err := w.syncState.TWAPExecutor.PlaceOrder(
 		sliceQty,
 		orderSide(remaining),
@@ -432,14 +452,14 @@ func (w *TWAPWorker) Tick(currentTime time.Time, orderBook types.OrderBook) erro
 		orderOptions,
 	)
 	if err != nil || createdOrder == nil {
-		return fmt.Errorf("failed to place order for next slice: %w", err)
+		return fmt.Errorf("failed to place order for the next slice: %w", err)
 	}
 	w.syncState.ActiveOrder = createdOrder
 
 	return nil
 }
 
-func (w *TWAPWorker) calculateSliceQuantity(currentTime time.Time, remaining fixedpoint.Value, deadlineExceeded bool) fixedpoint.Value {
+func (w *TWAPWorker) calculateSliceQuantity(currentTime time.Time, remaining fixedpoint.Value, deadlineExceeded bool, market types.Market, price fixedpoint.Value) fixedpoint.Value {
 	remaining = remaining.Abs()
 
 	if deadlineExceeded {
@@ -475,6 +495,19 @@ func (w *TWAPWorker) calculateSliceQuantity(currentTime time.Time, remaining fix
 	// cap at remaining
 	if sliceQty.Compare(remaining) > 0 {
 		sliceQty = remaining
+	}
+
+	if !price.IsZero() && market.IsDustQuantity(sliceQty, price) {
+		minQty := fixedpoint.Max(
+			market.MinQuantity,
+			market.AdjustQuantityByMinNotional(fixedpoint.Zero, price),
+		)
+		n := remaining.Div(minQty).Floor()
+		if n.Sign() > 0 {
+			sliceQty = remaining.Div(n)
+		} else {
+			sliceQty = remaining
+		}
 	}
 
 	return sliceQty

--- a/pkg/strategy/xfundingv2/twap_test.go
+++ b/pkg/strategy/xfundingv2/twap_test.go
@@ -718,6 +718,7 @@ func TestTWAPWorker_Misc(t *testing.T) {
 
 		worker, _, _, _ := newTestTWAPWorker(t, ctrl, config)
 
+		market := Market("BTCUSDT")
 		startTime := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 		worker.ResetTime(startTime, config.Duration)
 
@@ -725,33 +726,79 @@ func TestTWAPWorker_Misc(t *testing.T) {
 			// remaining = 2.0, time left = 8 min, interval = 2 min, remaining_slices = 4
 			// expected = 2.0 / 4 = 0.5
 			currentTime := startTime.Add(2 * time.Minute)
-			sliceQty := worker.calculateSliceQuantity(currentTime, Number(2.0), false)
+			sliceQty := worker.calculateSliceQuantity(currentTime, Number(2.0), false, market, fixedpoint.Zero)
 			assert.Equal(t, Number(0.5), sliceQty)
 		})
 
 		t.Run("respects max slice size", func(t *testing.T) {
 			// remaining = 5.0, remaining_slices = 5
 			// expected = 5.0 / 5 = 1.0, but max = 0.5
-			sliceQty := worker.calculateSliceQuantity(startTime, Number(5.0), false)
+			sliceQty := worker.calculateSliceQuantity(startTime, Number(5.0), false, market, fixedpoint.Zero)
 			assert.Equal(t, Number(0.5), sliceQty)
 		})
 
 		t.Run("respects min slice size", func(t *testing.T) {
 			// remaining = 0.5, remaining_slices = 5
 			// expected = 0.5 / 5 = 0.1
-			sliceQty := worker.calculateSliceQuantity(startTime, Number(0.5), false)
+			sliceQty := worker.calculateSliceQuantity(startTime, Number(0.5), false, market, fixedpoint.Zero)
 			assert.Equal(t, Number(0.1), sliceQty)
 		})
 
 		t.Run("remaining less than min returns remaining", func(t *testing.T) {
 			// remaining = 0.05, which is less than min 0.1
-			sliceQty := worker.calculateSliceQuantity(startTime, Number(0.05), false)
+			sliceQty := worker.calculateSliceQuantity(startTime, Number(0.05), false, market, fixedpoint.Zero)
 			assert.Equal(t, Number(0.05), sliceQty)
 		})
 
 		t.Run("deadline exceeded returns all remaining", func(t *testing.T) {
-			sliceQty := worker.calculateSliceQuantity(startTime, Number(3.0), true)
+			sliceQty := worker.calculateSliceQuantity(startTime, Number(3.0), true, market, fixedpoint.Zero)
 			assert.Equal(t, Number(3.0), sliceQty)
+		})
+
+		t.Run("dust slice re-sliced by minQty", func(t *testing.T) {
+			// BTCUSDT: MinNotional=10, MinQuantity=0.001
+			// price=100, so minQty = max(0.001, ceil(10/100)) = max(0.001, 0.1) = 0.1
+			// Use 20 slices so slice=1.0/20=0.05, notional=5<10 => dust
+			// n = floor(1.0 / 0.1) = 10, sliceQty = 1.0 / 10 = 0.1
+			dustConfig := TWAPWorkerConfig{
+				Duration:  types.Duration(10 * time.Minute),
+				NumSlices: 20,
+				OrderType: TWAPOrderTypeMaker,
+			}
+			dustWorker, _, _, _ := newTestTWAPWorker(t, ctrl, dustConfig)
+			dustWorker.ResetTime(startTime, dustConfig.Duration)
+
+			sliceQty := dustWorker.calculateSliceQuantity(startTime, Number(1.0), false, market, Number(100.0))
+			assert.Equal(t, Number(0.1), sliceQty)
+		})
+
+		t.Run("remaining less than minQty returns remaining", func(t *testing.T) {
+			// remaining=0.05, price=100, notional=5<10 => dust
+			// minQty=0.1, n=floor(0.05/0.1)=0 => return remaining
+			dustConfig := TWAPWorkerConfig{
+				Duration:  types.Duration(10 * time.Minute),
+				NumSlices: 1,
+				OrderType: TWAPOrderTypeMaker,
+			}
+			dustWorker, _, _, _ := newTestTWAPWorker(t, ctrl, dustConfig)
+			dustWorker.ResetTime(startTime, dustConfig.Duration)
+
+			sliceQty := dustWorker.calculateSliceQuantity(startTime, Number(0.05), false, market, Number(100.0))
+			assert.Equal(t, Number(0.05), sliceQty)
+		})
+
+		t.Run("non-dust slice unchanged", func(t *testing.T) {
+			// remaining=2.0, 5 slices, slice=0.4, price=100, notional=40>10 => not dust
+			dustConfig := TWAPWorkerConfig{
+				Duration:  types.Duration(10 * time.Minute),
+				NumSlices: 5,
+				OrderType: TWAPOrderTypeMaker,
+			}
+			dustWorker, _, _, _ := newTestTWAPWorker(t, ctrl, dustConfig)
+			dustWorker.ResetTime(startTime, dustConfig.Duration)
+
+			sliceQty := dustWorker.calculateSliceQuantity(startTime, Number(2.0), false, market, Number(100.0))
+			assert.Equal(t, Number(0.4), sliceQty)
 		})
 	})
 
@@ -845,8 +892,9 @@ func TestTWAPWorker_Misc(t *testing.T) {
 			worker.syncState.ActiveOrder = &types.Order{
 				OrderID: 1,
 				SubmitOrder: types.SubmitOrder{
-					Side:  types.SideTypeBuy,
-					Price: Number(99.01),
+					Side:     types.SideTypeBuy,
+					Price:    Number(99.01),
+					Quantity: Number(1.0),
 				},
 			}
 			// New best bid is higher, so improved price would be 99.51
@@ -859,8 +907,9 @@ func TestTWAPWorker_Misc(t *testing.T) {
 			worker.syncState.ActiveOrder = &types.Order{
 				OrderID: 1,
 				SubmitOrder: types.SubmitOrder{
-					Side:  types.SideTypeBuy,
-					Price: Number(99.51),
+					Side:     types.SideTypeBuy,
+					Price:    Number(99.51),
+					Quantity: Number(1.0),
 				},
 			}
 			// New best bid is lower
@@ -874,8 +923,9 @@ func TestTWAPWorker_Misc(t *testing.T) {
 			worker.syncState.ActiveOrder = &types.Order{
 				OrderID: 1,
 				SubmitOrder: types.SubmitOrder{
-					Side:  types.SideTypeSell,
-					Price: Number(99.98),
+					Side:     types.SideTypeSell,
+					Price:    Number(99.98),
+					Quantity: Number(1.0),
 				},
 			}
 			// New best ask is lower, so improved price would be 99.49
@@ -909,8 +959,9 @@ func TestTWAPWorker_Misc(t *testing.T) {
 		worker.syncState.ActiveOrder = &types.Order{
 			OrderID: 1,
 			SubmitOrder: types.SubmitOrder{
-				Side:  types.SideTypeBuy,
-				Price: Number(100.0),
+				Side:     types.SideTypeBuy,
+				Price:    Number(100.0),
+				Quantity: Number(1.0),
 			},
 		}
 


### PR DESCRIPTION
- add logging for error returned by `TWAPWorker.Tick()`.
- add dust quantity check for the TWAP slicing util function (`calculateSliceQuantity`)
    - if the slice is of dust quantity, `calculateSliceQuantity` will re-slice the given quantity so that the slice is as close as the original slice size and make it bigger enough to meet the min quantity/notional of the market