### PR TITLE
FIX: [xfundingv2] bug fix and add position metrics

### DIFF
--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -232,6 +232,10 @@ func (r *ArbitrageRound) TriggeredFundingRate() fixedpoint.Value {
 	return r.syncState.TriggeredFundingRate
 }
 
+func (r *ArbitrageRound) TriggeredTargetPosition() fixedpoint.Value {
+	return r.syncState.TriggeredSpotTargetPosition
+}
+
 func (r *ArbitrageRound) NumHoldingIntervals(currentTime time.Time) int {
 	if r.syncState.StartTime.IsZero() {
 		return 0
@@ -603,13 +607,6 @@ func (r *ArbitrageRound) HandleSpotTrade(trade types.Trade, currentTime time.Tim
 // After each spot fill, the futures position is synced to keep delta-neutral and the collateral asset is
 // transferred to futures so the futures leg can use it as collateral for its offsetting trade.
 func (r *ArbitrageRound) handleSpotTradeForOpen(trade types.Trade, currentTime time.Time) {
-	// no matter the transfer succeeds or not, we should update the futures position so that we can stay in delta-neutral
-	if _, found := r.syncState.SyncedSpotTrades[trade.ID]; !found {
-		// the trade is not synced to futures yet
-		r.syncFuturesPosition(trade)
-		r.syncState.SyncedSpotTrades[trade.ID] = struct{}{}
-	}
-
 	// move the collateral asset received from the spot fill onto the futures
 	// account so the futures leg can use it as margin.
 	transferAmount := r.syncState.DirectionPolicy.TransferAmountFromSpotTrade(trade)
@@ -652,6 +649,12 @@ func (r *ArbitrageRound) handleSpotTradeForOpen(trade types.Trade, currentTime t
 		asset,
 		trade,
 	)
+
+	// sync the futures position only after the transfer succeeds.
+	if _, found := r.syncState.SyncedSpotTrades[trade.ID]; !found {
+		r.syncFuturesPosition(trade)
+		r.syncState.SyncedSpotTrades[trade.ID] = struct{}{}
+	}
 }
 
 func (r *ArbitrageRound) HandleFuturesTrade(trade types.Trade, currentTime time.Time) {

--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -585,6 +585,7 @@ func (r *ArbitrageRound) SetRetryDuration(d time.Duration) {
 	r.syncState.RetryDuration = d
 }
 
+// HandleSpotTrade handles a spot trade, including update filled position, transfer collateral and sync futures position if the round is opening.
 func (r *ArbitrageRound) HandleSpotTrade(trade types.Trade, currentTime time.Time) {
 	// lock the round to ensure the state is updated correctly when receiving trade updates from spot worker
 	r.mu.Lock()
@@ -657,6 +658,7 @@ func (r *ArbitrageRound) handleSpotTradeForOpen(trade types.Trade, currentTime t
 	}
 }
 
+// HandleFuturesTrade handles a futures trade, including update filled position, transfer collateral and sync spot position if the round is closing.
 func (r *ArbitrageRound) HandleFuturesTrade(trade types.Trade, currentTime time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -838,6 +840,7 @@ func (r *ArbitrageRound) AnnualizedRate() fixedpoint.Value {
 	return AnnualizedRate(r.syncState.TriggeredFundingRate, r.syncState.FundingIntervalHours)
 }
 
+// Tick is called to tick the underlying spot and futures workers and update the round state
 func (r *ArbitrageRound) Tick(currentTime time.Time, spotOrderBook types.OrderBook, futuresOrderBook types.OrderBook) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/strategy/xfundingv2/metrics.go
+++ b/pkg/strategy/xfundingv2/metrics.go
@@ -55,3 +55,11 @@ var roundPositionFilledRatioMetrics = promauto.NewGaugeVec(
 	},
 	[]string{"strategy_type", "strategy_id", "symbol", "accountType"},
 )
+
+var roundPositionMetrics = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "xfundingv2_round_position",
+		Help: "Spot position of the arbitrage round",
+	},
+	[]string{"strategy_type", "strategy_id", "symbol", "accountType"},
+)

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -658,6 +658,23 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		// spot and futures position should be close to each other at all time.
 		spotFilled := round.SpotWorker().FilledPosition()
 		futuresFilled := round.FuturesWorker().FilledPosition()
+		// record the round spot/futures positions
+		roundPositionMetrics.With(
+			prometheus.Labels{
+				"strategy_type": s.ID(),
+				"strategy_id":   s.InstanceID(),
+				"symbol":        round.SpotSymbol(),
+				"accountType":   "spot",
+			},
+		).Set(spotFilled.Float64())
+		roundPositionMetrics.With(
+			prometheus.Labels{
+				"strategy_type": s.ID(),
+				"strategy_id":   s.InstanceID(),
+				"symbol":        round.FuturesSymbol(),
+				"accountType":   "futures",
+			},
+		).Set(futuresFilled.Float64())
 		// calculate the deviation of the unhedged position
 		spotFuturesRatio := fixedpoint.One
 		// when closing, the spotFilled may reach zero

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -566,10 +566,6 @@ func (s *Strategy) CrossRun(
 			if round.HasOrder(trade.OrderID) {
 				round.HandleSpotTrade(trade, trade.Time.Time())
 
-				spotOrderBook := s.spotOrderBooks[round.SpotSymbol()].Copy()
-				futuresOrderBook := s.futuresOrderBooks[round.FuturesSymbol()].Copy()
-				round.Tick(trade.Time.Time(), spotOrderBook, futuresOrderBook)
-
 				spotFilledPosition := round.SpotWorker().FilledPosition()
 				filledRatio := spotFilledPosition.Div(round.TriggeredTargetPosition()).Abs()
 				if round.State() == RoundClosing {
@@ -663,20 +659,28 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		spotFilled := round.SpotWorker().FilledPosition()
 		futuresFilled := round.FuturesWorker().FilledPosition()
 		// calculate the deviation of the unhedged position
-		deviation := fixedpoint.One.Sub(futuresFilled.Div(spotFilled)).Abs()
+		spotFuturesRatio := fixedpoint.One
+		// when closing, the spotFilled may reach zero
+		if !spotFilled.IsZero() {
+			spotFuturesRatio = futuresFilled.Div(spotFilled)
+		}
+		deviation := fixedpoint.One.Sub(spotFuturesRatio).Abs()
 		deviationTooLarge := deviation.Compare(s.CriticalErrorConfig.MaxHedgeDeviation) > 0
 		roundSymbol := round.SpotSymbol()
 		if !halted && deviationTooLarge {
 			// the round is originally not halted but the deviation is too large -> we need to halt the round
 			round.Halt(tickTime)
-			s.logger.Warnf("round %s halted due to large hedge deviation: %s, spot filled: %s, futures filled: %s",
+			s.logger.Warnf("round %s halted due to large hedge deviation: %s > %s, spot filled: %s, futures filled: %s",
 				roundSymbol,
 				deviation,
+				s.CriticalErrorConfig.MaxHedgeDeviation,
 				spotFilled,
 				futuresFilled,
 			)
-			bbgo.Notify("💥 Round %s halted due to large hedge deviation. Manual intervention is required.",
+			bbgo.Notify("💥 Round %s halted due to large hedge deviation (%s > %s). Manual intervention is required.",
 				roundSymbol,
+				deviation,
+				s.CriticalErrorConfig.MaxHedgeDeviation,
 				round.NewCriticalNotification(),
 			)
 			continue

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -571,7 +571,7 @@ func (s *Strategy) CrossRun(
 				round.Tick(trade.Time.Time(), spotOrderBook, futuresOrderBook)
 
 				spotFilledPosition := round.SpotWorker().FilledPosition()
-				filledRatio := spotFilledPosition.Div(round.TriggeredFundingRate()).Abs()
+				filledRatio := spotFilledPosition.Div(round.TriggeredTargetPosition()).Abs()
 				if round.State() == RoundClosing {
 					filledRatio = fixedpoint.One.Sub(filledRatio)
 				}
@@ -595,7 +595,7 @@ func (s *Strategy) CrossRun(
 				round.HandleFuturesTrade(trade, trade.Time.Time())
 
 				futuresFilledPosition := round.FuturesWorker().FilledPosition()
-				filledRatio := futuresFilledPosition.Div(round.TriggeredFundingRate()).Abs()
+				filledRatio := futuresFilledPosition.Div(round.TriggeredTargetPosition()).Abs()
 				if round.State() == RoundClosing {
 					filledRatio = fixedpoint.One.Sub(filledRatio)
 				}
@@ -679,6 +679,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 				roundSymbol,
 				round.NewCriticalNotification(),
 			)
+			continue
 		} else if halted && !deviationTooLarge {
 			// the deviation is back to normal, resume the round
 			haltedAt := round.HaltedAt()


### PR DESCRIPTION
- Fix deviation ratio calculation
    - prevent zero division when closing (spot filled may be zero)
    - add `TriggeredTargetPosition` to get the original target position for deviation ratio calculation
- Adjust the timing of futures position sync
   - sync futures position ONLY after a successful transfer
   - To prevent the risk of liquidation