### PR TITLE
FEATURE: [xfundingv2] closing all rounds on startup and periodic round stats notification

### DIFF
--- a/pkg/strategy/xfundingv2/arb_round.go
+++ b/pkg/strategy/xfundingv2/arb_round.go
@@ -346,6 +346,8 @@ func (n *roundNotification) SlackAttachment() slack.Attachment {
 				Short: true,
 			})
 	} else if n.HasStarted() {
+		minHoldingHours := n.syncState.MinHoldingIntervals * n.syncState.FundingIntervalHours
+		expectedClosingTime := n.syncState.FundingIntervalStart.Add(time.Duration(minHoldingHours) * time.Hour)
 		fields = append(fields,
 			slack.AttachmentField{
 				Title: "Start Time",
@@ -353,22 +355,26 @@ func (n *roundNotification) SlackAttachment() slack.Attachment {
 				Short: true,
 			},
 			slack.AttachmentField{
+				Title: "Last Update Time",
+				Value: n.syncState.LastUpdateTime.Format(time.RFC3339),
+				Short: true,
+			},
+			slack.AttachmentField{
 				Title: "Min Holding Intervals",
 				Value: fmt.Sprintf("%d", n.syncState.MinHoldingIntervals),
 				Short: true,
-			})
+			},
+			slack.AttachmentField{
+				Title: "Funding Interval Start",
+				Value: n.syncState.FundingIntervalStart.Format(time.RFC3339),
+				Short: true,
+			},
+			slack.AttachmentField{
+				Title: "Expected Closing Time",
+				Value: expectedClosingTime.Format(time.RFC3339),
+			},
+		)
 	}
-	fields = append(fields,
-		slack.AttachmentField{
-			Title: "Funding Interval Start",
-			Value: n.syncState.FundingIntervalStart.Format(time.RFC3339),
-			Short: true,
-		},
-		slack.AttachmentField{
-			Title: "Funding Interval End",
-			Value: n.syncState.FundingIntervalEnd.Format(time.RFC3339),
-			Short: true,
-		})
 	text := "Arbitrage Round Details"
 	if n.IsCritical && len(n.slackAlert.Mentions) > 0 {
 		text += "cc " + strings.Join(n.slackAlert.Mentions, " ")

--- a/pkg/strategy/xfundingv2/cost_estimator.go
+++ b/pkg/strategy/xfundingv2/cost_estimator.go
@@ -42,6 +42,14 @@ func (c *CostEstimator) SetTargetPosition(position fixedpoint.Value) *CostEstima
 	return c
 }
 
+func (c *CostEstimator) GetFuturesFeeRate() types.ExchangeFee {
+	return c.futuresFeeRate
+}
+
+func (c *CostEstimator) GetSpotFeeRate() types.ExchangeFee {
+	return c.spotFeeRate
+}
+
 // EstimatedCost represents the estimated cost of a transaction, either entry or exit
 type EstimatedCost struct {
 	FuturesPosition fixedpoint.Value

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -52,7 +52,8 @@ type Strategy struct {
 	// lock before update the strategy state, such as current round, selected market, etc
 	mu sync.Mutex
 
-	DryRun bool `json:"dryRun"`
+	DryRun              bool `json:"dryRun"`
+	ClosingAllOnStartup bool `json:"closingAllOnStartup"`
 
 	// Session configuration
 	SpotSession    string `json:"spotSession"`
@@ -618,6 +619,17 @@ func (s *Strategy) CrossRun(
 		}
 	})
 
+	// strategy is ready for running
+	if !bbgo.IsBackTesting && s.ClosingAllOnStartup {
+		s.mu.Lock()
+		s.logger.Info("closing all active rounds and clearing pending rounds on startup")
+		// set all active rounds to closing state and clear the pending rounds
+		for _, round := range s.ActiveRounds {
+			round.SetClosing(time.Now(), s.TWAPWorkerConfig.ClosingDuration)
+		}
+		s.PendingRounds = make(map[string]*PendingRound)
+		s.mu.Unlock()
+	}
 	bbgo.Notify("✅ Strategy %s is up and running with %d candidate symbols: %v",
 		s.InstanceID(),
 		len(s.candidateSymbols),

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -120,6 +120,10 @@ type Strategy struct {
 	SpotPositions    map[string]*types.Position `persistence:"spotPositions"`
 	FuturesPositions map[string]*types.Position `persistence:"futuresPositions"`
 
+	// StatsPeriod controls the duration of logging the stats of the strategy, such as the number of active rounds, pending rounds, closed rounds, etc.
+	StatsPeriod   types.Duration `json:"statsPeriod"`
+	lastStatsTime time.Time
+
 	// order executors for each symbol
 	// we need to cache the executors as map at startup since the executors are bound to the user data stream (via `.Bind()`).
 	// if we do no reuse them and create new executor at each round, the callbacks of the user data stream will be full of stale executors.
@@ -184,6 +188,10 @@ func (s *Strategy) Defaults() error {
 		s.HaltRoundNotificationInterval = types.Duration(time.Minute * 30)
 	}
 	s.CriticalErrorConfig.Defaults()
+
+	if s.StatsPeriod.Duration() == 0 {
+		s.StatsPeriod = types.Duration(time.Hour * 2)
+	}
 
 	return nil
 }
@@ -801,6 +809,12 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		futuresOrderBook := s.futuresOrderBooks[round.FuturesSymbol()].Copy()
 		round.Tick(tickTime, spotOrderBook, futuresOrderBook)
 	}
+
+	// 6. log stats
+	if s.lastStatsTime.IsZero() || tickTime.Sub(s.lastStatsTime) >= s.StatsPeriod.Duration() {
+		s.notifyStats()
+		s.lastStatsTime = tickTime
+	}
 }
 
 func (s *Strategy) transitRoundState(ctx context.Context, round *ArbitrageRound, currentTime time.Time) {
@@ -1400,4 +1414,28 @@ func (s *Strategy) newDebugLogger() *logrus.Entry {
 		"strategy":    ID,
 		"strategy_id": s.InstanceID(),
 	})
+}
+
+func (s *Strategy) notifyStats() {
+	var activeRoundNotifications []any
+	for _, round := range s.ActiveRounds {
+		activeRoundNotifications = append(activeRoundNotifications, round.NewNotification())
+	}
+
+	var pendingRoundNotifications []any
+	for _, pendingRound := range s.PendingRounds {
+		pendingRoundNotifications = append(pendingRoundNotifications, pendingRound.Round.NewNotification())
+	}
+
+	bbgo.Notify("📊 Round stats: %d active rounds, %d pending rounds",
+		len(s.ActiveRounds),
+		len(s.PendingRounds),
+	)
+	if len(activeRoundNotifications) > 0 {
+		bbgo.Notify("Active Rounds", activeRoundNotifications...)
+	}
+	if len(pendingRoundNotifications) > 0 {
+		bbgo.Notify("Pending Rounds", pendingRoundNotifications...)
+	}
+
 }

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1150,6 +1150,10 @@ func (s *Strategy) selectMostProfitableMarket(candidates []MarketCandidate) *Mar
 	spotAccount := s.spotSession.GetAccount()
 	breakevenIntervals := make(map[string]fixedpoint.Value)
 	targetFuturePositions := make(map[string]fixedpoint.Value)
+	// totalQuoteAmount = price * targetSize * feeRateFactor, where feeRateFactor = 1 + 2*feeRate (buy and sell fee)
+	// so the targetSize = totalQuoteAmount / (price * feeRateFactor)
+	feeRate := s.costEstimator.GetSpotFeeRate().TakerFeeRate
+	feeRateFactor := fixedpoint.One.Add(feeRate.Mul(fixedpoint.Two))
 	for _, candidate := range candidates {
 		spotMarket, ok := s.spotSession.Market(candidate.Symbol)
 		if !ok {
@@ -1165,11 +1169,12 @@ func (s *Strategy) selectMostProfitableMarket(candidates []MarketCandidate) *Mar
 			if !ok {
 				continue
 			}
-			tradeQuoteBalance := quoteBalance.Available.Mul(s.MarketSelectionConfig.TradeBalanceRatio)
+			totalQuoteAmount := quoteBalance.Available.Mul(s.MarketSelectionConfig.TradeBalanceRatio)
 			// long spot -> trade on the sell side of the order book
+			// targetSize = totalQuoteAmount / (price * feeRateFactor)
 			sellBook := s.spotOrderBooks[candidate.Symbol].SideBook(types.SideTypeSell)
-			spotPrice := sellBook.AverageDepthPriceByQuote(tradeQuoteBalance, 0)
-			targetSize := tradeQuoteBalance.Div(spotPrice)
+			spotPrice := sellBook.AverageDepthPriceByQuote(totalQuoteAmount, 0)
+			targetSize := totalQuoteAmount.Div(spotPrice.Mul(feeRateFactor))
 			// short futures -> trade on the buy side of the order book
 			buyBook := s.futuresOrderBooks[candidate.Symbol].SideBook(types.SideTypeBuy)
 			futuresPrice := buyBook.AverageDepthPrice(targetSize)
@@ -1189,12 +1194,15 @@ func (s *Strategy) selectMostProfitableMarket(candidates []MarketCandidate) *Mar
 			if !ok {
 				continue
 			}
-			targetSize := baseBalance.Available.Mul(s.MarketSelectionConfig.TradeBalanceRatio)
+			// totalQuoteAmount = price * totalBase and targetSize = totalQuoteAmount / (price * feeRateFactor)
+			// so targetSize = totalBase / feeRateFactor
+			totalBase := baseBalance.Available.Mul(s.MarketSelectionConfig.TradeBalanceRatio)
+			targetSize := totalBase.Div(feeRateFactor)
 			// long futures -> trade on the sell side of the order book
 			sellBook := s.futuresOrderBooks[candidate.Symbol].SideBook(types.SideTypeSell)
 			futuresPrice := sellBook.AverageDepthPrice(targetSize)
 			// long futures -> target future position should be positive
-			breakEvenIntervals, err := s.calculateMinHoldingIntervals(candidate, futuresPrice, targetSize)
+			breakEvenIntervals, err := s.calculateMinHoldingIntervals(candidate, futuresPrice, totalBase)
 			if err != nil {
 				continue
 			}

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -69,8 +69,9 @@ type Strategy struct {
 	TickSymbol   string         `json:"tickSymbol"`
 	TickInterval types.Interval `json:"tickInterval"`
 
-	FeeSymbol     string `json:"feeSymbol"`
-	QuoteCurrency string `json:"quoteCurrency"`
+	FeeSymbol       string           `json:"feeSymbol"`
+	FeeDiscountRate fixedpoint.Value `json:"feeDiscountRate"`
+	QuoteCurrency   string           `json:"quoteCurrency"`
 
 	PendingRoundGracePeriod types.Duration   `json:"pendingRoundGracePeriod"`
 	MaxPendingRoundRetry    int              `json:"maxPendingRoundRetry"`
@@ -240,6 +241,9 @@ func (s *Strategy) Validate() error {
 			return fmt.Errorf("maxPositionExposure should be positive: %s", symbol)
 		}
 	}
+	if s.FeeDiscountRate.Sign() < 0 || s.FeeDiscountRate.Compare(fixedpoint.One) > 0 {
+		return fmt.Errorf("feeDiscountRate should be between 0 and 1: %s", s.FeeDiscountRate)
+	}
 	return nil
 }
 
@@ -326,16 +330,25 @@ func (s *Strategy) CrossRun(
 	}
 
 	// initialize cost estimator
+	futuresFeeRate := types.ExchangeFee{
+		MakerFeeRate: s.futuresSession.MakerFeeRate,
+		TakerFeeRate: s.futuresSession.TakerFeeRate,
+	}
+	spotFeeRate := types.ExchangeFee{
+		MakerFeeRate: s.spotSession.MakerFeeRate,
+		TakerFeeRate: s.spotSession.TakerFeeRate,
+	}
+	if !s.FeeDiscountRate.IsZero() {
+		discountFactor := fixedpoint.One.Sub(s.FeeDiscountRate)
+		for _, feeRate := range []*types.ExchangeFee{&futuresFeeRate, &spotFeeRate} {
+			feeRate.MakerFeeRate = feeRate.MakerFeeRate.Mul(discountFactor)
+			feeRate.TakerFeeRate = feeRate.TakerFeeRate.Mul(discountFactor)
+		}
+	}
 	s.costEstimator = NewCostEstimator()
 	s.costEstimator.
-		SetFuturesFeeRate(types.ExchangeFee{
-			MakerFeeRate: s.futuresSession.MakerFeeRate,
-			TakerFeeRate: s.futuresSession.TakerFeeRate,
-		}).
-		SetSpotFeeRate(types.ExchangeFee{
-			MakerFeeRate: s.spotSession.MakerFeeRate,
-			TakerFeeRate: s.spotSession.TakerFeeRate,
-		})
+		SetFuturesFeeRate(futuresFeeRate).
+		SetSpotFeeRate(spotFeeRate)
 
 	// static filters
 	var candidateSymbols []string
@@ -1024,16 +1037,10 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 			)
 			round.SetLogger(s.logger)
 			round.SetSpotExchangeFeeRates(
-				types.ExchangeFee{
-					MakerFeeRate: s.spotSession.MakerFeeRate,
-					TakerFeeRate: s.spotSession.TakerFeeRate,
-				},
+				s.costEstimator.GetSpotFeeRate(),
 			)
 			round.SetFuturesExchangeFeeRates(
-				types.ExchangeFee{
-					MakerFeeRate: s.futuresSession.MakerFeeRate,
-					TakerFeeRate: s.futuresSession.TakerFeeRate,
-				},
+				s.costEstimator.GetFuturesFeeRate(),
 			)
 			round.SetSlackAlert(s.SlackAlert)
 			roundAnnualizedTriggerRateMetrics.With(


### PR DESCRIPTION
- add `ClosingAllOnStartup` flag
    - set all active rounds to closing state and clear the pending rounds queue
- periodic rounds stats notification
    - default to 2hrs
- minor round notification revision
- fee rate discount (ex: 10% BNB discount)
- adjust target size by trading fee