### PR TITLE
fix: supertrend Subscribe panics on disabled linearRegression config

### DIFF
--- a/pkg/strategy/supertrend/strategy.go
+++ b/pkg/strategy/supertrend/strategy.go
@@ -129,7 +129,14 @@ func (s *Strategy) Validate() error {
 
 func (s *Strategy) Subscribe(session *bbgo.ExchangeSession) {
 	session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.Interval})
-	session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.LinearRegression.Interval})
+	// LinearRegression is optional: setupIndicators() nils it for window==0 or
+	// empty-interval configs, and session.Subscribe panics on an empty kline
+	// interval — guard both panic paths here. Degenerate configs (window==0
+	// with an interval set) keep their historical unused subscription so
+	// existing backtest replay inputs are unchanged.
+	if s.LinearRegression != nil && s.LinearRegression.Interval != "" {
+		session.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: s.LinearRegression.Interval})
+	}
 
 	s.ExitMethods.SetAndSubscribe(session, s)
 

--- a/pkg/strategy/supertrend/strategy_test.go
+++ b/pkg/strategy/supertrend/strategy_test.go
@@ -1,0 +1,66 @@
+package supertrend
+
+import (
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/c9s/bbgo/pkg/bbgo"
+	"github.com/c9s/bbgo/pkg/types"
+	"github.com/c9s/bbgo/pkg/types/mocks"
+)
+
+func newTestSession(t *testing.T) *bbgo.ExchangeSession {
+	t.Helper()
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockEx := mocks.NewMockExchange(mockCtrl)
+	mockEx.EXPECT().NewStream().Return(&types.StandardStream{}).AnyTimes()
+	mockEx.EXPECT().Name().Return(types.ExchangeName("backtest")).AnyTimes()
+
+	return bbgo.NewExchangeSession("test", mockEx)
+}
+
+// A linearRegression block with window: 0 (or no interval) is nil-ed by
+// setupIndicators, but Subscribe used to dereference it unconditionally and
+// session.Subscribe panics on an empty kline interval.
+func TestStrategySubscribe_LinearRegressionNilSafe(t *testing.T) {
+	cases := []struct {
+		name   string
+		linReg *LinReg
+		subs   int
+	}{
+		{name: "nil block", linReg: nil, subs: 1},
+		{
+			name:   "window zero without interval",
+			linReg: &LinReg{IntervalWindow: types.IntervalWindow{Window: 0}},
+			subs:   1,
+		},
+		{
+			name: "valid block",
+			linReg: &LinReg{
+				IntervalWindow: types.IntervalWindow{Window: 20, Interval: types.Interval4h},
+			},
+			subs: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			session := newTestSession(t)
+			s := &Strategy{
+				Symbol:           "BTCUSDT",
+				IntervalWindow:   types.IntervalWindow{Interval: types.Interval1h, Window: 5},
+				LinearRegression: tc.linReg,
+			}
+
+			s.Subscribe(session)
+
+			if got := len(session.Subscriptions); got != tc.subs {
+				t.Fatalf("subscriptions = %d, want %d", got, tc.subs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`setupIndicators()` nils `LinearRegression` when `window == 0` or the interval is empty, but `Subscribe()` dereferences `s.LinearRegression.Interval` unconditionally.

A config like:

```yaml
exchangeStrategies:
- on: binance
  supertrend:
    symbol: BTCUSDT
    interval: 1h
    window: 50
    linearRegression:
      window: 0
```

panics with a nil-interval subscribe (and a block without an interval panics inside `session.Subscribe` on the empty kline interval).

## Fix

Guard both panic paths in `Subscribe()`, consistent with the `setupIndicators()` disable semantics. Degenerate configs that set an interval with `window: 0` keep their historical (unused) subscription, so existing backtest replay inputs are unchanged.

## Tests

Added `TestStrategySubscribe_LinearRegressionNilSafe` covering nil block / window-zero block / valid block (separate interval) — the first two panicked before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hiceFQWejhHyHnLayt1dE