### PR TITLE
FEATURE: opt-in pessimistic maker fill model for backtest limit orders

### DIFF
--- a/pkg/backtest/exchange.go
+++ b/pkg/backtest/exchange.go
@@ -138,12 +138,13 @@ func (e *Exchange) resetMatchingBooks() {
 
 func (e *Exchange) _addMatchingBook(symbol string, market types.Market) {
 	matching := &SimplePriceMatching{
-		Symbol:          symbol,
-		currentTime:     e.currentTime,
-		account:         e.account,
-		Market:          market,
-		closedOrders:    make(map[uint64]types.Order),
-		feeModeFunction: getFeeModeFunction(e.config.FeeMode),
+		Symbol:               symbol,
+		currentTime:          e.currentTime,
+		account:              e.account,
+		Market:               market,
+		closedOrders:         make(map[uint64]types.Order),
+		feeModeFunction:      getFeeModeFunction(e.config.FeeMode),
+		pessimisticMakerFill: e.config.GetAccount(e.sourceName.String()).PessimisticMakerFill,
 	}
 	e.matchingBooks[symbol] = matching
 }

--- a/pkg/backtest/matching.go
+++ b/pkg/backtest/matching.go
@@ -68,6 +68,8 @@ type SimplePriceMatching struct {
 
 	feeModeFunction FeeModeFunction
 
+	pessimisticMakerFill bool
+
 	account *types.Account
 
 	tradeUpdateCallbacks   []func(trade types.Trade)
@@ -214,9 +216,9 @@ func (m *SimplePriceMatching) PlaceOrder(o types.SubmitOrder) (*types.Order, *ty
 			// we assume it will be traded as a maker trade, and is traded at its original price
 			// TODO: if it is treated as a maker trade, fee should be specially handled
 			// otherwise, set NextKLine.Close(i.e., m.LastPrice) to be the taker traded price
-			if m.nextKLine != nil && m.nextKLine.High.Compare(order.Price) > 0 && order.Side == types.SideTypeBuy {
+			if !m.pessimisticMakerFill && m.nextKLine != nil && m.nextKLine.High.Compare(order.Price) > 0 && order.Side == types.SideTypeBuy {
 				order.AveragePrice = order.Price
-			} else if m.nextKLine != nil && m.nextKLine.Low.Compare(order.Price) < 0 && order.Side == types.SideTypeSell {
+			} else if !m.pessimisticMakerFill && m.nextKLine != nil && m.nextKLine.Low.Compare(order.Price) < 0 && order.Side == types.SideTypeSell {
 				order.AveragePrice = order.Price
 			} else {
 				order.AveragePrice = m.Market.TruncatePrice(m.lastPrice)
@@ -472,7 +474,7 @@ func (m *SimplePriceMatching) buyToPrice(price fixedpoint.Value) (closedOrders [
 			}
 
 		case types.OrderTypeLimit, types.OrderTypeLimitMaker:
-			if price.Compare(o.Price) >= 0 {
+			if m.shouldFillRestingSell(o, price) {
 				o.ExecutedQuantity = o.Quantity
 				o.Status = types.OrderStatusFilled
 				closedOrders = append(closedOrders, o)
@@ -601,7 +603,7 @@ func (m *SimplePriceMatching) sellToPrice(price fixedpoint.Value) (closedOrders 
 			}
 
 		case types.OrderTypeLimit, types.OrderTypeLimitMaker:
-			if price.Compare(o.Price) <= 0 {
+			if m.shouldFillRestingBuy(o, price) {
 				o.ExecutedQuantity = o.Quantity
 				o.Status = types.OrderStatusFilled
 				closedOrders = append(closedOrders, o)
@@ -703,6 +705,22 @@ func (m *SimplePriceMatching) processKLine(kline types.KLine) {
 	}
 
 	m.lastKLine = kline
+}
+
+func (m *SimplePriceMatching) shouldFillRestingBuy(o types.Order, price fixedpoint.Value) bool {
+	if !m.pessimisticMakerFill {
+		return price.Compare(o.Price) <= 0
+	}
+
+	return price.Compare(o.Price.Sub(m.Market.TickSize)) <= 0
+}
+
+func (m *SimplePriceMatching) shouldFillRestingSell(o types.Order, price fixedpoint.Value) bool {
+	if !m.pessimisticMakerFill {
+		return price.Compare(o.Price) >= 0
+	}
+
+	return price.Compare(o.Price.Add(m.Market.TickSize)) >= 0
 }
 
 func (m *SimplePriceMatching) newOrder(o types.SubmitOrder, orderID uint64) types.Order {

--- a/pkg/backtest/matching_test.go
+++ b/pkg/backtest/matching_test.go
@@ -498,6 +498,71 @@ func TestSimplePriceMatching_PlaceLimitOrder(t *testing.T) {
 	assert.Len(t, trades, 4)
 }
 
+func TestSimplePriceMatching_PessimisticMakerFill_RestingLimitTouchDoesNotFill(t *testing.T) {
+	account := getTestAccount()
+	account.MakerFeeRate = fixedpoint.MustNewFromString("0.05%")
+	account.TakerFeeRate = fixedpoint.MustNewFromString("0.10%")
+	market := getTestMarket()
+	engine := &SimplePriceMatching{
+		account:              account,
+		Market:               market,
+		closedOrders:         make(map[uint64]types.Order),
+		pessimisticMakerFill: true,
+	}
+
+	_, _, err := engine.PlaceOrder(newLimitOrder("BTCUSDT", types.SideTypeBuy, 8000.0, 1.0))
+	assert.NoError(t, err)
+	closedOrders, trades := engine.sellToPrice(fixedpoint.NewFromFloat(8000.0))
+	assert.Len(t, closedOrders, 0)
+	assert.Len(t, trades, 0)
+	assert.Len(t, engine.bidOrders, 1)
+
+	closedOrders, trades = engine.sellToPrice(fixedpoint.NewFromFloat(7999.99))
+	assert.Len(t, closedOrders, 1)
+	if assert.Len(t, trades, 1) {
+		assert.Equal(t, "8000", trades[0].Price.String())
+		assert.True(t, trades[0].IsMaker)
+		assert.Equal(t, fixedpoint.MustNewFromString("4").String(), trades[0].Fee.String())
+	}
+
+	_, _, err = engine.PlaceOrder(newLimitOrder("BTCUSDT", types.SideTypeSell, 9000.0, 1.0))
+	assert.NoError(t, err)
+	closedOrders, trades = engine.buyToPrice(fixedpoint.NewFromFloat(9000.0))
+	assert.Len(t, closedOrders, 0)
+	assert.Len(t, trades, 0)
+	assert.Len(t, engine.askOrders, 1)
+
+	closedOrders, trades = engine.buyToPrice(fixedpoint.NewFromFloat(9000.01))
+	assert.Len(t, closedOrders, 1)
+	if assert.Len(t, trades, 1) {
+		assert.Equal(t, "9000", trades[0].Price.String())
+		assert.True(t, trades[0].IsMaker)
+		assert.Equal(t, fixedpoint.MustNewFromString("4.5").String(), trades[0].Fee.String())
+	}
+}
+
+func TestSimplePriceMatching_DefaultMakerFillLimitTouchFills(t *testing.T) {
+	account := getTestAccount()
+	market := getTestMarket()
+	engine := &SimplePriceMatching{
+		account:      account,
+		Market:       market,
+		closedOrders: make(map[uint64]types.Order),
+	}
+
+	_, _, err := engine.PlaceOrder(newLimitOrder("BTCUSDT", types.SideTypeBuy, 8000.0, 1.0))
+	assert.NoError(t, err)
+	closedOrders, trades := engine.sellToPrice(fixedpoint.NewFromFloat(8000.0))
+	assert.Len(t, closedOrders, 1)
+	assert.Len(t, trades, 1)
+
+	_, _, err = engine.PlaceOrder(newLimitOrder("BTCUSDT", types.SideTypeSell, 9000.0, 1.0))
+	assert.NoError(t, err)
+	closedOrders, trades = engine.buyToPrice(fixedpoint.NewFromFloat(9000.0))
+	assert.Len(t, closedOrders, 1)
+	assert.Len(t, trades, 1)
+}
+
 func TestSimplePriceMatching_LimitTakerOrder(t *testing.T) {
 	account := getTestAccount()
 	market := getTestMarket()

--- a/pkg/bbgo/config.go
+++ b/pkg/bbgo/config.go
@@ -177,6 +177,8 @@ type BacktestAccount struct {
 	MakerFeeRate fixedpoint.Value `json:"makerFeeRate,omitempty" yaml:"makerFeeRate,omitempty"`
 	TakerFeeRate fixedpoint.Value `json:"takerFeeRate,omitempty" yaml:"takerFeeRate,omitempty"`
 
+	PessimisticMakerFill bool `json:"pessimisticMakerFill,omitempty" yaml:"pessimisticMakerFill,omitempty"`
+
 	Balances BacktestAccountBalanceMap `json:"balances" yaml:"balances"`
 }
 


### PR DESCRIPTION
## Motivation

The backtest matching engine is optimistic for resting limit orders:

1. they fill on any touch, at the exact limit price (no queue, no crossing requirement);
2. a limit order that crosses the current price can be classified as a *maker* via next-kline lookahead (`matching.go` `PlaceOrder`), earning maker fees on what a real market would fill as a taker.

Together these materially overstate maker/grid-style strategy PnL. While developing a maker-entry variant we measured the touch-fill assumption flipping a strategy's sign versus a crossing-required fill model.

## What

Adds `backtest.accounts.<name>.pessimisticMakerFill` (default `false` = existing behavior, bit-for-bit — verified against full-run report artifacts):

- crossing limit orders are takers, period — the next-kline lookahead maker classification is disabled;
- a resting maker order fills only when the bar's price range goes **strictly beyond** the limit price by one `tickSize` (a touch is not a fill), at the limit price.

```yaml
backtest:
  accounts:
    binance:
      makerFeeRate: 0.02%
      takerFeeRate: 0.05%
      pessimisticMakerFill: true
```

This is deliberately a *lower bound* rather than a realistic microstructure model: queue position and partial fills are still not modeled. But a strategy that survives this mode no longer depends on candle-perfect fills.

## Tests

`pkg/backtest/matching_test.go`: default-off keeps existing touch-fill behavior; pessimistic-on: touch-without-crossing does not fill, crossing by ≥ one tick fills at the limit price with the maker fee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hiceFQWejhHyHnLayt1dE