### PR TITLE
FIX: [xfundingv2] use mark price for PnL calculation and include estimated fees in unrealized PnL

### DIFF
--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -322,23 +322,23 @@ func (r *ArbitrageRound) SetSlackAlert(alert slackalert.SlackAlert) {
 	r.slackAlert = alert
 }
 
-func (r *ArbitrageRound) NewCriticalNotification(spotOrderBook, futuresOrderBook types.OrderBook) *roundNotification {
+func (r *ArbitrageRound) NewCriticalNotification(spotPrice, futuresPrice fixedpoint.Value) *roundNotification {
 	return &roundNotification{
 		ArbitrageRound: r,
 		IsCritical:     true,
 
-		spotOrderBook:    spotOrderBook,
-		futuresOrderBook: futuresOrderBook,
+		spotPrice:    spotPrice,
+		futuresPrice: futuresPrice,
 	}
 }
 
-func (r *ArbitrageRound) NewNotification(spotOrderBook, futuresOrderBook types.OrderBook) *roundNotification {
+func (r *ArbitrageRound) NewNotification(spotPrice, futuresPrice fixedpoint.Value) *roundNotification {
 	return &roundNotification{
 		ArbitrageRound: r,
 		IsCritical:     false,
 
-		spotOrderBook:    spotOrderBook,
-		futuresOrderBook: futuresOrderBook,
+		spotPrice:    spotPrice,
+		futuresPrice: futuresPrice,
 	}
 }
 
@@ -346,7 +346,7 @@ type roundNotification struct {
 	*ArbitrageRound
 	IsCritical bool
 
-	spotOrderBook, futuresOrderBook types.OrderBook
+	spotPrice, futuresPrice fixedpoint.Value
 }
 
 func (n *roundNotification) SlackAttachment() slack.Attachment {
@@ -434,8 +434,8 @@ func (n *roundNotification) SlackAttachment() slack.Attachment {
 			fields = append(fields, realizedPnLFields(realizedPnL)...)
 		} else {
 			unrealizedPnL := n.UnrealizedPnL(
-				n.spotOrderBook,
-				n.futuresOrderBook,
+				n.spotPrice,
+				n.futuresPrice,
 			)
 			spotAvgCost = unrealizedPnL.SpotPosition.AverageCost
 			futuresAvgCost = unrealizedPnL.FuturesPosition.AverageCost

--- a/pkg/strategy/xfundingv2/round_fee.go
+++ b/pkg/strategy/xfundingv2/round_fee.go
@@ -92,14 +92,12 @@ func (s *Strategy) processPendingRounds(ctx context.Context, currentTime time.Ti
 		// move to active round list
 		s.ActiveRounds[round.SpotSymbol()] = round
 		delete(s.PendingRounds, round.SpotSymbol())
-		spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+		spotPrice, futuresPrice, _ := s.getLastPrices(
 			round.SpotSymbol(),
 			round.FuturesSymbol(),
 		)
 		bbgo.Notify("🚀 Round started: %s", round.SpotSymbol(),
-			round.NewNotification(
-				spotOrderBook, futuresOrderBook,
-			),
+			round.NewNotification(spotPrice, futuresPrice),
 		)
 	}
 }

--- a/pkg/strategy/xfundingv2/round_pnl.go
+++ b/pkg/strategy/xfundingv2/round_pnl.go
@@ -122,11 +122,8 @@ type RoundUnrealizedPnL struct {
 	UnrealizedFuturesPnL fixedpoint.Value
 }
 
-// UnrealizedPnL calculates the unrealized profit and loss of the round by
-// marking the open spot and futures positions to the current order book prices.
-// Each leg is priced at its close side: a long leg at the best bid, a short leg
-// at the best ask.
-func (r *ArbitrageRound) UnrealizedPnL(spotOrderBook, futuresOrderBook types.OrderBook) *RoundUnrealizedPnL {
+// UnrealizedPnL calculates the unrealized profit and loss of the round by the given mark prices
+func (r *ArbitrageRound) UnrealizedPnL(spotPrice, futuresPrice fixedpoint.Value) *RoundUnrealizedPnL {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -136,10 +133,10 @@ func (r *ArbitrageRound) UnrealizedPnL(spotOrderBook, futuresOrderBook types.Ord
 		RoundRealizedPnL: *realized,
 	}
 
-	spotPrice, spotUnrealizedPnL := legUnrealizedPnL(spotOrderBook, realized.SpotPosition)
+	spotUnrealizedPnL := realized.SpotPosition.UnrealizedProfit(spotPrice)
 	result.SpotPrice = spotPrice
 	result.UnrealizedSpotPnL = spotUnrealizedPnL
-	futuresPrice, futuresUnrealizedPnL := legUnrealizedPnL(futuresOrderBook, realized.FuturesPosition)
+	futuresUnrealizedPnL := realized.FuturesPosition.UnrealizedProfit(futuresPrice)
 	result.FuturesPrice = futuresPrice
 	result.UnrealizedFuturesPnL = futuresUnrealizedPnL
 
@@ -158,29 +155,4 @@ func (r *RoundUnrealizedPnL) TotalFuturesNetPnL() fixedpoint.Value {
 // unrealized PnL of both open legs.
 func (p *RoundUnrealizedPnL) TotalPnL() fixedpoint.Value {
 	return p.RoundRealizedPnL.TotalPnL().Add(p.UnrealizedSpotPnL).Add(p.UnrealizedFuturesPnL)
-}
-
-// legUnrealizedPnL marks one leg to market.
-// If the position is long, it uses the best bid price; Otherwise, it uses the best ask price.
-func legUnrealizedPnL(book types.OrderBook, position *types.Position) (fixedpoint.Value, fixedpoint.Value) {
-	if position.IsClosed() {
-		return fixedpoint.Zero, fixedpoint.Zero
-	}
-
-	var price fixedpoint.Value
-	if position.IsLong() {
-		bid, ok := book.BestBid()
-		if !ok {
-			return fixedpoint.Zero, fixedpoint.Zero
-		}
-		price = bid.Price
-	} else {
-		ask, ok := book.BestAsk()
-		if !ok {
-			return fixedpoint.Zero, fixedpoint.Zero
-		}
-		price = ask.Price
-	}
-
-	return price, position.UnrealizedProfit(price)
 }

--- a/pkg/strategy/xfundingv2/round_pnl.go
+++ b/pkg/strategy/xfundingv2/round_pnl.go
@@ -133,12 +133,22 @@ func (r *ArbitrageRound) UnrealizedPnL(spotPrice, futuresPrice fixedpoint.Value)
 		RoundRealizedPnL: *realized,
 	}
 
+	// calculate estimated fees based on the current prices and base position sizes
+	spotFeeRate := r.spotExchangeFeeRates[r.syncState.SpotExchangeName].TakerFeeRate
+	futuresFeeRate := r.futuresExchangeFeeRates[r.syncState.FuturesExchangeName].TakerFeeRate
+	estimatedSpotFee := spotPrice.Mul(
+		realized.SpotPosition.Base.Abs(),
+	).Mul(spotFeeRate)
+	estimatedFuturesFee := futuresPrice.Mul(
+		realized.FuturesPosition.Base.Abs(),
+	).Mul(futuresFeeRate)
+
 	spotUnrealizedPnL := realized.SpotPosition.UnrealizedProfit(spotPrice)
 	result.SpotPrice = spotPrice
-	result.UnrealizedSpotPnL = spotUnrealizedPnL
+	result.UnrealizedSpotPnL = spotUnrealizedPnL.Sub(estimatedSpotFee)
 	futuresUnrealizedPnL := realized.FuturesPosition.UnrealizedProfit(futuresPrice)
 	result.FuturesPrice = futuresPrice
-	result.UnrealizedFuturesPnL = futuresUnrealizedPnL
+	result.UnrealizedFuturesPnL = futuresUnrealizedPnL.Sub(estimatedFuturesFee)
 
 	return result
 }

--- a/pkg/strategy/xfundingv2/round_pnl_test.go
+++ b/pkg/strategy/xfundingv2/round_pnl_test.go
@@ -131,19 +131,6 @@ func TestArbitrageRound_TradePnL(t *testing.T) {
 	})
 }
 
-// newTestOrderBook builds an order book with the given bid/ask price-volume text.
-// Either side may be empty to simulate a one-sided book.
-func newTestOrderBook(symbol, bidsText, asksText string) types.OrderBook {
-	book := &types.SliceOrderBook{Symbol: symbol}
-	if bidsText != "" {
-		book.Bids = PriceVolumeSliceFromText(bidsText)
-	}
-	if asksText != "" {
-		book.Asks = PriceVolumeSliceFromText(asksText)
-	}
-	return book
-}
-
 func TestArbitrageRound_UnrealizedPnL(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -153,10 +140,8 @@ func TestArbitrageRound_UnrealizedPnL(t *testing.T) {
 	t.Run("returns zero unrealized PnL when there are no trades", func(t *testing.T) {
 		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
 
-		spotBook := newTestOrderBook("BTCUSDT", "41000, 10", "41010, 10")
-		futuresBook := newTestOrderBook("BTCUSDT", "40990, 10", "41000, 10")
-
-		pnl := round.UnrealizedPnL(spotBook, futuresBook)
+		// no open positions → marking to any price yields zero unrealized PnL
+		pnl := round.UnrealizedPnL(Number(41000), Number(40000))
 		assert.Equal(t, fixedpoint.Zero, pnl.UnrealizedSpotPnL)
 		assert.Equal(t, fixedpoint.Zero, pnl.UnrealizedFuturesPnL)
 		// with no realized profit and no unrealized profit, total is zero
@@ -194,52 +179,30 @@ func TestArbitrageRound_UnrealizedPnL(t *testing.T) {
 			Time:          types.Time(time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC)),
 		})
 
-		// Spot long closes at the bid (41000 > 40000 avg cost → profit).
-		// Futures short closes at the ask (40000 < 40100 avg cost → profit).
-		spotBook := newTestOrderBook("BTCUSDT", "41000, 10", "41010, 10")
-		futuresBook := newTestOrderBook("BTCUSDT", "39990, 10", "40000, 10")
+		// Mark to the current prices: spot at 41000 (> 40000 avg cost → profit),
+		// futures at 40000 (< 40100 avg cost → profit for the short leg).
+		spotPrice := Number(41000)
+		futuresPrice := Number(40000)
 
-		pnl := round.UnrealizedPnL(spotBook, futuresBook)
+		pnl := round.UnrealizedPnL(spotPrice, futuresPrice)
 
 		// realized positions are populated on the embedded struct
 		assert.True(t, pnl.SpotPosition.IsLong(), "spot position should be long")
 		assert.True(t, pnl.FuturesPosition.IsShort(), "futures position should be short")
 
+		// prices are recorded on the result
+		assert.Equal(t, spotPrice, pnl.SpotPrice)
+		assert.Equal(t, futuresPrice, pnl.FuturesPrice)
+
 		// spot: (41000 - 40000) * 1 = 1000
 		assert.Equal(t, Number(1000), pnl.UnrealizedSpotPnL,
 			"unrealized spot PnL should be 1000, got: %s", pnl.UnrealizedSpotPnL)
-		// futures: (40000 - 40100) * -1 = 100
+		// futures: (40100 - 40000) * 1 = 100
 		assert.Equal(t, Number(100), pnl.UnrealizedFuturesPnL,
 			"unrealized futures PnL should be 100, got: %s", pnl.UnrealizedFuturesPnL)
 
 		// total = realized net + both unrealized legs
 		expectedTotal := pnl.NetPnL().Add(Number(1000)).Add(Number(100))
 		assert.Equal(t, expectedTotal, pnl.TotalPnL())
-	})
-
-	t.Run("returns zero for a leg when its close-side book is empty", func(t *testing.T) {
-		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
-
-		// long spot position → needs a bid to mark to market
-		spotExecutor := round.spotWorker.Executor()
-		spotExecutor.syncState.Orders[1] = types.OrderQuery{OrderID: "1"}
-		spotExecutor.AddTrade(types.Trade{
-			ID:            100,
-			OrderID:       1,
-			Symbol:        "BTCUSDT",
-			Side:          types.SideTypeBuy,
-			Price:         Number(40000),
-			Quantity:      Number(1),
-			QuoteQuantity: Number(40000),
-			Time:          types.Time(time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC)),
-		})
-
-		// spot book has asks only (no bid) → long leg cannot be priced → zero
-		spotBook := newTestOrderBook("BTCUSDT", "", "41010, 10")
-		futuresBook := newTestOrderBook("BTCUSDT", "39990, 10", "40000, 10")
-
-		pnl := round.UnrealizedPnL(spotBook, futuresBook)
-		assert.Equal(t, fixedpoint.Zero, pnl.UnrealizedSpotPnL,
-			"unrealized spot PnL should be zero when the bid side is empty")
 	})
 }

--- a/pkg/strategy/xfundingv2/round_record.go
+++ b/pkg/strategy/xfundingv2/round_record.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
-	"github.com/c9s/bbgo/pkg/types"
 )
 
 type RoundRecordBase struct {
@@ -267,9 +266,9 @@ type ActiveRoundRecord struct {
 // so the snapshot path persists the same funding-fee rows as the closed-round path.
 func (s *RoundInsertService) newActiveRoundRecord(
 	round *ArbitrageRound,
-	spotOrderBook, futuresOrderBook types.OrderBook,
+	spotPrice, futuresPrice fixedpoint.Value,
 ) (ActiveRoundRecord, []FundingFee) {
-	pnl := round.UnrealizedPnL(spotOrderBook, futuresOrderBook)
+	pnl := round.UnrealizedPnL(spotPrice, futuresPrice)
 
 	record := ActiveRoundRecord{
 		RoundRecordBase: RoundRecordBase{
@@ -330,13 +329,13 @@ func (s *RoundInsertService) newActiveRoundRecord(
 // round_id, txn) so they can be re-persisted when the round is later closed.
 func (s *RoundInsertService) InsertActiveRound(
 	round *ArbitrageRound,
-	spotOrderBook, futuresOrderBook types.OrderBook,
+	spotPrice, futuresPrice fixedpoint.Value,
 ) error {
 	if round.State() == RoundClosed {
 		return fmt.Errorf("given round is not active but closed: %s", round)
 	}
 
-	record, fees := s.newActiveRoundRecord(round, spotOrderBook, futuresOrderBook)
+	record, fees := s.newActiveRoundRecord(round, spotPrice, futuresPrice)
 
 	return s.insertActiveRound(record, fees)
 }

--- a/pkg/strategy/xfundingv2/round_sync.go
+++ b/pkg/strategy/xfundingv2/round_sync.go
@@ -18,20 +18,14 @@ func (r *ArbitrageRound) Initialize(ctx context.Context, s *Strategy) error {
 			r.syncState.FuturesExchangeName, s.futuresSession.Exchange.Name())
 	}
 	r.SetFuturesExchangeFeeRates(
-		types.ExchangeFee{
-			MakerFeeRate: s.futuresSession.MakerFeeRate,
-			TakerFeeRate: s.futuresSession.TakerFeeRate,
-		},
+		s.costEstimator.GetSpotFeeRate(),
 	)
 	if s.spotSession.Exchange.Name() != r.syncState.SpotExchangeName {
 		return fmt.Errorf("[ArbitrageRound] spot exchange name mismatch: expected %s, got %s",
 			r.syncState.SpotExchangeName, s.spotSession.Exchange.Name())
 	}
 	r.SetSpotExchangeFeeRates(
-		types.ExchangeFee{
-			MakerFeeRate: s.spotSession.MakerFeeRate,
-			TakerFeeRate: s.spotSession.TakerFeeRate,
-		},
+		s.costEstimator.GetFuturesFeeRate(),
 	)
 	r.retryTransferTickC = make(chan time.Time, 100)
 	if r.hasStarted() {

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -103,6 +103,9 @@ type Strategy struct {
 	// stream order books to keep track of the latest order book for the candidate symbols
 	futuresOrderBooks, spotOrderBooks map[string]*types.StreamOrderBook
 
+	updateLastPriceC                  chan time.Time
+	futuresMarkPrices, spotLastPrices map[string]fixedpoint.Value
+
 	candidateSymbols          []string
 	costEstimator             *CostEstimator
 	preliminaryMarketSelector *MarketSelector
@@ -267,6 +270,10 @@ func (s *Strategy) Initialize() error {
 		s.CircuitBreakers = make(map[string]*circuitbreaker.BasicCircuitBreaker)
 	}
 	s.haltNotificationLimiters = make(map[string]*rate.Limiter)
+
+	s.futuresMarkPrices = make(map[string]fixedpoint.Value)
+	s.spotLastPrices = make(map[string]fixedpoint.Value)
+
 	return nil
 }
 
@@ -692,6 +699,13 @@ func (s *Strategy) CrossRun(
 	// start round funding income syncing worker
 	s.runFundingIncomeWorker(s.ctx)
 
+	// update the last prices for the first time
+	if err := s.updateLastPrices(s.ctx); err != nil {
+		s.logger.WithError(err).Error("failed to update last prices at startup")
+	}
+	// start the last price updater worker
+	s.runLastPriceWorker(s.ctx)
+
 	// setup callbacks
 	s.spotSession.MarketDataStream.OnKLineClosed(types.KLineWith(s.TickSymbol, s.TickInterval, func(kline types.KLine) {
 		// end time of the kline is hh:mm:ss.999 -> add 1ms to round it up
@@ -777,11 +791,11 @@ func (s *Strategy) CrossRun(
 				continue
 			}
 			round.SetClosing(time.Now(), s.TWAPWorkerConfig.ClosingDuration)
-			spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+			spotPrice, futuresPrice, _ := s.getLastPrices(
 				round.SpotSymbol(),
 				round.FuturesSymbol(),
 			)
-			bbgo.Notify("⚠️ Round is set to closing state on startup", round.NewNotification(spotOrderBook, futuresOrderBook))
+			bbgo.Notify("⚠️ Round is set to closing state on startup", round.NewNotification(spotPrice, futuresPrice))
 		}
 		s.PendingRounds = make(map[string]*PendingRound)
 		s.mu.Unlock()
@@ -866,6 +880,14 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		}
 	}()
 
+	// trigger the worker to update the last prices
+	select {
+	case s.updateLastPriceC <- tickTime:
+		s.logger.Debugf("sent last price update tick time: %s", tickTime)
+	default:
+		s.logger.Warnf("last price update tick time channel is full, skip tick time: %s", tickTime)
+	}
+
 	if !s.lastTickTime.IsZero() && (s.lastTickTime.Equal(tickTime) || tickTime.Before(s.lastTickTime)) {
 		return
 	}
@@ -923,7 +945,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 					posDeviation.FuturesFilled,
 					posDeviation.DeviatedQuantity,
 				)
-				spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+				spotPrice, futuresPrice, _ := s.getLastPrices(
 					round.SpotSymbol(),
 					round.FuturesSymbol(),
 				)
@@ -931,7 +953,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 					roundSymbol,
 					posDeviation.SpotFilled, posDeviation.FuturesFilled,
 					posDeviation.DeviatedQuantity,
-					round.NewCriticalNotification(spotOrderBook, futuresOrderBook),
+					round.NewCriticalNotification(spotPrice, futuresPrice),
 				)
 				continue
 			} else if halted && !posDeviation.DeviateTooLong {
@@ -943,14 +965,14 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 					posDeviation.SpotFilled,
 					posDeviation.FuturesFilled,
 				)
-				spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+				spotPrice, futuresPrice, _ := s.getLastPrices(
 					round.SpotSymbol(),
 					round.FuturesSymbol(),
 				)
 				bbgo.Notify("✅ Round %s resumed as hedge deviation back to normal. It was halted at %s.",
 					roundSymbol,
 					haltedAt.Format(time.RFC3339),
-					round.NewNotification(spotOrderBook, futuresOrderBook),
+					round.NewNotification(spotPrice, futuresPrice),
 				)
 			}
 
@@ -959,7 +981,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 				haltedAt := round.HaltedAt()
 				elapsed := tickTime.Sub(haltedAt)
 				limiter, found := s.haltNotificationLimiters[round.SpotSymbol()]
-				spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+				spotPrice, futuresPrice, _ := s.getLastPrices(
 					round.SpotSymbol(),
 					round.FuturesSymbol(),
 				)
@@ -969,7 +991,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 						roundSymbol,
 						elapsed.String(),
 						haltedAt.Format(time.RFC3339),
-						round.NewCriticalNotification(spotOrderBook, futuresOrderBook),
+						round.NewCriticalNotification(spotPrice, futuresPrice),
 					)
 				}
 				continue
@@ -980,25 +1002,26 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 		// all transitions are done, check if the state has changed
 		currentState := round.State()
 		if oriState != currentState {
-			spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+			spotPrice, futuresPrice, _ := s.getLastPrices(
 				round.SpotSymbol(),
 				round.FuturesSymbol(),
 			)
+			notification := round.NewNotification(spotPrice, futuresPrice)
 			switch currentState {
 			case RoundReady:
 				bbgo.Notify("🟢 Round entered ready state: %s",
 					round.SpotSymbol(),
-					round.NewNotification(spotOrderBook, futuresOrderBook),
+					notification,
 				)
 			case RoundClosing:
 				bbgo.Notify("🟡 Round is closing: %s",
 					round.SpotSymbol(),
-					round.NewNotification(spotOrderBook, futuresOrderBook),
+					notification,
 				)
 			case RoundClosed:
 				bbgo.Notify("🔴 Round is closed: %s",
 					round.SpotSymbol(),
-					round.NewNotification(spotOrderBook, futuresOrderBook),
+					notification,
 				)
 			}
 		}
@@ -1027,13 +1050,13 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 				// send notification for rounds that failed to pass the cleanup process for 3 times.
 				// the symbol of the round will be blocked for opening new round until the issue is resolved.
 				task.Notified = true
-				spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+				spotPrice, futuresPrice, _ := s.getLastPrices(
 					round.SpotSymbol(),
 					round.FuturesSymbol(),
 				)
 				bbgo.Notify("💥 Failed to handle closed round after %d retries. Manual intervention is required.",
 					s.MaxClosedRetryCnt,
-					round.NewCriticalNotification(spotOrderBook, futuresOrderBook),
+					round.NewCriticalNotification(spotPrice, futuresPrice),
 				)
 			}
 			continue
@@ -1045,11 +1068,11 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 			s.logger.WithError(err).Errorf("failed to handle closed round: %s", task.Round)
 		} else {
 			s.closedRoundStats(task.Round, tickTime)
-			spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+			spotPrice, futuresPrice, _ := s.getLastPrices(
 				round.SpotSymbol(),
 				round.FuturesSymbol(),
 			)
-			bbgo.Notify("✅ Successfully handled closed round: %s", round.String(), round.NewNotification(spotOrderBook, futuresOrderBook))
+			bbgo.Notify("✅ Successfully handled closed round: %s", round.String(), round.NewNotification(spotPrice, futuresPrice))
 			delete(s.ClosedRoundTasks, task.Round.SpotSymbol())
 		}
 	}
@@ -1116,13 +1139,9 @@ func (s *Strategy) transitOpeningOrReadyRoundToClosing(ctx context.Context, roun
 
 	// the funding rate has flipped
 	if round.TriggeredFundingRate().Sign()*fundingRate.LastFundingRate.Sign() <= 0 {
-		spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+		spotPrice, futuresPrice, _ := s.getLastPrices(
 			round.SpotSymbol(),
 			round.FuturesSymbol(),
-		)
-		bbgo.Notify("⚠️ Round funding rate flipped %s -> %s (%s)",
-			round.TriggeredFundingRate(), fundingRate.LastFundingRate, round.SpotSymbol(),
-			round.NewNotification(spotOrderBook, futuresOrderBook),
 		)
 		rateDiffAbs := fundingRate.LastFundingRate.Sub(round.TriggeredFundingRate()).Abs()
 		if rateDiffAbs.Compare(s.CriticalErrorConfig.MaxFundingRateFlip) > 0 {
@@ -1130,10 +1149,15 @@ func (s *Strategy) transitOpeningOrReadyRoundToClosing(ctx context.Context, roun
 				round.TriggeredFundingRate(),
 				fundingRate.LastFundingRate,
 				s.CriticalErrorConfig.MaxFundingRateFlip,
-				round.NewCriticalNotification(spotOrderBook, futuresOrderBook),
+				round.NewCriticalNotification(spotPrice, futuresPrice),
 			)
 			round.SetClosing(currentTime, s.TWAPWorkerConfig.ClosingDuration)
 			return
+		} else {
+			bbgo.Notify("⚠️ Round funding rate flipped %s -> %s (%s)",
+				round.TriggeredFundingRate(), fundingRate.LastFundingRate, round.SpotSymbol(),
+				round.NewNotification(spotPrice, futuresPrice),
+			)
 		}
 
 		// the round is still within the min holding time, keep holding
@@ -1156,24 +1180,20 @@ func (s *Strategy) transitOpeningOrReadyRoundToClosing(ctx context.Context, roun
 		}
 		// the round is already beyond the min holding time and the funding rate has flipped
 		// check if the unrealized PnL is positive
-		spotOrderBook, futuresOrderBook, ok := s.getOrderBooks(
-			round.SpotSymbol(),
-			round.FuturesSymbol(),
-		)
+		spotPrice, futuresPrice, ok := s.getLastPrices(round.SpotSymbol(), round.FuturesSymbol())
 		if !ok {
 			s.logger.Warnf("[transitOpeningOrReadyRound] order book not found for symbols: %s", round.SpotSymbol())
 			return
 		}
 
-		midPrice := getMidPrice(futuresOrderBook)
 		futuresPosition := round.FuturesWorker().FilledPosition()
-		futuresPositionNotional := futuresPosition.Abs().Mul(midPrice)
+		futuresPositionNotional := futuresPosition.Abs().Mul(futuresPrice)
 		// short position -> last funding rate is negative due to the flipped rate
 		// long position -> last funding rate is positive due to the flipped rate
 		// the product of the flipped rate and the position is positive
 		// we need to negate the product to get the next funding income, which should be negative -> expected loss
 		nextFundingIncome := fundingRate.LastFundingRate.Mul(futuresPosition).Neg()
-		unrealizedPnL := round.UnrealizedPnL(spotOrderBook, futuresOrderBook)
+		unrealizedPnL := round.UnrealizedPnL(spotPrice, futuresPrice)
 		unrealizedTotalPnL := unrealizedPnL.TotalPnL()
 		// the unrealized PnL is positive or the expected unrealized net PnL is below the max closing loss ratio, transit to closing
 		// That is, we will close the round either when there is profit or the estimated loss is too large
@@ -1614,14 +1634,14 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 		if err := s.futuresService.TransferFuturesAccountAsset(ctx, asset, residualAmount, types.TransferOut); err != nil {
 			return fmt.Errorf("[handleClosedRound] failed to transfer %s %s during round exit: %w", balance.Available, asset, err)
 		} else {
-			spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+			spotPrice, futuresPrice, _ := s.getLastPrices(
 				round.SpotSymbol(),
 				round.FuturesSymbol(),
 			)
 			bbgo.Notify("⬅️ Transferred %s %s back to spot account",
 				balance.Available,
 				asset,
-				round.NewNotification(spotOrderBook, futuresOrderBook),
+				round.NewNotification(spotPrice, futuresPrice),
 			)
 		}
 	}
@@ -1716,16 +1736,16 @@ func (s *Strategy) newDebugLogger() *logrus.Entry {
 func (s *Strategy) notifyStats() {
 	var activeRoundNotifications []any
 	for _, round := range s.ActiveRounds {
-		spotOrderBook, futuresOrderBook, ok := s.getOrderBooks(
+		spotPrice, futuresPrice, ok := s.getLastPrices(
 			round.SpotSymbol(),
 			round.FuturesSymbol(),
 		)
 		if !ok {
 			continue
 		}
-		activeRoundNotifications = append(activeRoundNotifications, round.NewNotification(spotOrderBook, futuresOrderBook))
+		activeRoundNotifications = append(activeRoundNotifications, round.NewNotification(spotPrice, futuresPrice))
 		if s.roundInsertService != nil {
-			if err := s.roundInsertService.InsertActiveRound(round, spotOrderBook, futuresOrderBook); err != nil {
+			if err := s.roundInsertService.InsertActiveRound(round, spotPrice, futuresPrice); err != nil {
 				s.logger.WithError(err).Warnf("failed to insert active round to database: %s", round)
 			}
 		}
@@ -1733,11 +1753,11 @@ func (s *Strategy) notifyStats() {
 
 	var pendingRoundNotifications []any
 	for _, pendingRound := range s.PendingRounds {
-		spotOrderBook, futuresOrderBook, _ := s.getOrderBooks(
+		spotPrice, futuresPrice, _ := s.getLastPrices(
 			pendingRound.Round.SpotSymbol(),
 			pendingRound.Round.FuturesSymbol(),
 		)
-		pendingRoundNotifications = append(pendingRoundNotifications, pendingRound.Round.NewNotification(spotOrderBook, futuresOrderBook))
+		pendingRoundNotifications = append(pendingRoundNotifications, pendingRound.Round.NewNotification(spotPrice, futuresPrice))
 	}
 
 	bbgo.Notify("📊 Round stats: %d active rounds, %d pending rounds",
@@ -1872,8 +1892,56 @@ func (s *Strategy) setLeverage(ctx context.Context) error {
 	return nil
 }
 
-func (s *Strategy) getOrderBooks(spotSymbol, futuresSymbol string) (types.OrderBook, types.OrderBook, bool) {
-	spotOrderBook, spotOk := s.spotOrderBooks[spotSymbol]
-	futuresOrderBook, futuresOk := s.futuresOrderBooks[futuresSymbol]
-	return spotOrderBook.Copy(), futuresOrderBook.Copy(), spotOk && futuresOk
+func (s *Strategy) getLastPrices(spotSymbol, futuresSybol string) (spotPrice, futuresPrice fixedpoint.Value, ok bool) {
+	spotPrice, spotOk := s.spotLastPrices[spotSymbol]
+	futuresPrice, futuresOk := s.futuresMarkPrices[futuresSybol]
+
+	return spotPrice, futuresPrice, spotOk && futuresOk
+}
+
+func (s *Strategy) runLastPriceWorker(ctx context.Context) {
+	if s.updateLastPriceC != nil {
+		return
+	}
+
+	s.updateLastPriceC = make(chan time.Time, 5)
+	s.logger.Info("starting last price worker")
+	go func() {
+		defer s.logger.Info("last price worker exited")
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case tickTime, ok := <-s.updateLastPriceC:
+				if !ok {
+					return
+				}
+				if err := s.updateLastPrices(ctx); err != nil {
+					s.logger.WithError(err).Errorf("failed to update last price at %s", tickTime.Format(time.RFC3339))
+				}
+			}
+		}
+	}()
+}
+
+func (s *Strategy) updateLastPrices(ctx context.Context) error {
+	timedCtx, cancel := context.WithTimeout(ctx, 40*time.Second)
+	defer cancel()
+
+	for _, symbol := range s.candidateSymbols {
+		// update spot price
+		if ticker, err := s.spotSession.Exchange.QueryTicker(timedCtx, symbol); err != nil {
+			return err
+		} else {
+			s.spotLastPrices[symbol] = ticker.Last
+		}
+
+		// update futures price
+		if index, err := s.futuresService.QueryPremiumIndex(timedCtx, symbol); err != nil {
+			return err
+		} else {
+			s.futuresMarkPrices[symbol] = index.MarkPrice
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
- Use mark price for PnL calculation
    - use the last tick price for the spot market
    - use the mark price of the premium index  on the futures market
- Include estimated fee in unrealized PnL