### PR TITLE
fix(bbgo): skip interaction/OTP setup when no notifier is configured

### DIFF
--- a/pkg/bbgo/environment.go
+++ b/pkg/bbgo/environment.go
@@ -769,9 +769,17 @@ func (environ *Environment) ConfigureNotificationSystem(ctx context.Context, use
 	var isolation = GetIsolationFromContext(ctx)
 	var persistence = isolation.persistenceServiceFacade.Get()
 
-	err := environ.setupInteraction(persistence)
-	if err != nil {
-		return err
+	// check if telegram bot token is defined
+	telegramBotToken := viper.GetString("telegram-bot-token")
+
+	// the interaction (OTP / auth) subsystem is only meaningful when there is a
+	// messenger (currently only telegram) that can actually send or receive it.
+	// skip it entirely when telegram is not configured so bbgo does not touch
+	// persistence or attempt any network dial when no notifier is set up at all.
+	if len(telegramBotToken) > 0 {
+		if err := environ.setupInteraction(persistence); err != nil {
+			return err
+		}
 	}
 
 	// setup slack
@@ -780,8 +788,6 @@ func (environ *Environment) ConfigureNotificationSystem(ctx context.Context, use
 		environ.setupSlack(userConfig, slackToken, persistence)
 	}
 
-	// check if telegram bot token is defined
-	telegramBotToken := viper.GetString("telegram-bot-token")
 	if len(telegramBotToken) > 0 {
 		if err := environ.setupTelegram(userConfig, telegramBotToken, persistence); err != nil {
 			return err

--- a/pkg/bbgo/environment_notification_test.go
+++ b/pkg/bbgo/environment_notification_test.go
@@ -1,0 +1,72 @@
+package bbgo
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/bbgo/pkg/service"
+)
+
+// resetNotifierViperFlags clears the viper flags that
+// ConfigureNotificationSystem reads to decide whether any notifier is
+// configured, and restores them afterwards so other tests are not affected.
+func resetNotifierViperFlags(t *testing.T) {
+	keys := []string{"telegram-bot-token", "slack-bot-token", "slack-token"}
+	original := make(map[string]interface{}, len(keys))
+	for _, k := range keys {
+		original[k] = viper.Get(k)
+		viper.Set(k, "")
+	}
+
+	t.Cleanup(func() {
+		for _, k := range keys {
+			viper.Set(k, original[k])
+		}
+	})
+}
+
+// TestConfigureNotificationSystem_NoNotifierConfigured covers issue #2209:
+// when no notifier env (telegram/slack token) and no notifications config
+// block are present, the notification bootstrap must not initialize the
+// interaction/OTP subsystem, since that subsystem only exists to authorize a
+// messenger, and there is no messenger without a telegram bot token. In
+// particular it must not touch the persistence layer, since doing so on a
+// misconfigured or unavailable persistence backend is what previously
+// crashed with "dial tcp :0".
+func TestConfigureNotificationSystem_NoNotifierConfigured(t *testing.T) {
+	resetNotifierViperFlags(t)
+
+	mem := service.NewMemoryService()
+	isolation := NewIsolation(&service.PersistenceServiceFacade{Memory: mem})
+	ctx := NewContextWithIsolation(context.Background(), isolation)
+
+	environ := NewEnvironment()
+	userConfig := &Config{}
+
+	err := environ.ConfigureNotificationSystem(ctx, userConfig)
+	assert.NoError(t, err)
+	assert.Empty(t, mem.Slots, "notification bootstrap should not touch persistence when no notifier is configured")
+}
+
+// TestSetupInteraction_PersistsOTPKey ensures the interaction (OTP/auth)
+// subsystem, when it does run (i.e. the path taken when telegram is
+// configured), still persists the OTP auth key as before. This guards
+// against over-broad gating that would silently disable the auth flow for
+// users who do use telegram notifications. It exercises setupInteraction
+// directly, bypassing setupTelegram/telebot.NewBot, which performs a real
+// network call to the Telegram API and is out of scope for this fix.
+func TestSetupInteraction_PersistsOTPKey(t *testing.T) {
+	otpImagePath := "otp.png"
+	t.Cleanup(func() { os.Remove(otpImagePath) })
+
+	mem := service.NewMemoryService()
+	environ := NewEnvironment()
+
+	err := environ.setupInteraction(mem)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, mem.Slots, "OTP auth key should be persisted when the interaction subsystem runs")
+}


### PR DESCRIPTION
## Summary

Fixes #2209.

The notification bootstrap in `ConfigureNotificationSystem` always called `setupInteraction`, which generates or loads a one time password auth key and saves it through the persistence layer, even when no telegram bot token and no slack token are configured. That subsystem only exists to authorize a telegram messenger through the `/auth` command, and there is no messenger without a telegram bot token, so running it has no value when telegram is not configured.

In Docker deployments where the persistence backend ends up misconfigured (for example an unrecognized `redis` config key leaving host and port empty), this unconditional call produced a fatal `dial tcp :0: connect: connection refused` error on startup, even though the user never asked for any notifier and had no `notifications:` block in their config. bbgo never got to start the webserver or the strategies.

This change gates `setupInteraction` on the same telegram bot token check already used for `setupTelegram`, so the whole notification bootstrap becomes a no op when neither telegram nor slack is configured. That matches the existing skip behavior in `Interact.Start`, which already logs "messenger is not set, skip initializing" when there are no messengers registered, so no new command surface is removed, only the redundant persistence access ahead of it.

## Changes

- `pkg/bbgo/environment.go`: only call `setupInteraction` when a telegram bot token is present.
- `pkg/bbgo/environment_notification_test.go`: new tests.
  - `TestConfigureNotificationSystem_NoNotifierConfigured` asserts that with no telegram/slack token and no `notifications:` config, `ConfigureNotificationSystem` returns no error and never writes to the persistence layer.
  - `TestSetupInteraction_PersistsOTPKey` asserts that when the interaction subsystem does run, it still persists the OTP auth key as before, so telegram users are unaffected.

## AI disclosure

This PR was prepared with AI assistance (Cursor). The change and tests were verified by running the repository's own build, vet, and test commands and by confirming the new regression test fails on the pre-fix code and passes after the fix. Human review: Stan Shih (stantheman0128).

## Evidence

Reproduced the reported crash path: on the pre-fix code, calling the notification bootstrap with no telegram or slack token configured still runs `setupInteraction`, which writes an OTP auth key to persistence. The new test `TestConfigureNotificationSystem_NoNotifierConfigured` fails against pre-fix `pkg/bbgo/environment.go` with:

```
Error:      	Should be empty, but was map[bbgo:auth:default:otpauth://totp/...]
Test:       	TestConfigureNotificationSystem_NoNotifierConfigured
--- FAIL: TestConfigureNotificationSystem_NoNotifierConfigured (0.01s)
```

After the fix, the full package suite is green:

```
$ go build ./pkg/bbgo/...
$ go vet ./pkg/bbgo/...
$ go test ./pkg/bbgo/... -run "TestConfigureNotificationSystem|TestSetupInteraction" -v
=== RUN   TestConfigureNotificationSystem_NoNotifierConfigured
--- PASS: TestConfigureNotificationSystem_NoNotifierConfigured (0.00s)
=== RUN   TestSetupInteraction_PersistsOTPKey
--- PASS: TestSetupInteraction_PersistsOTPKey (0.01s)
PASS
ok  	github.com/c9s/bbgo/pkg/bbgo	0.161s

$ go test ./pkg/bbgo/...
ok  	github.com/c9s/bbgo/pkg/bbgo	1.309s
ok  	github.com/c9s/bbgo/pkg/bbgo/sessionworker	0.159s

$ go build ./cmd/... ./pkg/...
(exit 0, no output)
```

What was not tested: the reporter's exact Docker/Redis misconfiguration was not reproduced end to end (no Docker/Redis available in this environment). The fix addresses the root cause reported in the issue, that the interaction subsystem should not initialize at all when no notifier is configured, which is independent of what specifically made the reporter's persistence backend fail to dial. `go build ./...` also fails in `examples/max-withdraw`, but that failure is preexisting on `origin/main` and unrelated to this change (confirmed by reproducing it on a clean stash of this diff).
