### PR TITLE
fix(binance): lock futures MinNotional conversion and warn on zero

### DIFF
--- a/pkg/exchange/binance/convert.go
+++ b/pkg/exchange/binance/convert.go
@@ -118,6 +118,14 @@ func toGlobalFuturesMarket(symbol futures.Symbol) types.Market {
 		market.TickSize = fixedpoint.MustNewFromString(f.TickSize)
 	}
 
+	if market.MinNotional.IsZero() {
+		log.Warnf("binance futures market %s minNotional is zero", market.Symbol)
+	}
+
+	if market.MinQuantity.IsZero() {
+		log.Warnf("binance futures market %s minQuantity is zero", market.Symbol)
+	}
+
 	return market
 }
 

--- a/pkg/exchange/binance/convert_futures_test.go
+++ b/pkg/exchange/binance/convert_futures_test.go
@@ -11,6 +11,70 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestToGlobalFuturesMarket_MinNotional(t *testing.T) {
+	// Fixture shaped like fapi/v1/exchangeInfo filters for BTCUSDT (MIN_NOTIONAL).
+	// Regression for #1610: MinNotionalFilter() must populate MinNotional and MinAmount.
+	symbol := futures.Symbol{
+		Symbol:             "BTCUSDT",
+		BaseAsset:          "BTC",
+		QuoteAsset:         "USDT",
+		PricePrecision:     2,
+		QuantityPrecision:  3,
+		BaseAssetPrecision: 8,
+		QuotePrecision:     8,
+		Filters: []map[string]any{
+			{
+				"filterType": "PRICE_FILTER",
+				"maxPrice":   "4529764",
+				"minPrice":   "556.80",
+				"tickSize":   "0.10",
+			},
+			{
+				"filterType": "LOT_SIZE",
+				"maxQty":     "1000",
+				"minQty":     "0.001",
+				"stepSize":   "0.001",
+			},
+			{
+				"filterType": "MIN_NOTIONAL",
+				"notional":   "50",
+			},
+		},
+	}
+
+	market := toGlobalFuturesMarket(symbol)
+	assert.Equal(t, "BTCUSDT", market.Symbol)
+	assert.Equal(t, types.ExchangeBinance, market.Exchange)
+	assert.Equal(t, fixedpoint.MustNewFromString("50"), market.MinNotional)
+	assert.Equal(t, fixedpoint.MustNewFromString("50"), market.MinAmount)
+	assert.Equal(t, fixedpoint.MustNewFromString("0.001"), market.MinQuantity)
+	assert.Equal(t, fixedpoint.MustNewFromString("0.001"), market.StepSize)
+	assert.Equal(t, fixedpoint.MustNewFromString("0.10"), market.TickSize)
+	assert.False(t, market.MinNotional.IsZero())
+	assert.False(t, market.MinAmount.IsZero())
+}
+
+func TestToGlobalFuturesMarket_MinNotionalMissingFilter(t *testing.T) {
+	symbol := futures.Symbol{
+		Symbol:     "BTCUSDT",
+		BaseAsset:  "BTC",
+		QuoteAsset: "USDT",
+		Filters: []map[string]any{
+			{
+				"filterType": "LOT_SIZE",
+				"maxQty":     "1000",
+				"minQty":     "0.001",
+				"stepSize":   "0.001",
+			},
+		},
+	}
+
+	market := toGlobalFuturesMarket(symbol)
+	assert.True(t, market.MinNotional.IsZero())
+	assert.True(t, market.MinAmount.IsZero())
+	assert.Equal(t, fixedpoint.MustNewFromString("0.001"), market.MinQuantity)
+}
+
 func TestToGlobalPositionRisk(t *testing.T) {
 	positions := []binanceapi.FuturesPositionRisk{
 		{


### PR DESCRIPTION
## Summary

Closes #1610.

Reporter saw `MinNotionalFilter()` return nil in futures mode, so `market.MinNotional` / `market.MinAmount` stayed zero. Maintainer upgraded `adshao/go-binance` and the reporter confirmed the live path works again. The issue was still open with no conversion regression coverage.

This PR keeps the conversion locked with a fixture shaped like current `fapi/v1/exchangeInfo` (`MIN_NOTIONAL` + `notional`) and adds the same zero MinNotional / MinQuantity warnings futures was missing compared with the spot `toGlobalMarket` path.

Live public check on this machine (no API keys): BTCUSDT futures still exposes `filterType=MIN_NOTIONAL` with `notional=50`.

## Changes

- `pkg/exchange/binance/convert_futures_test.go`: `TestToGlobalFuturesMarket_MinNotional` and `TestToGlobalFuturesMarket_MinNotionalMissingFilter`.
- `pkg/exchange/binance/convert.go`: warn when futures MinNotional or MinQuantity is zero after filter parse.

## AI disclosure

Prepared with AI assistance (Cursor / Grok). Changes and tests were verified with the repo Go toolchain on this machine. Human review: Stan Shih (stantheman0128).

## Evidence

```
$ go test ./pkg/exchange/binance/ -count=1 -run TestToGlobalFuturesMarket_MinNotional
ok  	github.com/c9s/bbgo/pkg/exchange/binance	0.323s

$ go test ./pkg/exchange/binance/ -count=1 -run TestToGlobalFutures
ok  	github.com/c9s/bbgo/pkg/exchange/binance	0.323s
```

Public futures exchangeInfo snippet used for the fixture shape:

```
filterType=MIN_NOTIONAL, notional=50  (BTCUSDT on fapi.binance.com)
```

## What was not tested

- Full `bbgo run` against a live Binance futures session (no exchange keys in this environment). The conversion path is covered by the unit fixture above.