### PR TITLE
FEATURE: [xmaker] add AdaptiveQuoteInterval for dynamic quoting based on market volatility

### DIFF
--- a/pkg/strategy/xmaker/adaptivequoteinterval.go
+++ b/pkg/strategy/xmaker/adaptivequoteinterval.go
@@ -1,6 +1,7 @@
 package xmaker
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"time"
@@ -12,6 +13,11 @@ import (
 	indicatorv2 "github.com/c9s/bbgo/pkg/indicator/v2"
 	"github.com/c9s/bbgo/pkg/types"
 )
+
+// minBackfillKLines is the lower bound on the number of historical klines to
+// query when backfilling the ATR indicator, so the RMA has enough samples to
+// converge even for a small window.
+const minBackfillKLines = 100
 
 // AdaptiveQuoteInterval adjusts the maker quote (place/cancel) interval based on
 // market volatility measured by the ATR percentage (ATRP) of the source market.
@@ -26,6 +32,8 @@ import (
 type AdaptiveQuoteInterval struct {
 	// Enabled enables the adaptive quote interval feature
 	Enabled bool `json:"enabled"`
+
+	DisableBackfill bool `json:"disableBackfill"`
 
 	// Interval is the kline interval used to compute the ATR, default 1m
 	Interval types.Interval `json:"interval"`
@@ -106,6 +114,55 @@ func (a *AdaptiveQuoteInterval) Bind(session *bbgo.ExchangeSession, symbol strin
 	a.logger = logger.WithField("feature", "adaptiveQuoteInterval")
 	a.atrp = session.Indicators(symbol).ATRP(a.Interval, a.Window)
 	a.scale = a.buildScale()
+}
+
+// Backfill warms up the underlying indicators by feeding it historical klines
+// at startup. It acts as a safety-net for when the framework's history-kline
+// preloader is unavailable (e.g. DisableHistoryKLinePreload is set): in that case
+// the shared kline stream is still empty and the indicators would otherwise start cold,
+// leaving NextInterval stuck at the fallback until enough live klines have closed.
+//
+// It feeds the same shared kline stream the indicators is built on (IndicatorSet.KLines
+// is cached), so the subscriber attached in Bind picks up the emitted updates
+// without any extra live wiring. To avoid double-counting the klines the preloader
+// may have already loaded, it only backfills when that stream is empty.
+func (a *AdaptiveQuoteInterval) Backfill(
+	ctx context.Context, session *bbgo.ExchangeSession, symbol string,
+) error {
+	if a.DisableBackfill {
+		if a.logger != nil {
+			a.logger.Info("adaptive quote interval backfill disabled, skipping")
+		}
+		return nil
+	}
+	klineStream := session.Indicators(symbol).KLines(a.Interval)
+	if n := klineStream.Length(); n > 0 {
+		if a.logger != nil {
+			a.logger.Debugf("ATR kline stream already warmed up with %d klines, skipping backfill", n)
+		}
+		return nil
+	}
+
+	limit := a.Window * 3
+	if limit < minBackfillKLines {
+		limit = minBackfillKLines
+	}
+
+	kLines, err := session.Exchange.QueryKLines(ctx, symbol, a.Interval, types.KLineQueryOptions{
+		Limit: limit,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to query %s %s klines for ATR backfill: %w", symbol, a.Interval, err)
+	}
+
+	klineStream.BackFill(kLines)
+
+	if a.logger != nil {
+		a.logger.Infof("backfilled %d %s klines into the ATR(%s, %d) indicator",
+			len(kLines), a.Interval, a.Interval, a.Window)
+	}
+
+	return nil
 }
 
 // buildScale constructs the clamped inverse linear scale:

--- a/pkg/strategy/xmaker/adaptivequoteinterval_test.go
+++ b/pkg/strategy/xmaker/adaptivequoteinterval_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
+	indicatorv2 "github.com/c9s/bbgo/pkg/indicator/v2"
 	"github.com/c9s/bbgo/pkg/types"
 )
 
@@ -93,6 +94,52 @@ func TestAdaptiveQuoteInterval_intervalForVolatility(t *testing.T) {
 		low := a.intervalForVolatility(0.001, fallback)
 		high := a.intervalForVolatility(0.004, fallback)
 		assert.Greater(t, low, high)
+	})
+}
+
+// buildKLine constructs a synthetic kline with the given OHLC values.
+func buildKLine(high, low, cloze float64) types.KLine {
+	return types.KLine{
+		High:  fixedpoint.NewFromFloat(high),
+		Low:   fixedpoint.NewFromFloat(low),
+		Open:  fixedpoint.NewFromFloat(cloze),
+		Close: fixedpoint.NewFromFloat(cloze),
+	}
+}
+
+func TestAdaptiveQuoteInterval_backfillWarmup(t *testing.T) {
+	fallback := 3 * time.Second
+
+	// mirror what Bind() wires up, but against a standalone kline stream so we can
+	// drive the ATR indicator directly without a live session.
+	newWarmable := func() (*AdaptiveQuoteInterval, *indicatorv2.KLineStream) {
+		a := newTestAdaptiveQuoteInterval()
+		ks := &indicatorv2.KLineStream{}
+		a.atrp = indicatorv2.ATRP2(ks, a.Window)
+		return a, ks
+	}
+
+	t.Run("cold stream falls back", func(t *testing.T) {
+		a, _ := newWarmable()
+		// no klines fed -> atrp is non-positive -> fallback
+		assert.Equal(t, fallback, a.NextInterval(fallback))
+	})
+
+	t.Run("backfilled klines warm up the indicator", func(t *testing.T) {
+		a, ks := newWarmable()
+
+		// feed enough volatile klines (~1% range around 100) so the ATRP produces a
+		// positive value and NextInterval no longer returns the fallback.
+		var kLines []types.KLine
+		for i := 0; i < a.Window*4; i++ {
+			kLines = append(kLines, buildKLine(100.5, 99.5, 100.0))
+		}
+		ks.BackFill(kLines)
+
+		next := a.NextInterval(fallback)
+		assert.NotEqual(t, fallback, next, "indicator should be warm after backfill")
+		assert.GreaterOrEqual(t, next, a.MinInterval.Duration())
+		assert.LessOrEqual(t, next, a.MaxInterval.Duration())
 	})
 }
 

--- a/pkg/strategy/xmaker/fastcancel.go
+++ b/pkg/strategy/xmaker/fastcancel.go
@@ -146,6 +146,11 @@ func (c *FastCancel) fastCancel(ctx context.Context, marketTrade types.Trade) {
 }
 
 func (c *FastCancel) executeFastCancel(ctx context.Context, symbol string, side types.SideType) (err error) {
+	if c.strategy.DryRun {
+		c.logger.Infof("[dryRun] skip fast-canceling %s %s orders", c.makerSymbol, side.String())
+		return nil
+	}
+
 	c.logger.Infof("FastCancel: cancelling %s %s", c.makerSymbol, side.String())
 
 	if service, ok := c.makerExchange.(cancelOrdersBySymbolSide); ok {

--- a/pkg/strategy/xmaker/hedgeexecutor.go
+++ b/pkg/strategy/xmaker/hedgeexecutor.go
@@ -208,9 +208,13 @@ func (m *CounterpartyHedgeExecutor) Clear(ctx context.Context) error {
 	// trigger CancelOrders only if the order is not already closed
 	switch m.hedgeOrder.Status {
 	case types.OrderStatusNew, types.OrderStatusPartiallyFilled:
-		m.logger.Infof("cancelling existing hedge order: %+v", m.hedgeOrder)
-		if err := m.session.Exchange.CancelOrders(ctx, *m.hedgeOrder); err != nil {
-			m.logger.WithError(err).Errorf("failed to cancel order: %+v", m.hedgeOrder)
+		if m.dryRun {
+			m.logger.Infof("[dryRun] skip canceling existing hedge order: %+v", m.hedgeOrder)
+		} else {
+			m.logger.Infof("cancelling existing hedge order: %+v", m.hedgeOrder)
+			if err := m.session.Exchange.CancelOrders(ctx, *m.hedgeOrder); err != nil {
+				m.logger.WithError(err).Errorf("failed to cancel order: %+v", m.hedgeOrder)
+			}
 		}
 	}
 

--- a/pkg/strategy/xmaker/hedgemarket.go
+++ b/pkg/strategy/xmaker/hedgemarket.go
@@ -212,6 +212,9 @@ type HedgeMarket struct {
 
 	logger logrus.FieldLogger
 
+	// dryRun, when true, skips real order submission in submitOrder and only logs the intended order.
+	dryRun bool
+
 	mu sync.Mutex
 
 	hedgeExecutor HedgeExecutor
@@ -430,6 +433,11 @@ func (m *HedgeMarket) newMockTrade(
 func (m *HedgeMarket) submitOrder(ctx context.Context, submitOrder types.SubmitOrder) (*types.Order, error) {
 	submitOrder.Market = m.market
 	submitOrder.Symbol = m.market.Symbol
+
+	if m.dryRun {
+		m.logger.Infof("[dryRun] hedge order: %+v", submitOrder)
+		return nil, nil
+	}
 
 	submitOrders := []types.SubmitOrder{
 		submitOrder,

--- a/pkg/strategy/xmaker/splithedge.go
+++ b/pkg/strategy/xmaker/splithedge.go
@@ -186,6 +186,7 @@ func (h *SplitHedge) InitializeAndBind(sessions map[string]*bbgo.ExchangeSession
 		}
 
 		hedgeMarket.SetLogger(h.logger)
+		hedgeMarket.dryRun = strategy.DryRun
 
 		// ensure the hedge market base currency matches the maker market base currency
 		if h.strategy.makerMarket.BaseCurrency != hedgeMarket.market.BaseCurrency {

--- a/pkg/strategy/xmaker/spreadmaker.go
+++ b/pkg/strategy/xmaker/spreadmaker.go
@@ -40,6 +40,9 @@ type SpreadMaker struct {
 
 	symbol string
 
+	// dryRun, when true, skips real order submission/cancellation and only logs the intent.
+	dryRun bool
+
 	mu sync.Mutex
 }
 
@@ -158,6 +161,11 @@ func (c *SpreadMaker) getOrder() (o types.Order, ok bool) {
 }
 
 func (c *SpreadMaker) cancelOrder(ctx context.Context) error {
+	if c.dryRun {
+		log.Infof("[dryRun] skip canceling spread maker order")
+		return nil
+	}
+
 	if order, ok := c.getOrder(); ok {
 		return retry.CancelOrdersUntilSuccessful(ctx, c.session.Exchange, order)
 	}
@@ -201,6 +209,11 @@ func (c *SpreadMaker) shouldKeepOrder(o types.Order, now time.Time) bool {
 }
 
 func (c *SpreadMaker) placeOrder(ctx context.Context, submitOrder *types.SubmitOrder) (*types.Order, error) {
+	if c.dryRun {
+		log.Infof("[dryRun] spread maker order: %+v", submitOrder)
+		return nil, nil
+	}
+
 	createdOrder, err := c.session.Exchange.SubmitOrder(ctx, *submitOrder)
 	if err != nil {
 		return nil, err

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -378,8 +378,10 @@ func (s *Strategy) CrossSubscribe(sessions map[string]*bbgo.ExchangeSession) {
 
 	makerSession.Subscribe(types.KLineChannel, s.Symbol, types.SubscribeOptions{Interval: "1m"})
 
-	for _, sig := range s.SignalConfigList.Signals {
-		sig.Signal.Subscribe(sourceSession, s.SourceSymbol)
+	if s.SignalConfigList != nil {
+		for _, sig := range s.SignalConfigList.Signals {
+			sig.Signal.Subscribe(sourceSession, s.SourceSymbol)
+		}
 	}
 
 	subscribeFeeTokenMarkets(sourceSession)
@@ -541,8 +543,10 @@ func (s *Strategy) Initialize() error {
 	s.positionExposure = bbgo.NewPositionExposure(s.Symbol)
 	s.positionExposure.SetLogger(s.logger)
 	s.positionExposure.SetMetricsLabels(ID, s.InstanceID(), s.MakerExchange, s.Symbol)
-	for _, sig := range s.SignalConfigList.Signals {
-		s.logger.Infof("using signal provider: %s", sig)
+	if s.SignalConfigList != nil {
+		for _, sig := range s.SignalConfigList.Signals {
+			s.logger.Infof("using signal provider: %s", sig)
+		}
 	}
 
 	// initialize connector manager
@@ -788,6 +792,9 @@ func (s *Strategy) collectSignalsAndWeights(ctx context.Context) (signals []floa
 
 // TODO: move this AggregateSignal to the signal package
 func (s *Strategy) AggregateSignal(ctx context.Context) (float64, error) {
+	if s.SignalConfigList == nil {
+		return 0.0, nil
+	}
 	sum := 0.0
 	voters := 0.0
 	for _, signalWrapper := range s.SignalConfigList.Signals {
@@ -2963,28 +2970,30 @@ func (s *Strategy) CrossRun(
 		)
 	}
 
-	for _, signalConfig := range s.SignalConfigList.Signals {
-		sigProvider := signalConfig.Signal
-		if setter, ok := sigProvider.(signal.StreamBookSetter); ok {
-			s.logger.Infof("setting stream book on signal %T", sigProvider)
-			setter.SetStreamBook(s.sourceBook)
-		}
+	if s.SignalConfigList != nil {
+		for _, signalConfig := range s.SignalConfigList.Signals {
+			sigProvider := signalConfig.Signal
+			if setter, ok := sigProvider.(signal.StreamBookSetter); ok {
+				s.logger.Infof("setting stream book on signal %T", sigProvider)
+				setter.SetStreamBook(s.sourceBook)
+			}
 
-		if setter, ok := sigProvider.(signal.MarketTradeStreamSetter); ok {
-			s.logger.Infof("setting market trade stream on signal %T", sigProvider)
-			setter.SetMarketTradeStream(s.marketTradeStream)
-		}
+			if setter, ok := sigProvider.(signal.MarketTradeStreamSetter); ok {
+				s.logger.Infof("setting market trade stream on signal %T", sigProvider)
+				setter.SetMarketTradeStream(s.marketTradeStream)
+			}
 
-		// pass logger to the signal provider
-		if setter, ok := sigProvider.(interface {
-			SetLogger(logger logrus.FieldLogger)
-		}); ok {
-			setter.SetLogger(s.logger.WithField("component", "signal"))
-		}
+			// pass logger to the signal provider
+			if setter, ok := sigProvider.(interface {
+				SetLogger(logger logrus.FieldLogger)
+			}); ok {
+				setter.SetLogger(s.logger.WithField("component", "signal"))
+			}
 
-		s.logger.Infof("binding session on signal %T", sigProvider)
-		if err := sigProvider.Bind(s.tradingCtx, s.hedgeSession, s.SourceSymbol); err != nil {
-			return err
+			s.logger.Infof("binding session on signal %T", sigProvider)
+			if err := sigProvider.Bind(s.tradingCtx, s.hedgeSession, s.SourceSymbol); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -111,6 +111,11 @@ type Strategy struct {
 
 	Environment *bbgo.Environment
 
+	// DryRun, when true, runs the strategy against live market data but never
+	// submits or cancels real orders on any exchange; intended orders and cancels
+	// are only logged with a [dryRun] prefix.
+	DryRun bool `json:"dryRun"`
+
 	// Symbol is the maker Symbol
 	Symbol      string `json:"symbol"`
 	MakerSymbol string `json:"makerSymbol"`
@@ -1000,10 +1005,14 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 
 	cancelMakerOrdersProfile := timeprofile.Start("cancelMakerOrders")
 
-	if err := s.activeMakerOrders.GracefulCancel(ctx, s.makerSession.Exchange); err != nil {
-		s.logger.Warnf("there are some %s orders not canceled, skipping placing maker orders", s.Symbol)
-		s.activeMakerOrders.Print()
-		return nil
+	// In dry-run mode we never place maker orders, so there is nothing to cancel;
+	// skip the cancel call entirely to avoid touching the exchange.
+	if !s.DryRun {
+		if err := s.activeMakerOrders.GracefulCancel(ctx, s.makerSession.Exchange); err != nil {
+			s.logger.Warnf("there are some %s orders not canceled, skipping placing maker orders", s.Symbol)
+			s.activeMakerOrders.Print()
+			return nil
+		}
 	}
 
 	s.cancelOrderDurationMetrics.Observe(float64(cancelMakerOrdersProfile.Stop().Milliseconds()))
@@ -1690,6 +1699,11 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 		return nil
 	}
 
+	if s.DryRun {
+		s.logger.Infof("[dryRun] maker orders: %+v", submitOrders)
+		return nil
+	}
+
 	formattedOrders, err := s.makerSession.FormatOrders(submitOrders)
 	if err != nil {
 		return err
@@ -1825,6 +1839,11 @@ func (s *Strategy) tryArbitrage(ctx context.Context, quote *Quote, disableBid, d
 	}
 
 	if len(iocOrders) == 0 {
+		return false, nil
+	}
+
+	if s.DryRun {
+		s.logger.Infof("[dryRun] arbitrage IOC orders: %+v", iocOrders)
 		return false, nil
 	}
 
@@ -1997,6 +2016,11 @@ func (s *Strategy) spreadMakerHedge(ctx context.Context, sig float64) error {
 		}
 
 		if !hasOrder || !keptOrder {
+			if s.DryRun {
+				s.logger.Infof("[dryRun] spread maker order: %+v", makerOrderForm)
+				return nil
+			}
+
 			spreadMakerCounterMetrics.With(s.metricsLabels).Inc()
 			s.logger.Infof("spreadMaker: placing new spread maker order: %+v...", makerOrderForm)
 
@@ -2177,6 +2201,11 @@ func (s *Strategy) directHedge(
 		bbgo.Notify("Hit hedge error rate limit, waiting...")
 		time.Sleep(s.hedgeErrorRateReservation.Delay())
 		s.hedgeErrorRateReservation = nil
+	}
+
+	if s.DryRun {
+		s.logger.Infof("[dryRun] hedge order: %s %s @ %s", side.String(), quantity.String(), price.String())
+		return nil, nil
 	}
 
 	bbgo.Notify("Submitting %s hedge order %s %v", s.Symbol, side.String(), quantity)
@@ -2494,6 +2523,9 @@ func (s *Strategy) quoteWorker(ctx context.Context) {
 	defer ticker.Stop()
 
 	defer func() {
+		if s.DryRun {
+			return
+		}
 		if err := s.activeMakerOrders.GracefulCancel(ctx, s.makerSession.Exchange); err != nil {
 			s.logger.WithError(err).Errorf("can not cancel %s orders", s.Symbol)
 		}
@@ -2700,6 +2732,10 @@ func (s *Strategy) CrossRun(
 
 	s.simpleHedgeMode = s.isSimpleHedgeMode()
 
+	if s.DryRun {
+		s.logger.Warnf("xmaker is running in DRY-RUN mode: no real orders will be submitted")
+	}
+
 	if s.UseSandbox {
 		balances := types.BalanceMap{
 			s.hedgeMarket.BaseCurrency:  types.NewBalance(s.hedgeMarket.BaseCurrency, fixedpoint.NewFromFloat(50.0)),
@@ -2775,7 +2811,9 @@ func (s *Strategy) CrossRun(
 		)
 	}
 
-	if err := tradingutil.UniversalCancelAllOrders(ctx, s.makerSession.Exchange, s.Symbol, nil); err != nil {
+	if s.DryRun {
+		s.logger.Infof("[dryRun] skip canceling all %s orders on startup", s.Symbol)
+	} else if err := tradingutil.UniversalCancelAllOrders(ctx, s.makerSession.Exchange, s.Symbol, nil); err != nil {
 		s.logger.WithError(err).Warnf("unable to cancel all orders: %v", err)
 	}
 
@@ -2852,6 +2890,7 @@ func (s *Strategy) CrossRun(
 	}
 
 	if s.SpreadMaker != nil && s.SpreadMaker.Enabled {
+		s.SpreadMaker.dryRun = s.DryRun
 		if err := s.SpreadMaker.Bind(s.tradingCtx, s.makerSession, s.Symbol); err != nil {
 			return err
 		}
@@ -3159,7 +3198,9 @@ func (s *Strategy) gracefulShutDown(shutdownCtx context.Context) {
 	}
 
 	// make sure all orders are cancelled
-	if err := tradingutil.UniversalCancelAllOrders(shutdownCtx, s.makerSession.Exchange, s.Symbol, nil); err != nil {
+	if s.DryRun {
+		s.logger.Infof("[dryRun] skip canceling all %s orders on shutdown", s.Symbol)
+	} else if err := tradingutil.UniversalCancelAllOrders(shutdownCtx, s.makerSession.Exchange, s.Symbol, nil); err != nil {
 		s.logger.WithError(err).Errorf("graceful cancel order error")
 	}
 

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -2784,6 +2784,11 @@ func (s *Strategy) CrossRun(
 
 	if s.AdaptiveQuoteInterval != nil && s.AdaptiveQuoteInterval.Enabled {
 		s.AdaptiveQuoteInterval.Bind(s.hedgeSession, s.SourceSymbol, s.logger)
+
+		if err := s.AdaptiveQuoteInterval.Backfill(ctx, s.hedgeSession, s.SourceSymbol); err != nil {
+			s.logger.WithError(err).Warn("failed to backfill adaptive quote interval indicators; will warm up from live klines")
+		}
+
 		s.logger.Infof("adaptive quote interval enabled: ATR(%s, %d), interval range [%s, %s]",
 			s.AdaptiveQuoteInterval.Interval, s.AdaptiveQuoteInterval.Window,
 			s.AdaptiveQuoteInterval.MinInterval.Duration(), s.AdaptiveQuoteInterval.MaxInterval.Duration())

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -130,6 +130,10 @@ type Strategy struct {
 	HedgeInterval       types.Duration `json:"hedgeInterval"`
 	OrderCancelWaitTime types.Duration `json:"orderCancelWaitTime"`
 
+	// AdaptiveQuoteInterval adjusts the quote (place/cancel) interval based on
+	// market volatility (ATR). When disabled, the fixed UpdateInterval is used.
+	AdaptiveQuoteInterval *AdaptiveQuoteInterval `json:"adaptiveQuoteInterval,omitempty"`
+
 	EnableSignalMargin bool `json:"enableSignalMargin"`
 
 	// Direction-divergence (D2) control — optional risk widener driven by signal direction conflicts
@@ -321,6 +325,8 @@ type Strategy struct {
 	openOrderBidExposureInUsdMetrics   prometheus.Gauge
 	openOrderAskExposureInUsdMetrics   prometheus.Gauge
 
+	adaptiveQuoteIntervalMetrics prometheus.Observer
+
 	d2Metrics            prometheus.Gauge
 	directionMeanMetrics prometheus.Gauge
 	alignedWeightMetrics prometheus.Gauge
@@ -351,6 +357,14 @@ func (s *Strategy) CrossSubscribe(sessions map[string]*bbgo.ExchangeSession) {
 	}
 
 	sourceSession.Subscribe(types.KLineChannel, s.SourceSymbol, types.SubscribeOptions{Interval: "1m"})
+
+	// subscribe the kline interval used by the adaptive quote interval (ATR),
+	// if it differs from the 1m interval already subscribed above.
+	if s.AdaptiveQuoteInterval != nil && s.AdaptiveQuoteInterval.Enabled &&
+		s.AdaptiveQuoteInterval.Interval != "" && s.AdaptiveQuoteInterval.Interval != types.Interval1m {
+		sourceSession.Subscribe(types.KLineChannel, s.SourceSymbol,
+			types.SubscribeOptions{Interval: s.AdaptiveQuoteInterval.Interval})
+	}
 
 	makerSession, ok := sessions[s.MakerExchange]
 	if !ok {
@@ -474,6 +488,8 @@ func (s *Strategy) Initialize() error {
 	s.makerOrderPlacementDurationMetrics = makerOrderPlacementDurationMetrics.With(s.metricsLabels)
 	s.openOrderBidExposureInUsdMetrics = openOrderBidExposureInUsdMetrics.With(s.metricsLabels)
 	s.openOrderAskExposureInUsdMetrics = openOrderAskExposureInUsdMetrics.With(s.metricsLabels)
+
+	s.adaptiveQuoteIntervalMetrics = adaptiveQuoteIntervalSecondsMetrics.With(s.metricsLabels)
 
 	s.d2Metrics = divergenceD2.With(s.metricsLabels)
 	s.directionMeanMetrics = directionMean.With(s.metricsLabels)
@@ -2289,6 +2305,12 @@ func (s *Strategy) Defaults() error {
 		s.UpdateInterval = types.Duration(time.Second)
 	}
 
+	if s.AdaptiveQuoteInterval != nil && s.AdaptiveQuoteInterval.Enabled {
+		if err := s.AdaptiveQuoteInterval.Defaults(); err != nil {
+			return err
+		}
+	}
+
 	if s.HedgeInterval == 0 {
 		s.HedgeInterval = types.Duration(10 * time.Second)
 	}
@@ -2446,6 +2468,12 @@ func (s *Strategy) Validate() error {
 		return errors.New("hedge session is required")
 	}
 
+	if s.AdaptiveQuoteInterval != nil && s.AdaptiveQuoteInterval.Enabled {
+		if err := s.AdaptiveQuoteInterval.Validate(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -2490,6 +2518,15 @@ func (s *Strategy) quoteWorker(ctx context.Context) {
 				if !errors.Is(err, context.Canceled) {
 					s.logger.WithError(err).Errorf("unable to place maker orders")
 				}
+			}
+
+			// adapt the next quote interval to market volatility (ATR).
+			// this only reschedules the ticker; the fast-cancel path above
+			// (marketTradeC) is driven by market-trade events and is unaffected.
+			if s.AdaptiveQuoteInterval != nil && s.AdaptiveQuoteInterval.Enabled {
+				next := s.AdaptiveQuoteInterval.NextInterval(s.UpdateInterval.Duration())
+				s.adaptiveQuoteIntervalMetrics.Observe(next.Seconds())
+				ticker.Reset(timejitter.Milliseconds(next, 200))
 			}
 
 		}
@@ -2701,6 +2738,13 @@ func (s *Strategy) CrossRun(
 
 	indicators := s.hedgeSession.Indicators(s.SourceSymbol)
 	_ = indicators
+
+	if s.AdaptiveQuoteInterval != nil && s.AdaptiveQuoteInterval.Enabled {
+		s.AdaptiveQuoteInterval.Bind(s.hedgeSession, s.SourceSymbol, s.logger)
+		s.logger.Infof("adaptive quote interval enabled: ATR(%s, %d), interval range [%s, %s]",
+			s.AdaptiveQuoteInterval.Interval, s.AdaptiveQuoteInterval.Window,
+			s.AdaptiveQuoteInterval.MinInterval.Duration(), s.AdaptiveQuoteInterval.MaxInterval.Duration())
+	}
 
 	// restore state
 	s.groupID = util.FNV32(instanceID)

--- a/pkg/strategy/xmaker/synthetichedge.go
+++ b/pkg/strategy/xmaker/synthetichedge.go
@@ -71,6 +71,7 @@ func (s *SyntheticHedge) InitializeAndBind(sessions map[string]*bbgo.ExchangeSes
 	}
 
 	s.sourceMarket.SetLogger(s.logger)
+	s.sourceMarket.dryRun = strategy.DryRun
 
 	s.fiatMarket, err = InitializeHedgeMarketFromConfig(s.Fiat, sessions)
 	if err != nil {
@@ -78,6 +79,7 @@ func (s *SyntheticHedge) InitializeAndBind(sessions map[string]*bbgo.ExchangeSes
 	}
 
 	s.fiatMarket.SetLogger(s.logger)
+	s.fiatMarket.dryRun = strategy.DryRun
 
 	// update strategy instance ID for the source and fiat markets
 	s.sourceMarket.Position.StrategyInstanceID = strategy.InstanceID()


### PR DESCRIPTION
- adjust update interval based on market volatility (measured by atrp)
- dry-run mode

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>