### PR TITLE
REFACTOR: [xmaker] trade-based adaptive quote interval

### DIFF
--- a/pkg/indicator/v2/realizedvolatility.go
+++ b/pkg/indicator/v2/realizedvolatility.go
@@ -1,0 +1,79 @@
+package indicatorv2
+
+import (
+	"math"
+
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+// RealizedVolatilityStream computes a RiskMetrics-style realized volatility from
+// a market-trade stream: an exponentially weighted moving average (EWMA) of
+// squared trade log-returns.
+//
+//	rₜ = ln(pₜ / pₜ₋₁)
+//	σ²ₜ = λ·σ²ₜ₋₁ + (1−λ)·rₜ²
+//	σₜ = sqrt(σ²ₜ)
+//
+// Unlike a kline/ATR-based volatility, this updates on every trade, so it reacts
+// immediately to volatility bursts and decays predictably via the single decay
+// factor λ. The emitted value is a dimensionless per-trade return standard
+// deviation — comparable in spirit to ATRP (atr/close) but on a per-trade rather
+// than per-bar scale, so any downstream thresholds must be calibrated to it.
+type RealizedVolatilityStream struct {
+	*types.Float64Series
+
+	// lambda is the EWMA decay factor (0 < λ < 1); higher means longer memory.
+	lambda float64
+
+	// warmup is the minimum number of returns to accumulate before emitting a
+	// value. Until then Last(0) returns 0.0, which downstream consumers treat as
+	// the indicator still warming up.
+	warmup int
+
+	prevPrice float64
+	variance  float64 // running σ²
+	count     int     // number of returns seen so far
+}
+
+// RealizedVolatility subscribes to a trade stream and emits the per-trade
+// realized volatility σ = sqrt(EWMA of squared log-returns). A non-positive or
+// out-of-range read (cold stream) returns 0.0 from Last(0).
+func RealizedVolatility(source *TradeStream, lambda float64, warmup int) *RealizedVolatilityStream {
+	s := &RealizedVolatilityStream{
+		Float64Series: types.NewFloat64Series(),
+		lambda:        lambda,
+		warmup:        warmup,
+	}
+
+	source.AddSubscriber(func(trade types.Trade) {
+		s.update(trade.Price.Float64())
+	})
+
+	return s
+}
+
+func (s *RealizedVolatilityStream) update(price float64) {
+	// ignore non-positive prices; a log-return is undefined for them.
+	if price <= 0 {
+		return
+	}
+
+	// the first trade only seeds the reference price; no return yet.
+	if s.prevPrice <= 0 {
+		s.prevPrice = price
+		return
+	}
+
+	r := math.Log(price / s.prevPrice)
+	s.prevPrice = price
+
+	s.variance = s.lambda*s.variance + (1-s.lambda)*r*r
+	s.count++
+
+	if s.count < s.warmup {
+		return
+	}
+
+	s.PushAndEmit(math.Sqrt(s.variance))
+	s.Slice = generalTruncate(s.Slice)
+}

--- a/pkg/indicator/v2/realizedvolatility_test.go
+++ b/pkg/indicator/v2/realizedvolatility_test.go
@@ -1,0 +1,88 @@
+package indicatorv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+// tradesFromPrices builds a trade slice from a price series (BTCUSDT).
+func tradesFromPrices(prices ...float64) []types.Trade {
+	trades := make([]types.Trade, 0, len(prices))
+	for i, p := range prices {
+		trades = append(trades, makeTrade(uint64(i+1), "BTCUSDT", p))
+	}
+	return trades
+}
+
+func TestRealizedVolatility_coldReturnsZero(t *testing.T) {
+	src := &TradeStream{}
+	rv := RealizedVolatility(src, 0.94, 3)
+
+	// no trades yet
+	assert.Equal(t, 0.0, rv.Last(0))
+
+	// fewer returns than warmup (3 prices => 2 returns) -> still cold
+	src.BackFill(tradesFromPrices(100, 101, 100))
+	assert.Equal(t, 0.0, rv.Last(0), "should not emit before warmup is reached")
+}
+
+func TestRealizedVolatility_warmsUpAndEmitsPositive(t *testing.T) {
+	src := &TradeStream{}
+	rv := RealizedVolatility(src, 0.94, 3)
+
+	// 5 prices => 4 returns, all non-zero -> warm after the 3rd return
+	src.BackFill(tradesFromPrices(100, 101, 100, 102, 101))
+
+	assert.Positive(t, rv.Last(0), "indicator should emit a positive volatility once warm")
+}
+
+func TestRealizedVolatility_higherDispersionHigherVol(t *testing.T) {
+	warmup := 3
+
+	calm := &TradeStream{}
+	rvCalm := RealizedVolatility(calm, 0.94, warmup)
+	calm.BackFill(tradesFromPrices(100, 100.1, 100, 100.1, 100, 100.1))
+
+	wild := &TradeStream{}
+	rvWild := RealizedVolatility(wild, 0.94, warmup)
+	wild.BackFill(tradesFromPrices(100, 105, 100, 105, 100, 105))
+
+	assert.Positive(t, rvCalm.Last(0))
+	assert.Positive(t, rvWild.Last(0))
+	assert.Greater(t, rvWild.Last(0), rvCalm.Last(0),
+		"a wider return dispersion must yield a higher realized volatility")
+}
+
+func TestRealizedVolatility_decaysWhenPriceIsFlat(t *testing.T) {
+	// warmup=1 so we emit from the first return onward.
+	src := &TradeStream{}
+	rv := RealizedVolatility(src, 0.9, 1)
+
+	// one volatility spike, then a flat price series (zero returns) that should
+	// let the EWMA variance decay by lambda on each subsequent trade.
+	src.BackFill(tradesFromPrices(100, 110)) // the spike
+	peak := rv.Last(0)
+	assert.Positive(t, peak)
+
+	// flat price -> zero returns -> monotonically decreasing volatility
+	src.BackFill(tradesFromPrices(110, 110, 110))
+	after := rv.Last(0)
+	assert.Less(t, after, peak, "volatility should decay while the price is flat")
+}
+
+func TestRealizedVolatility_ignoresNonPositivePrice(t *testing.T) {
+	src := &TradeStream{}
+	rv := RealizedVolatility(src, 0.94, 1)
+
+	// a zero price must not produce a NaN/Inf return; it is skipped.
+	src.BackFill(tradesFromPrices(100, 0, 101, 102))
+	assert.False(t, isNaNOrInf(rv.Last(0)), "non-positive prices must be ignored, not poison the state")
+	assert.Positive(t, rv.Last(0))
+}
+
+func isNaNOrInf(f float64) bool {
+	return f != f || f > 1e308 || f < -1e308
+}

--- a/pkg/strategy/xmaker/adaptivequoteinterval.go
+++ b/pkg/strategy/xmaker/adaptivequoteinterval.go
@@ -14,30 +14,31 @@ import (
 	"github.com/c9s/bbgo/pkg/types"
 )
 
-// minBackfillKLines is the lower bound on the number of historical klines to
-// query when backfilling the ATR indicator, so the RMA has enough samples to
-// converge even for a small window.
-const minBackfillKLines = 100
-
 // AdaptiveQuoteInterval adjusts the maker quote (place/cancel) interval based on
-// market volatility measured by the ATR percentage (ATRP) of the source market.
+// market volatility measured by a RiskMetrics-style realized volatility (an EWMA
+// of squared trade log-returns) on the source market-trade stream.
 //
 // When volatility is low, the interval is stretched towards MaxInterval to reduce
 // the load on the exchange; when volatility is high, the interval is shortened
 // towards MinInterval to react faster. The mapping is a clamped inverse linear
 // scale, so the resulting interval always stays within [MinInterval, MaxInterval].
 //
-// This feature only controls the periodic quote ticker. It does NOT affect the
-// fast-cancel path, which is driven by market-trade events independently.
+// Unlike a kline/ATR-based measure, the realized volatility updates on every trade,
+// so it reacts immediately to volatility bursts and shares the same event clock as
+// the fast-cancel path. This feature only controls the periodic quote ticker; it
+// does NOT affect the fast-cancel path, which is driven by market-trade events
+// independently.
 type AdaptiveQuoteInterval struct {
 	// Enabled enables the adaptive quote interval feature
 	Enabled bool `json:"enabled"`
 
-	// Interval is the kline interval used to compute the ATR, default 1m
-	Interval types.Interval `json:"interval"`
+	// Lambda is the EWMA decay factor for the realized volatility (0 < λ < 1).
+	// Higher means longer memory / slower reaction; the RiskMetrics default is 0.94.
+	Lambda fixedpoint.Value `json:"lambda"`
 
-	// Window is the ATR window, default 14
-	Window int `json:"window"`
+	// Warmup is the minimum number of trade returns to accumulate before the
+	// volatility reading is used (until then the fixed fallback interval applies).
+	Warmup int `json:"warmup"`
 
 	// MinInterval is the fastest (shortest) quote interval, used at high volatility
 	MinInterval types.Duration `json:"minInterval"`
@@ -45,13 +46,16 @@ type AdaptiveQuoteInterval struct {
 	// MaxInterval is the slowest (longest) quote interval, used at low volatility
 	MaxInterval types.Duration `json:"maxInterval"`
 
-	// LowVolatility is the ATRP (atr/close) ratio at or below which MaxInterval is used
+	// LowVolatility is the realized-volatility (per-trade σ) at or below which
+	// MaxInterval is used. NOTE: this is on a per-trade scale, much smaller than a
+	// 1m ATRP, so it must be calibrated against the live market.
 	LowVolatility fixedpoint.Value `json:"lowVolatility"`
 
-	// HighVolatility is the ATRP (atr/close) ratio at or above which MinInterval is used
+	// HighVolatility is the realized-volatility (per-trade σ) at or above which
+	// MinInterval is used. See LowVolatility on calibration.
 	HighVolatility fixedpoint.Value `json:"highVolatility"`
 
-	atrp   *indicatorv2.ATRPStream
+	rv     *indicatorv2.RealizedVolatilityStream
 	scale  *bbgo.LinearScale
 	logger logrus.FieldLogger
 
@@ -60,12 +64,12 @@ type AdaptiveQuoteInterval struct {
 }
 
 func (a *AdaptiveQuoteInterval) Defaults() error {
-	if a.Interval == "" {
-		a.Interval = types.Interval1m
+	if a.Lambda.IsZero() {
+		a.Lambda = fixedpoint.NewFromFloat(0.94) // RiskMetrics default
 	}
 
-	if a.Window == 0 {
-		a.Window = 14
+	if a.Warmup == 0 {
+		a.Warmup = 30
 	}
 
 	if a.MinInterval == 0 {
@@ -76,20 +80,27 @@ func (a *AdaptiveQuoteInterval) Defaults() error {
 		a.MaxInterval = types.Duration(time.Minute)
 	}
 
+	// NOTE: per-trade realized volatility is on a much smaller scale than a 1m
+	// ATRP. These defaults are conservative placeholders and should be calibrated
+	// against the live market/symbol.
 	if a.LowVolatility.IsZero() {
-		a.LowVolatility = fixedpoint.NewFromFloat(0.0005) // 0.05%
+		a.LowVolatility = fixedpoint.NewFromFloat(0.00005) // 0.005%
 	}
 
 	if a.HighVolatility.IsZero() {
-		a.HighVolatility = fixedpoint.NewFromFloat(0.005) // 0.5%
+		a.HighVolatility = fixedpoint.NewFromFloat(0.001) // 0.1%
 	}
 
 	return nil
 }
 
 func (a *AdaptiveQuoteInterval) Validate() error {
-	if a.Window <= 0 {
-		return fmt.Errorf("adaptiveQuoteInterval.window must be positive, got %d", a.Window)
+	if a.Lambda.Float64() <= 0 || a.Lambda.Float64() >= 1 {
+		return fmt.Errorf("adaptiveQuoteInterval.lambda must be in (0, 1), got %s", a.Lambda.String())
+	}
+
+	if a.Warmup <= 0 {
+		return fmt.Errorf("adaptiveQuoteInterval.warmup must be positive, got %d", a.Warmup)
 	}
 
 	if a.MinInterval <= 0 {
@@ -109,14 +120,14 @@ func (a *AdaptiveQuoteInterval) Validate() error {
 	return nil
 }
 
-// Bind sets up the ATRP indicator on the given session/symbol and builds the
-// inverse linear scale that maps the volatility ratio to a quote interval. It
-// also wires the Prometheus metric observers from the given labels.
+// Bind sets up the realized-volatility indicator on the given market-trade stream
+// and builds the inverse linear scale that maps the volatility ratio to a quote
+// interval. It also wires the Prometheus metric observers from the given labels.
 func (a *AdaptiveQuoteInterval) Bind(
-	session *bbgo.ExchangeSession, symbol string, logger logrus.FieldLogger, metricsLabels prometheus.Labels,
+	tradeStream types.Stream, symbol string, logger logrus.FieldLogger, metricsLabels prometheus.Labels,
 ) {
 	a.logger = logger.WithField("feature", "adaptiveQuoteInterval")
-	a.atrp = session.Indicators(symbol).ATRP(a.Interval, a.Window)
+	a.rv = indicatorv2.RealizedVolatility(indicatorv2.Trades(tradeStream, symbol), a.Lambda.Float64(), a.Warmup)
 	a.scale = a.buildScale()
 
 	a.volatilityMetric = adaptiveQuoteIntervalVolatilityMetrics.With(metricsLabels)
@@ -144,15 +155,16 @@ func (a *AdaptiveQuoteInterval) buildScale() *bbgo.LinearScale {
 	return scale
 }
 
-// intervalForVolatility maps an ATRP ratio to a quote interval. It is a pure
-// function of the configured scale and is unit-testable without a live session.
-// A non-positive atrp (indicator warm-up) falls back to the given duration.
-func (a *AdaptiveQuoteInterval) intervalForVolatility(atrp float64, fallback time.Duration) time.Duration {
-	if atrp <= 0 {
+// intervalForVolatility maps a realized-volatility reading to a quote interval. It
+// is a pure function of the configured scale and is unit-testable without a live
+// session. A non-positive reading (indicator warm-up) falls back to the given
+// duration.
+func (a *AdaptiveQuoteInterval) intervalForVolatility(vol float64, fallback time.Duration) time.Duration {
+	if vol <= 0 {
 		return fallback
 	}
 
-	ms := a.scale.Call(atrp)
+	ms := a.scale.Call(vol)
 	// Round rather than truncate: the domain endpoints go through a
 	// fixedpoint->float64 conversion (exact under stdlib, slightly lossy under
 	// dnum), so a boundary volatility can yield e.g. 999.999ms which must map
@@ -160,18 +172,18 @@ func (a *AdaptiveQuoteInterval) intervalForVolatility(atrp float64, fallback tim
 	return time.Duration(math.Round(ms)) * time.Millisecond
 }
 
-// NextInterval reads the current volatility from the ATRP indicator and returns
+// NextInterval reads the current realized volatility from the indicator and returns
 // the corresponding quote interval, falling back to the given duration while the
 // indicator is still warming up.
 func (a *AdaptiveQuoteInterval) NextInterval(fallback time.Duration) time.Duration {
-	atrp := a.atrp.Last(0)
-	interval := a.intervalForVolatility(atrp, fallback)
+	vol := a.rv.Last(0)
+	interval := a.intervalForVolatility(vol, fallback)
 
 	// emit the raw volatility reading and the resulting interval together, so the
 	// two are always recorded from the same decision. Guard against nil observers
 	// because unit tests call NextInterval without Bind().
 	if a.volatilityMetric != nil {
-		a.volatilityMetric.Set(atrp)
+		a.volatilityMetric.Set(vol)
 	}
 
 	if a.intervalSecondsMetric != nil {
@@ -179,7 +191,7 @@ func (a *AdaptiveQuoteInterval) NextInterval(fallback time.Duration) time.Durati
 	}
 
 	if a.logger != nil {
-		a.logger.Debugf("adaptive quote interval: atrp=%f -> %s", atrp, interval)
+		a.logger.Debugf("adaptive quote interval: volatility=%f -> %s", vol, interval)
 	}
 
 	return interval

--- a/pkg/strategy/xmaker/adaptivequoteinterval_test.go
+++ b/pkg/strategy/xmaker/adaptivequoteinterval_test.go
@@ -15,6 +15,8 @@ import (
 func newTestAdaptiveQuoteInterval() *AdaptiveQuoteInterval {
 	a := &AdaptiveQuoteInterval{
 		Enabled:        true,
+		Lambda:         fixedpoint.NewFromFloat(0.94),
+		Warmup:         3,
 		LowVolatility:  fixedpoint.NewFromFloat(0.0005),
 		HighVolatility: fixedpoint.NewFromFloat(0.005),
 		MinInterval:    types.Duration(time.Second),
@@ -29,12 +31,12 @@ func TestAdaptiveQuoteInterval_Defaults(t *testing.T) {
 	a := &AdaptiveQuoteInterval{Enabled: true}
 	assert.NoError(t, a.Defaults())
 
-	assert.Equal(t, types.Interval1m, a.Interval)
-	assert.Equal(t, 14, a.Window)
+	assert.InDelta(t, 0.94, a.Lambda.Float64(), 1e-12)
+	assert.Equal(t, 30, a.Warmup)
 	assert.Equal(t, time.Second, a.MinInterval.Duration())
 	assert.Equal(t, time.Minute, a.MaxInterval.Duration())
-	assert.InDelta(t, 0.0005, a.LowVolatility.Float64(), 1e-12)
-	assert.InDelta(t, 0.005, a.HighVolatility.Float64(), 1e-12)
+	assert.InDelta(t, 0.00005, a.LowVolatility.Float64(), 1e-12)
+	assert.InDelta(t, 0.001, a.HighVolatility.Float64(), 1e-12)
 }
 
 func TestAdaptiveQuoteInterval_Validate(t *testing.T) {
@@ -43,9 +45,18 @@ func TestAdaptiveQuoteInterval_Validate(t *testing.T) {
 		assert.NoError(t, a.Validate())
 	})
 
-	t.Run("non-positive window", func(t *testing.T) {
+	t.Run("invalid lambda", func(t *testing.T) {
 		a := newTestAdaptiveQuoteInterval()
-		a.Window = 0
+		a.Lambda = fixedpoint.One
+		assert.Error(t, a.Validate())
+
+		a.Lambda = fixedpoint.Zero
+		assert.Error(t, a.Validate())
+	})
+
+	t.Run("non-positive warmup", func(t *testing.T) {
+		a := newTestAdaptiveQuoteInterval()
+		a.Warmup = 0
 		assert.Error(t, a.Validate())
 	})
 
@@ -97,47 +108,47 @@ func TestAdaptiveQuoteInterval_intervalForVolatility(t *testing.T) {
 	})
 }
 
-// buildKLine constructs a synthetic kline with the given OHLC values.
-func buildKLine(high, low, cloze float64) types.KLine {
-	return types.KLine{
-		High:  fixedpoint.NewFromFloat(high),
-		Low:   fixedpoint.NewFromFloat(low),
-		Open:  fixedpoint.NewFromFloat(cloze),
-		Close: fixedpoint.NewFromFloat(cloze),
-	}
+// buildTrade constructs a synthetic trade at the given price.
+func buildTrade(price float64) types.Trade {
+	return types.Trade{Price: fixedpoint.NewFromFloat(price)}
 }
 
-func TestAdaptiveQuoteInterval_backfillWarmup(t *testing.T) {
+func TestAdaptiveQuoteInterval_tradeWarmup(t *testing.T) {
 	fallback := 3 * time.Second
 
-	// mirror what Bind() wires up, but against a standalone kline stream so we can
-	// drive the ATR indicator directly without a live session.
-	newWarmable := func() (*AdaptiveQuoteInterval, *indicatorv2.KLineStream) {
+	// mirror what Bind() wires up, but against a standalone trade stream so we can
+	// drive the realized-volatility indicator directly without a live session.
+	newWarmable := func() (*AdaptiveQuoteInterval, *indicatorv2.TradeStream) {
 		a := newTestAdaptiveQuoteInterval()
-		ks := &indicatorv2.KLineStream{}
-		a.atrp = indicatorv2.ATRP2(ks, a.Window)
-		return a, ks
+		ts := &indicatorv2.TradeStream{}
+		a.rv = indicatorv2.RealizedVolatility(ts, a.Lambda.Float64(), a.Warmup)
+		return a, ts
 	}
 
 	t.Run("cold stream falls back", func(t *testing.T) {
 		a, _ := newWarmable()
-		// no klines fed -> atrp is non-positive -> fallback
+		// no trades fed -> volatility is non-positive -> fallback
 		assert.Equal(t, fallback, a.NextInterval(fallback))
 	})
 
-	t.Run("backfilled klines warm up the indicator", func(t *testing.T) {
-		a, ks := newWarmable()
+	t.Run("trades warm up the indicator", func(t *testing.T) {
+		a, ts := newWarmable()
 
-		// feed enough volatile klines (~1% range around 100) so the ATRP produces a
-		// positive value and NextInterval no longer returns the fallback.
-		var kLines []types.KLine
-		for i := 0; i < a.Window*4; i++ {
-			kLines = append(kLines, buildKLine(100.5, 99.5, 100.0))
+		// feed enough volatile trades (alternating ~1% around 100) so the realized
+		// volatility produces a positive value and NextInterval no longer returns
+		// the fallback.
+		var trades []types.Trade
+		for i := 0; i < a.Warmup*4; i++ {
+			price := 99.0
+			if i%2 == 0 {
+				price = 101.0
+			}
+			trades = append(trades, buildTrade(price))
 		}
-		ks.BackFill(kLines)
+		ts.BackFill(trades)
 
 		next := a.NextInterval(fallback)
-		assert.NotEqual(t, fallback, next, "indicator should be warm after backfill")
+		assert.NotEqual(t, fallback, next, "indicator should be warm after trades")
 		assert.GreaterOrEqual(t, next, a.MinInterval.Duration())
 		assert.LessOrEqual(t, next, a.MaxInterval.Duration())
 	})
@@ -146,23 +157,23 @@ func TestAdaptiveQuoteInterval_backfillWarmup(t *testing.T) {
 func TestAdaptiveQuoteInterval_ConfigParse(t *testing.T) {
 	const payload = `{
 		"enabled": true,
-		"interval": "5m",
-		"window": 20,
+		"lambda": 0.9,
+		"warmup": 50,
 		"minInterval": "1s",
 		"maxInterval": "1m",
-		"lowVolatility": 0.0008,
-		"highVolatility": 0.006
+		"lowVolatility": 0.0001,
+		"highVolatility": 0.002
 	}`
 
 	var a AdaptiveQuoteInterval
 	assert.NoError(t, json.Unmarshal([]byte(payload), &a))
 
 	assert.True(t, a.Enabled)
-	assert.Equal(t, types.Interval5m, a.Interval)
-	assert.Equal(t, 20, a.Window)
+	assert.InDelta(t, 0.9, a.Lambda.Float64(), 1e-12)
+	assert.Equal(t, 50, a.Warmup)
 	assert.Equal(t, time.Second, a.MinInterval.Duration())
 	assert.Equal(t, time.Minute, a.MaxInterval.Duration())
-	assert.InDelta(t, 0.0008, a.LowVolatility.Float64(), 1e-12)
-	assert.InDelta(t, 0.006, a.HighVolatility.Float64(), 1e-12)
+	assert.InDelta(t, 0.0001, a.LowVolatility.Float64(), 1e-12)
+	assert.InDelta(t, 0.002, a.HighVolatility.Float64(), 1e-12)
 	assert.NoError(t, a.Validate())
 }

--- a/pkg/strategy/xmaker/metrics.go
+++ b/pkg/strategy/xmaker/metrics.go
@@ -36,7 +36,7 @@ var makerOrderPlacementDurationMetrics = prometheus.NewHistogramVec(
 var adaptiveQuoteIntervalSecondsMetrics = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "xmaker_adaptive_quote_interval_seconds",
-		Help:    "the adaptive quote (place/cancel) interval in seconds, driven by ATR volatility",
+		Help:    "the adaptive quote (place/cancel) interval in seconds, driven by realized volatility",
 		Buckets: prometheus.ExponentialBuckets(1, 2.0, 11),
 	}, []string{"strategy_type", "strategy_id", "exchange", "symbol"},
 )

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -136,7 +136,8 @@ type Strategy struct {
 	OrderCancelWaitTime types.Duration `json:"orderCancelWaitTime"`
 
 	// AdaptiveQuoteInterval adjusts the quote (place/cancel) interval based on
-	// market volatility (ATR). When disabled, the fixed UpdateInterval is used.
+	// market volatility (realized volatility from trade returns). When disabled,
+	// the fixed UpdateInterval is used.
 	AdaptiveQuoteInterval *AdaptiveQuoteInterval `json:"adaptiveQuoteInterval,omitempty"`
 
 	EnableSignalMargin bool `json:"enableSignalMargin"`
@@ -360,14 +361,6 @@ func (s *Strategy) CrossSubscribe(sessions map[string]*bbgo.ExchangeSession) {
 	}
 
 	sourceSession.Subscribe(types.KLineChannel, s.SourceSymbol, types.SubscribeOptions{Interval: "1m"})
-
-	// subscribe the kline interval used by the adaptive quote interval (ATR),
-	// if it differs from the 1m interval already subscribed above.
-	if s.AdaptiveQuoteInterval != nil && s.AdaptiveQuoteInterval.Enabled &&
-		s.AdaptiveQuoteInterval.Interval != "" && s.AdaptiveQuoteInterval.Interval != types.Interval1m {
-		sourceSession.Subscribe(types.KLineChannel, s.SourceSymbol,
-			types.SubscribeOptions{Interval: s.AdaptiveQuoteInterval.Interval})
-	}
 
 	makerSession, ok := sessions[s.MakerExchange]
 	if !ok {
@@ -2777,14 +2770,6 @@ func (s *Strategy) CrossRun(
 	indicators := s.hedgeSession.Indicators(s.SourceSymbol)
 	_ = indicators
 
-	if s.AdaptiveQuoteInterval != nil && s.AdaptiveQuoteInterval.Enabled {
-		s.AdaptiveQuoteInterval.Bind(s.hedgeSession, s.SourceSymbol, s.logger, s.metricsLabels)
-
-		s.logger.Infof("adaptive quote interval enabled: ATR(%s, %d), interval range [%s, %s]",
-			s.AdaptiveQuoteInterval.Interval, s.AdaptiveQuoteInterval.Window,
-			s.AdaptiveQuoteInterval.MinInterval.Duration(), s.AdaptiveQuoteInterval.MaxInterval.Duration())
-	}
-
 	// restore state
 	s.groupID = util.FNV32(instanceID)
 	s.logger.Infof("using group id %d from fnv(%s)", s.groupID, instanceID)
@@ -2900,12 +2885,25 @@ func (s *Strategy) CrossRun(
 	}
 
 	// allocate required isolated streams to the connectors
-	if (s.FastCancel != nil && s.FastCancel.Enabled) || (s.EnableSignalMargin && s.SignalConfigList != nil && len(s.SignalConfigList.Signals) > 0) {
+	adaptiveQuoteIntervalEnabled := s.AdaptiveQuoteInterval != nil && s.AdaptiveQuoteInterval.Enabled
+	if (s.FastCancel != nil && s.FastCancel.Enabled) ||
+		(s.EnableSignalMargin && s.SignalConfigList != nil && len(s.SignalConfigList.Signals) > 0) ||
+		adaptiveQuoteIntervalEnabled {
 		s.marketTradeStream = bbgo.NewMarketTradeStream(s.hedgeSession, s.SourceSymbol)
 		s.marketTradeStream.OnMarketTrade(func(trade types.Trade) {
 			s.lastPrice.Set(trade.Price)
 		})
 		s.connectorManager.Add(s.marketTradeStream)
+	}
+
+	// the adaptive quote interval derives its realized volatility from the source
+	// market-trade stream allocated above, so it must be bound after that stream exists.
+	if adaptiveQuoteIntervalEnabled {
+		s.AdaptiveQuoteInterval.Bind(s.marketTradeStream, s.SourceSymbol, s.logger, s.metricsLabels)
+
+		s.logger.Infof("adaptive quote interval enabled: realizedVolatility(lambda=%s, warmup=%d), interval range [%s, %s]",
+			s.AdaptiveQuoteInterval.Lambda.String(), s.AdaptiveQuoteInterval.Warmup,
+			s.AdaptiveQuoteInterval.MinInterval.Duration(), s.AdaptiveQuoteInterval.MaxInterval.Duration())
 	}
 
 	if s.FastCancel != nil && s.FastCancel.Enabled {


### PR DESCRIPTION
# Adaptive Quote Interval: ATRP → Realized Volatility

## 1. Why replace ATRP

The xmaker `AdaptiveQuoteInterval` feature adjusts the maker's requote (place/cancel)
cadence to market volatility: when the market is calm, stretch the interval toward
`MaxInterval` to reduce exchange load; when it's volatile, shorten it toward
`MinInterval` to react faster.

It originally measured volatility with **ATRP** — the ATR percentage of the source
market on `1m` klines (`ATRP(1m, 14)`). For driving a market maker's requote cadence,
that signal is a poor fit:

- **Bar-close latency.** ATR only updates when the `1m` kline closes, so a volatility
  burst mid-bar is invisible for up to ~55 seconds — directly defeating the goal of
  *reacting faster* when the market moves.
- **Long, asymmetric RMA memory.** Wilder's RMA over window 14 (α ≈ 0.071) has an
  effective memory of ~14 bars. It's slow to rise *and* slow to relax, the opposite of
  what a maker wants (spike quickly, decay gradually).
- **True range conflates direction and volatility** and folds in gaps/jumps a maker
  can't quote around anyway.
- **Different clock from fast-cancel.** The fast-cancel path is already trade-driven,
  so the two risk signals ran on unrelated clocks.

ATRP's one genuine virtue is that it is normalized (`atr/close`), so it's scale-free
across symbols. The replacement keeps that property.

### The replacement: EWMA realized volatility

A **RiskMetrics-style realized volatility** — an exponentially weighted moving average
of squared trade log-returns, computed on the source **market-trade stream**:

```
rₜ  = ln(pₜ / pₜ₋₁)
σ²ₜ = λ·σ²ₜ₋₁ + (1 − λ)·rₜ²
σₜ  = √σ²ₜ
```

Why it fits a maker better:

- **Updates on every trade** — reacts immediately to bursts, no bar-close lag.
- **Single decay factor λ** — memory is tunable and its rise/decay are symmetric and
  predictable; no arbitrary kline window.
- **Same event clock as fast-cancel** — both consume the same market-trade stream.
- **Dimensionless** — `σ` is a per-trade return standard deviation, so it stays
  scale-free like ATRP (though on a per-trade, not per-bar, magnitude — see calibration
  note below).

The volatility→interval **mapping was kept**: the existing clamped inverse-linear
`bbgo.LinearScale` (low vol → `MaxInterval`, high vol → `MinInterval`) is unchanged and
well-tested; only the default volatility thresholds were recalibrated.

## 2. Refactor details

### New indicator — `pkg/indicator/v2/realizedvolatility.go`

`RealizedVolatilityStream` follows the existing streaming-indicator conventions
(mirrors the `ATRP2` pattern of manual `AddSubscriber` + `PushAndEmit`, since a trade
stream emits `types.Trade`, not `float64`):

```go
func RealizedVolatility(source *TradeStream, lambda float64, warmup int) *RealizedVolatilityStream
```

- On each trade: read `trade.Price.Float64()`, compute the log-return against the
  previous price, update the running EWMA variance, and emit `√variance`.
- **Warm-up gate:** emits nothing until `warmup` returns have accumulated, so `Last(0)`
  returns `0.0` while cold — which the downstream fallback contract already treats as
  "still warming up".
- **Robustness:** non-positive prices are skipped (a log-return would be undefined);
  the backing slice is bounded via `generalTruncate`.
- Test coverage in `realizedvolatility_test.go`: cold→0, warm→positive, wider dispersion
  → higher σ, λ decay while price is flat, and non-positive-price handling.

### Feature refactor — `pkg/strategy/xmaker/adaptivequoteinterval.go`

| Before | After |
| --- | --- |
| `Interval types.Interval` (kline interval) | *removed* |
| `Window int` (ATR window) | *removed* |
| — | `Lambda fixedpoint.Value` (`json:"lambda"`, default `0.94`) |
| — | `Warmup int` (`json:"warmup"`, default `30`) |
| `atrp *indicatorv2.ATRPStream` | `rv *indicatorv2.RealizedVolatilityStream` |
| `LowVolatility` = `0.0005`, `HighVolatility` = `0.005` | recalibrated defaults `0.00005` / `0.001` |

- `Defaults()` / `Validate()` updated for the new fields (`0 < λ < 1`, `warmup > 0`);
  the `MinInterval ≤ MaxInterval` and `LowVolatility < HighVolatility` checks are kept.
- `Bind()` signature changed to take the market-trade stream directly:
  ```go
  func (a *AdaptiveQuoteInterval) Bind(tradeStream types.Stream, symbol string, logger logrus.FieldLogger, metricsLabels prometheus.Labels)
  ```
  It builds `RealizedVolatility(Trades(tradeStream, symbol), λ, warmup)`.
- `buildScale()` and `intervalForVolatility()` are **unchanged** — the clamped
  inverse-linear mapping and boundary rounding are preserved.
- `NextInterval()` now reads `a.rv.Last(0)` instead of `a.atrp.Last(0)`; the Prometheus
  emission and warm-up fallback behavior are otherwise identical.

### Strategy wiring — `pkg/strategy/xmaker/strategy.go`

- **Removed** the adaptive-interval-specific extra kline subscription in `Subscribe()`
  (no kline is needed anymore).
- **Market-trade stream availability:** the source-market trade stream
  (`s.marketTradeStream`, via `bbgo.NewMarketTradeStream`) was previously created only
  when FastCancel or signal-margin was enabled. Its creation guard now also includes the
  adaptive interval. It reuses the same shared stream that FastCancel and the signal
  providers already tap.
- **Ordering fix:** the adaptive `Bind` call was moved to *after* the trade stream is
  allocated (it previously sat above the stream-creation block). The `logger.Infof`
  startup line now reports `lambda`/`warmup` instead of the old ATR params.

### Metrics — `pkg/strategy/xmaker/metrics.go`

Metric **names are unchanged** (`xmaker_adaptive_quote_interval_seconds`,
`xmaker_adaptive_quote_interval_volatility`) to avoid breaking dashboards; only the help
text was updated ("ATR" → "realized volatility"). The volatility gauge now reports the
per-trade σ.

### Tests — `pkg/strategy/xmaker/adaptivequoteinterval_test.go`

Updated for the new config surface (`lambda`/`warmup`, JSON parsing) and the warm-up
test now drives a standalone `indicatorv2.TradeStream` via `BackFill` instead of klines.
The pure mapping tests (`intervalForVolatility`) are retained unchanged.

## Migration & follow-up notes

- **Breaking config change.** Under `adaptiveQuoteInterval`, `interval` and `window` are
  removed and replaced by `lambda` and `warmup`. Existing configs must be updated.
- **Thresholds need calibration.** Per-trade σ is on a much smaller scale than a `1m`
  ATRP, so the default `lowVolatility` / `highVolatility` are conservative placeholders
  and should be tuned against live data per symbol.
- **Concurrency (unchanged parity).** `NextInterval` reads `rv.Last(0)` on the quote
  worker goroutine while trade callbacks update it on the stream goroutine — the same
  cross-goroutine read pattern as the previous ATRP path, so no new hazard is introduced,
  but it is not additionally hardened.

### Verification

- `go build ./...`, `go vet`, and the targeted/regression tests pass under the default
  build, `-tags dnum`, and `-race`.
- Affected packages: `pkg/indicator/v2`, `pkg/strategy/xmaker` (and `pkg/bbgo` confirmed
  unaffected).
