### PR TITLE
REFACTOR: [dynamic] support embedded anonymous structs

### DIFF
--- a/pkg/dynamic/metric.go
+++ b/pkg/dynamic/metric.go
@@ -82,11 +82,11 @@ func castToFloat64(valInf any) (float64, bool) {
 }
 
 func InitializeConfigMetrics(id, instanceId string, st any) error {
-	_, err := initializeConfigMetricsWithFieldPrefix(id, instanceId, "", st)
+	_, err := initializeConfigMetricsWithFieldPrefix(id, instanceId, "", "", st)
 	return err
 }
 
-func initializeConfigMetricsWithFieldPrefix(id, instanceId, fieldPrefix string, st any) ([]string, error) {
+func initializeConfigMetricsWithFieldPrefix(id, instanceId, fieldPrefix, parentSymbol string, st any) ([]string, error) {
 	var metricNames []string
 	tv := reflect.TypeOf(st).Elem()
 
@@ -97,12 +97,30 @@ func initializeConfigMetricsWithFieldPrefix(id, instanceId, fieldPrefix string, 
 
 	sv := reflect.Indirect(vv)
 
-	symbolField := sv.FieldByName("Symbol")
-	hasSymbolField := symbolField.IsValid()
+	// symbol is resolved from the nearest struct that declares a Symbol field.
+	// When recursing into a nested/embedded struct that has no Symbol field of
+	// its own, the parent's symbol is inherited so the metric label stays stable.
+	symbol := parentSymbol
+	if symbolField := sv.FieldByName("Symbol"); symbolField.IsValid() && symbolField.Kind() == reflect.String {
+		symbol = symbolField.String()
+	}
 
 	for i := 0; i < tv.NumField(); i++ {
 		field := tv.Field(i)
 		if !field.IsExported() {
+			continue
+		}
+
+		// Recurse into embedded (anonymous) structs so that their promoted json
+		// fields are registered exactly as if they were declared at this level
+		// (same field prefix, i.e. flat metric names).
+		if field.Anonymous && field.Type.Kind() == reflect.Struct {
+			subMetricNames, err := initializeConfigMetricsWithFieldPrefix(id, instanceId, fieldPrefix, symbol, sv.Field(i).Addr().Interface())
+			if err != nil {
+				return nil, err
+			}
+
+			metricNames = append(metricNames, subMetricNames...)
 			continue
 		}
 
@@ -118,7 +136,7 @@ func initializeConfigMetricsWithFieldPrefix(id, instanceId, fieldPrefix string, 
 
 		fieldName := fieldPrefix + toSnakeCase(tagAttrs[0])
 		if field.Type.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.Struct {
-			subMetricNames, err := initializeConfigMetricsWithFieldPrefix(id, instanceId, fieldName+"_", sv.Field(i).Interface())
+			subMetricNames, err := initializeConfigMetricsWithFieldPrefix(id, instanceId, fieldName+"_", symbol, sv.Field(i).Interface())
 			if err != nil {
 				return nil, err
 			}
@@ -132,11 +150,6 @@ func initializeConfigMetricsWithFieldPrefix(id, instanceId, fieldPrefix string, 
 		val, ok := castToFloat64(valInf)
 		if !ok {
 			continue
-		}
-
-		symbol := ""
-		if hasSymbolField {
-			symbol = symbolField.String()
 		}
 
 		metric, metricName, err := getOrCreateMetric(id, fieldName)

--- a/pkg/dynamic/metric_test.go
+++ b/pkg/dynamic/metric_test.go
@@ -24,7 +24,7 @@ func TestInitializeConfigMetrics(t *testing.T) {
 	}
 
 	t.Run("general", func(t *testing.T) {
-		metricNames, err := initializeConfigMetricsWithFieldPrefix("test", "test-01", "", &Foo{
+		metricNames, err := initializeConfigMetricsWithFieldPrefix("test", "test-01", "", "", &Foo{
 			MinMarginLevel: Number(1.4),
 			Bar: &Bar{
 				Enabled: true,
@@ -39,13 +39,42 @@ func TestInitializeConfigMetrics(t *testing.T) {
 	})
 
 	t.Run("nil struct field", func(t *testing.T) {
-		metricNames, err := initializeConfigMetricsWithFieldPrefix("test", "test-01", "", &Foo{
+		metricNames, err := initializeConfigMetricsWithFieldPrefix("test", "test-01", "", "", &Foo{
 			MinMarginLevel: Number(1.4),
 		})
 
 		if assert.NoError(t, err) {
 			assert.Len(t, metricNames, 1)
 			assert.Equal(t, "test_config_min_margin_level", metricNames[0])
+		}
+	})
+
+	t.Run("embedded anonymous struct", func(t *testing.T) {
+		type Config struct {
+			MinMarginLevel fixedpoint.Value `json:"minMarginLevel"`
+			Bar            *Bar             `json:"bar"`
+		}
+
+		// Symbol stays on the outer struct while the config knobs live in an
+		// embedded anonymous struct; promoted fields must keep flat metric names.
+		type Strategy struct {
+			Config
+
+			Symbol string `json:"symbol"`
+		}
+
+		metricNames, err := initializeConfigMetricsWithFieldPrefix("test2", "test2-01", "", "", &Strategy{
+			Symbol: "BTCUSDT",
+			Config: Config{
+				MinMarginLevel: Number(1.4),
+				Bar:            &Bar{Enabled: true},
+			},
+		})
+
+		if assert.NoError(t, err) {
+			assert.Len(t, metricNames, 2)
+			assert.Contains(t, metricNames, "test2_config_min_margin_level", "promoted field keeps a flat metric name")
+			assert.Contains(t, metricNames, "test2_config_bar_enabled", "nested struct under embedded config")
 		}
 	})
 

--- a/pkg/dynamic/print_config.go
+++ b/pkg/dynamic/print_config.go
@@ -24,7 +24,8 @@ func DefaultWhiteList() []string {
 // @param f: io.Writer used for writing the config dump
 // @param style: pretty print table style. Use NewDefaultTableStyle() to get default one.
 // @param withColor: whether to print with color
-// @param whiteLists: fields to be printed out from embedded struct (1st layer only)
+// @param whiteLists: deprecated no-op. All json-tagged fields of embedded
+// anonymous structs are now printed as if declared on the parent struct.
 func PrintConfig(s interface{}, f io.Writer, style *table.Style, withColor bool, whiteLists ...string) {
 	t := table.NewWriter()
 	var write func(io.Writer, string, ...interface{})
@@ -46,11 +47,6 @@ func PrintConfig(s interface{}, f io.Writer, style *table.Style, withColor bool,
 	}
 	write(f, "---- %s Settings ---\n", CallID(s))
 
-	embeddedWhiteSet := map[string]struct{}{}
-	for _, whiteList := range whiteLists {
-		embeddedWhiteSet[whiteList] = struct{}{}
-	}
-
 	redundantSet := map[string]struct{}{}
 
 	var rows []table.Row
@@ -60,68 +56,71 @@ func PrintConfig(s interface{}, f io.Writer, style *table.Style, withColor bool,
 	if val.Type().Kind() == util.Pointer {
 		val = val.Elem()
 	}
+
 	var values types.JsonArr
+
+	// appendField renders a single struct field into the values slice, honoring
+	// the json / ignore tags and de-duplicating by json name.
+	appendField := func(sf reflect.StructField, fv reflect.Value) {
+		if !sf.IsExported() {
+			return
+		}
+
+		jsonTag := sf.Tag.Get("json")
+		if jsonTag == "" || jsonTag == "-" {
+			return
+		}
+
+		if ig := sf.Tag.Get("ignore"); ig == "true" {
+			return
+		}
+
+		name := strings.Split(jsonTag, ",")[0]
+		if _, ok := redundantSet[name]; ok {
+			return
+		}
+
+		redundantSet[name] = struct{}{}
+
+		value := fv.Interface()
+		if e, err := json.Marshal(value); err == nil {
+			value = string(e)
+		}
+
+		values = append(values, types.JsonStruct{Key: sf.Name, Json: name, Type: sf.Type.String(), Value: value})
+	}
+
 	for i := 0; i < val.Type().NumField(); i++ {
 		t := val.Type().Field(i)
 		if !t.IsExported() {
 			continue
 		}
-		fieldName := t.Name
-		switch jsonTag := t.Tag.Get("json"); jsonTag {
-		case "-":
-		case "":
-			// we only fetch fields from the first layer of the embedded struct
-			if t.Anonymous {
-				var target reflect.Type
-				var field reflect.Value
-				if t.Type.Kind() == util.Pointer {
-					target = t.Type.Elem()
-					field = val.Field(i).Elem()
-				} else {
-					target = t.Type
-					field = val.Field(i)
+
+		// Expand embedded (anonymous) structs so that their promoted json fields
+		// are printed as if they were declared directly on the parent struct.
+		if t.Anonymous && t.Tag.Get("json") == "" {
+			var target reflect.Type
+			var field reflect.Value
+			if t.Type.Kind() == util.Pointer {
+				if val.Field(i).IsNil() {
+					continue
 				}
-				for j := 0; j < target.NumField(); j++ {
-					tt := target.Field(j)
-					if !tt.IsExported() {
-						continue
-					}
-					fieldName := tt.Name
-					if _, ok := embeddedWhiteSet[fieldName]; !ok {
-						continue
-					}
-					if jtag := tt.Tag.Get("json"); jtag != "" && jtag != "-" {
-						if ig := tt.Tag.Get("ignore"); ig == "true" {
-							continue
-						}
-						name := strings.Split(jtag, ",")[0]
-						if _, ok := redundantSet[name]; ok {
-							continue
-						}
-						redundantSet[name] = struct{}{}
-						value := field.Field(j).Interface()
-						if e, err := json.Marshal(value); err == nil {
-							value = string(e)
-						}
-						values = append(values, types.JsonStruct{Key: fieldName, Json: name, Type: tt.Type.String(), Value: value})
-					}
-				}
+
+				target = t.Type.Elem()
+				field = val.Field(i).Elem()
+			} else {
+				target = t.Type
+				field = val.Field(i)
 			}
-		default:
-			name := strings.Split(jsonTag, ",")[0]
-			if ig := t.Tag.Get("ignore"); ig == "true" {
-				continue
+
+			for j := 0; j < target.NumField(); j++ {
+				appendField(target.Field(j), field.Field(j))
 			}
-			if _, ok := redundantSet[name]; ok {
-				continue
-			}
-			redundantSet[name] = struct{}{}
-			value := val.Field(i).Interface()
-			if e, err := json.Marshal(value); err == nil {
-				value = string(e)
-			}
-			values = append(values, types.JsonStruct{Key: fieldName, Json: name, Type: t.Type.String(), Value: value})
+
+			continue
 		}
+
+		appendField(t, val.Field(i))
 	}
 	sort.Sort(values)
 	for _, value := range values {

--- a/pkg/dynamic/print_config_test.go
+++ b/pkg/dynamic/print_config_test.go
@@ -1,0 +1,44 @@
+package dynamic
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+)
+
+type PrintConfigConfig struct {
+	Margin    fixedpoint.Value `json:"margin"`
+	MakerOnly bool             `json:"makerOnly"`
+}
+
+type printConfigStrategy struct {
+	PrintConfigConfig
+
+	Symbol string `json:"symbol"`
+}
+
+func (s *printConfigStrategy) ID() string { return "printtest" }
+
+func TestPrintConfig_EmbeddedAnonymousStruct(t *testing.T) {
+	s := &printConfigStrategy{
+		PrintConfigConfig: PrintConfigConfig{
+			Margin:    fixedpoint.NewFromFloat(0.0015),
+			MakerOnly: true,
+		},
+		Symbol: "BTCUSDT",
+	}
+
+	var buf bytes.Buffer
+	// style=nil takes the plain-text "json: value" writer path.
+	PrintConfig(s, &buf, nil, false, DefaultWhiteList()...)
+
+	out := buf.String()
+	// top-level json field
+	assert.Contains(t, out, "symbol: ", "top-level field should be printed")
+	// promoted fields from the embedded anonymous config struct
+	assert.Contains(t, out, "margin: ", "embedded config field should be printed")
+	assert.Contains(t, out, "makerOnly: ", "embedded config field should be printed")
+}


### PR DESCRIPTION
Support for anonymous embedded struct:
- metrics
- print configs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>