### PR TITLE
FIX: [persistence] fix panics on null values in loadPersistenceFields 

### DIFF
--- a/pkg/bbgo/persistence.go
+++ b/pkg/bbgo/persistence.go
@@ -57,7 +57,7 @@ func Sync(ctx context.Context, obj interface{}) {
 	}
 }
 
-func loadPersistenceFields(obj interface{}, id string, persistence service.PersistenceService) error {
+func LoadPersistenceFields(obj interface{}, id string, persistence service.PersistenceService) error {
 	return dynamic.IterateFieldsByTag(obj, "persistence", true, func(
 		tag string, field reflect.StructField, value reflect.Value,
 	) error {

--- a/pkg/bbgo/persistence.go
+++ b/pkg/bbgo/persistence.go
@@ -76,6 +76,14 @@ func loadPersistenceFields(obj interface{}, id string, persistence service.Persi
 		}
 
 		newValue := reflect.ValueOf(newValueInf)
+		if !newValue.IsValid() {
+			// The stored value was JSON null (a nil pointer field). json.Unmarshal
+			// turns null into an untyped nil,
+			// so newValue is the zero Value. Leave the field as-is, matching the
+			// missing-key behavior, instead of panicking on the following value.Set.
+			return nil
+		}
+
 		if value.Kind() != reflect.Ptr && newValue.Kind() == reflect.Ptr {
 			newValue = newValue.Elem()
 		}

--- a/pkg/bbgo/persistence_test.go
+++ b/pkg/bbgo/persistence_test.go
@@ -75,13 +75,13 @@ func Test_loadPersistenceFields(t *testing.T) {
 		psName := reflect.TypeOf(ps).Elem().String()
 		t.Run(psName+"/empty", func(t *testing.T) {
 			b := &TestStruct{}
-			err := loadPersistenceFields(b, "test-empty", ps)
+			err := LoadPersistenceFields(b, "test-empty", ps)
 			assert.NoError(t, err)
 		})
 
 		t.Run(psName+"/nil", func(t *testing.T) {
 			var b *TestStruct = nil
-			err := loadPersistenceFields(b, "test-nil", ps)
+			err := LoadPersistenceFields(b, "test-nil", ps)
 			assert.Equal(t, dynamic.ErrCanNotIterateNilPointer, err)
 		})
 
@@ -95,7 +95,7 @@ func Test_loadPersistenceFields(t *testing.T) {
 			assert.NoError(t, err)
 
 			b := &TestStruct{}
-			err = loadPersistenceFields(b, "pointer-field-test", ps)
+			err = LoadPersistenceFields(b, "pointer-field-test", ps)
 			assert.NoError(t, err)
 
 			assert.Equal(t, "10", a.Position.Base.String())
@@ -139,7 +139,7 @@ func Test_storePersistenceFields(t *testing.T) {
 			assert.Equal(t, fixedpoint.NewFromFloat(3343.0), p.AverageCost)
 
 			var b = &TestStruct{}
-			err = loadPersistenceFields(b, id, ps)
+			err = LoadPersistenceFields(b, id, ps)
 			assert.NoError(t, err)
 			assert.Equal(t, a.Integer, b.Integer)
 			assert.Equal(t, a.Integer2, b.Integer2)
@@ -172,7 +172,7 @@ func Test_storePersistenceFields(t *testing.T) {
 			assert.Equal(t, types.PnLModeExcludeFeeFromCost, p.PnLMode)
 
 			var b = &TestStruct{}
-			err = loadPersistenceFields(b, id, ps)
+			err = LoadPersistenceFields(b, id, ps)
 			assert.NoError(t, err)
 			assert.Equal(t, a.Integer, b.Integer)
 			assert.Equal(t, a.Integer2, b.Integer2)

--- a/pkg/bbgo/trader.go
+++ b/pkg/bbgo/trader.go
@@ -374,7 +374,7 @@ func (trader *Trader) LoadState(ctx context.Context) error {
 			return customSync.Load(ctx, store)
 		}
 
-		return loadPersistenceFields(strategy, id, ps)
+		return LoadPersistenceFields(strategy, id, ps)
 	})
 }
 


### PR DESCRIPTION
Use the following yaml to reproduce the panics:
```yaml
---
persistence:
  json:
    directory: var/data

logging:
  trade: true
  order: true
  fields:
    env: dryrun

sessions:
  max:
    exchange: max
    envVarPrefix: max

  binance:
    exchange: binance
    envVarPrefix: binance

crossExchangeStrategies:
- xmaker:
    dryRun: true
    symbol: "BTCUSDT"
    makerExchange: max
    sourceExchange: binance
    quantity: 0.001
    quantityMultiplier: 2
```