### PR TITLE
FEATURE: [xmaker] support quote quantity mode

### DIFF
--- a/pkg/strategy/xmaker/pricer/pricer.go
+++ b/pkg/strategy/xmaker/pricer/pricer.go
@@ -15,15 +15,23 @@ type CoveredDepth struct {
 	initialDepth     fixedpoint.Value
 	depthBook        *types.DepthBook
 	side             types.SideType
+
+	// if useQuoteQuantity is true, the depth will be interpreted as quote quantity, not base quantity.
+	useQuoteQuantity bool
 }
 
-func NewCoveredDepth(depthBook *types.DepthBook, side types.SideType, initialDepth fixedpoint.Value) *CoveredDepth {
+// NewCoveredDepth creates a new CoveredDepth instance.
+// If useQuoteQuantity is true, the instance will work under the quote depth mode, which means all the depth-related
+// calculations will be based on quote quantity instead of base quantity.
+// Note that it will interpret all the depth-related parameters that are passed to the instance as quote quantity as well.
+func NewCoveredDepth(depthBook *types.DepthBook, side types.SideType, initialDepth fixedpoint.Value, useQuoteQuantity bool) *CoveredDepth {
 	return &CoveredDepth{
 		lastIndex:        -1,
 		initialDepth:     initialDepth,
 		depthBook:        depthBook,
 		side:             side,
 		accumulatedDepth: fixedpoint.Zero,
+		useQuoteQuantity: useQuoteQuantity,
 	}
 }
 
@@ -37,19 +45,23 @@ func (d *CoveredDepth) Cover(depth fixedpoint.Value) {
 
 func (d *CoveredDepth) Pricer() Pricer {
 	return func(i int, price fixedpoint.Value) fixedpoint.Value {
+		depthFunc := d.depthBook.PriceAtDepth
+		if d.useQuoteQuantity {
+			depthFunc = d.depthBook.PriceAtQuoteDepth
+		}
 		if i <= d.lastIndex {
 			// If the index is not increasing, we do not accumulate depth.
 			// This is to prevent re-accumulating depth when the same index is processed again.
 			log.Warnf("FromAccumulatedDepth: index %d is not increasing from last index %d, skipping accumulation", i, d.lastIndex)
-			return d.depthBook.PriceAtDepth(d.side, d.initialDepth)
+			return depthFunc(d.side, d.initialDepth)
 		}
 
 		if d.lastIndex == 0 {
 			// If this is the first index, we set the initial depth.
-			price = d.depthBook.PriceAtDepth(d.side, d.initialDepth)
+			price = depthFunc(d.side, d.initialDepth)
 			d.accumulatedDepth = d.initialDepth
 		} else {
-			price = d.depthBook.PriceAtDepth(d.side, d.accumulatedDepth)
+			price = depthFunc(d.side, d.accumulatedDepth)
 		}
 
 		d.lastIndex = i
@@ -57,8 +69,11 @@ func (d *CoveredDepth) Pricer() Pricer {
 	}
 }
 
-func FromDepthBook(side types.SideType, depthBook *types.DepthBook, depth fixedpoint.Value) Pricer {
+func FromDepthBook(side types.SideType, depthBook *types.DepthBook, depth fixedpoint.Value, useQuoteQuantity bool) Pricer {
 	return func(i int, price fixedpoint.Value) fixedpoint.Value {
+		if useQuoteQuantity {
+			return depthBook.PriceAtQuoteDepth(side, depth)
+		}
 		return depthBook.PriceAtDepth(side, depth)
 	}
 }

--- a/pkg/strategy/xmaker/pricer/pricer_test.go
+++ b/pkg/strategy/xmaker/pricer/pricer_test.go
@@ -355,7 +355,7 @@ func TestFromDepth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pricer := FromDepthBook(tt.side, tt.book, tt.depth)
+			pricer := FromDepthBook(tt.side, tt.book, tt.depth, false)
 			got := pricer(tt.call.i, tt.call.price)
 			assert.Equal(t, tt.call.want, got)
 		})
@@ -443,7 +443,7 @@ func TestNewCoveredDepth(t *testing.T) {
 	depthBook := types.NewDepthBook(book)
 	initialDepth := Number(1)
 
-	coveredDepth := NewCoveredDepth(depthBook, types.SideTypeBuy, initialDepth)
+	coveredDepth := NewCoveredDepth(depthBook, types.SideTypeBuy, initialDepth, false)
 	pricer := coveredDepth.Pricer()
 
 	// Assume the order quantity per layer is 1

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -856,7 +856,7 @@ func (s *Strategy) getInitialLayerQuantity(i int, price fixedpoint.Value) (fixed
 	if s.QuantityMultiplier.Sign() > 0 && i > 0 {
 		q = fixedpoint.NewFromFloat(
 			q.Float64() * math.Pow(
-				s.QuantityMultiplier.Float64(), float64(i+1),
+				s.QuantityMultiplier.Float64(), float64(i),
 			),
 		)
 	}
@@ -1481,7 +1481,7 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 				// if we bought, then we need to sell the base from the hedge session
 				// if the hedge session is a margin session, we don't need to lock the base asset
 				if makerQuota.QuoteAsset.Lock(requiredQuote) &&
-					(s.hedgeSession.Margin || hedgeQuota.BaseAsset.Lock(bidQuantity)) {
+					(s.DryRun || (s.hedgeSession.Margin || hedgeQuota.BaseAsset.Lock(bidQuantity))) {
 
 					submitOrders = append(
 						submitOrders, types.SubmitOrder{
@@ -1540,7 +1540,7 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 				}
 
 				if makerQuota.BaseAsset.Lock(requiredBase) &&
-					(s.hedgeSession.Margin || hedgeQuota.QuoteAsset.Lock(requiredBase.Mul(askPrice))) {
+					(s.DryRun || (s.hedgeSession.Margin || hedgeQuota.QuoteAsset.Lock(requiredBase.Mul(askPrice)))) {
 
 					// if we sell on the maker market, then we need to buy the base from the hedge session
 					submitOrders = append(
@@ -1631,7 +1631,7 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 				// if we bought, then we need to sell the base from the hedge session
 				// if the hedge session is a margin session, we don't need to lock the base asset
 				if makerQuota.QuoteAsset.Lock(requiredQuote) &&
-					(s.hedgeSession.Margin || hedgeQuota.BaseAsset.Lock(bidQuantity)) {
+					(s.DryRun || (s.hedgeSession.Margin || hedgeQuota.BaseAsset.Lock(bidQuantity))) {
 
 					// if we bought, then we need to sell the base from the hedge session
 					submitOrders = append(
@@ -1710,7 +1710,7 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 				}
 
 				if makerQuota.BaseAsset.Lock(requiredBase) &&
-					(s.hedgeSession.Margin || hedgeQuota.QuoteAsset.Lock(requiredBase.Mul(askPrice))) {
+					(s.DryRun || (s.hedgeSession.Margin || hedgeQuota.QuoteAsset.Lock(requiredBase.Mul(askPrice)))) {
 
 					// if we bought, then we need to sell the base from the hedge session
 					submitOrders = append(
@@ -1747,7 +1747,22 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 	}
 
 	if s.DryRun {
-		s.logger.Infof("[dryRun] maker orders: %+v", submitOrders)
+		var buyOrders, sellOrders []types.SubmitOrder
+		for _, order := range submitOrders {
+			if order.Side == types.SideTypeBuy {
+				buyOrders = append(buyOrders, order)
+			} else {
+				sellOrders = append(sellOrders, order)
+			}
+		}
+		s.logger.Info("[dryRun] maker buy orders:")
+		for i, order := range buyOrders {
+			s.logger.Infof("[dryRun] %d: price=%f, quantity=%f, quote quantity=%s", i, order.Price.Float64(), order.Quantity.Float64(), order.Quantity.Mul(order.Price))
+		}
+		s.logger.Info("[dryRun] maker sell orders:")
+		for i, order := range sellOrders {
+			s.logger.Infof("[dryRun] %d: price=%f, quantity=%f, quote quantity=%s", i, order.Price.Float64(), order.Quantity.Float64(), order.Quantity.Mul(order.Price))
+		}
 		return nil
 	}
 

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -163,9 +163,6 @@ type StrategyConfig struct {
 	// MinMargin is the minimum margin protection for signal margin
 	MinMargin *fixedpoint.Value `json:"minMargin"`
 
-	UseDepthPrice bool             `json:"useDepthPrice"`
-	DepthQuantity fixedpoint.Value `json:"depthQuantity"`
-
 	// TODO: move SourceDepthLevel to HedgeMarket
 	SourceDepthLevel types.Depth `json:"sourceDepthLevel"`
 	MakerOnly        bool        `json:"makerOnly"`
@@ -192,6 +189,18 @@ type StrategyConfig struct {
 
 	StopHedgeQuoteBalance fixedpoint.Value `json:"stopHedgeQuoteBalance"`
 	StopHedgeBaseBalance  fixedpoint.Value `json:"stopHedgeBaseBalance"`
+
+	// UseQuoteQuantity enables the quantity calculation base on quote amount.
+	// When enabled, the following fields will be interpreted as quote currency instead of base currency:
+	//  - DepthQuantity
+	//  - Quantity
+	//  - QuantityScale: the settings will be interpreted as quote currency
+	UseQuoteQuantity bool `json:"useQuoteQuantity"`
+
+	// UseDepthPrice enables the price calculation based on depth instead of best price.
+	UseDepthPrice bool `json:"useDepthPrice"`
+	// DepthQuantity is the depth quantity to calculate the price based on depth.
+	DepthQuantity fixedpoint.Value `json:"depthQuantity"`
 
 	// Quantity is used for fixed quantity of the first layer
 	Quantity fixedpoint.Value `json:"quantity"`
@@ -820,11 +829,16 @@ func (s *Strategy) AggregateSignal(ctx context.Context) (float64, error) {
 
 // getInitialLayerQuantity returns the initial quantity for the layer
 // i is the layer index, starting from 0
-func (s *Strategy) getInitialLayerQuantity(i int) (fixedpoint.Value, error) {
+func (s *Strategy) getInitialLayerQuantity(i int, price fixedpoint.Value) (fixedpoint.Value, error) {
 	if s.QuantityScale != nil {
 		qf, err := s.QuantityScale.Scale(i + 1)
 		if err != nil {
 			return fixedpoint.Zero, fmt.Errorf("quantityScale error: %w", err)
+		}
+
+		if s.UseQuoteQuantity && price.Sign() > 0 {
+			// the quantity scale is in quote currency -> convert to base currency
+			qf = qf / price.Float64()
 		}
 
 		s.logger.Infof("%s scaling bid #%d quantity to %f", s.Symbol, i+1, qf)
@@ -834,6 +848,10 @@ func (s *Strategy) getInitialLayerQuantity(i int) (fixedpoint.Value, error) {
 	}
 
 	q := s.Quantity
+	if s.UseQuoteQuantity && price.Sign() > 0 {
+		// s.Quantity is in quote currency -> convert to base currency
+		q = q.Div(price)
+	}
 
 	if s.QuantityMultiplier.Sign() > 0 && i > 0 {
 		q = fixedpoint.NewFromFloat(
@@ -1388,7 +1406,7 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 
 	// if depth price is enabled, replace the default best pricing
 	if s.UseDepthPrice {
-		bidCoveredDepth := pricer.NewCoveredDepth(s.depthSourceBook, types.SideTypeBuy, s.DepthQuantity)
+		bidCoveredDepth := pricer.NewCoveredDepth(s.depthSourceBook, types.SideTypeBuy, s.DepthQuantity, s.UseQuoteQuantity)
 		bidSourcePricer = bidCoveredDepth.Pricer()
 		coverBidDepth = bidCoveredDepth.Cover
 	}
@@ -1403,7 +1421,7 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 	askSourcePricer := pricer.FromBestPrice(types.SideTypeSell, s.sourceBook)
 	coverAskDepth := nopCover
 	if s.UseDepthPrice {
-		askCoveredDepth := pricer.NewCoveredDepth(s.depthSourceBook, types.SideTypeSell, s.DepthQuantity)
+		askCoveredDepth := pricer.NewCoveredDepth(s.depthSourceBook, types.SideTypeSell, s.DepthQuantity, s.UseQuoteQuantity)
 		coverAskDepth = askCoveredDepth.Cover
 		askSourcePricer = askCoveredDepth.Pricer()
 	}
@@ -1423,7 +1441,17 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 
 		if !disableMakerBid {
 			for i := 0; i < s.NumLayers; i++ {
-				bidQuantity, err := s.getInitialLayerQuantity(i)
+				bidPrice := bidPriceSpread(i, bestBidPrice)
+				if bidPrice.IsZero() {
+					s.logger.Warnf("no valid bid price, skip quoting")
+					break
+				}
+
+				quotePrice := fixedpoint.Zero
+				if s.UseQuoteQuantity {
+					quotePrice = bidPrice
+				}
+				bidQuantity, err := s.getInitialLayerQuantity(i, quotePrice)
 				if err != nil {
 					return err
 				}
@@ -1431,12 +1459,6 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 				// apply D2 size scale
 				if sizeScale < 1.0 {
 					bidQuantity = bidQuantity.Mul(fixedpoint.NewFromFloat(sizeScale))
-				}
-
-				bidPrice := bidPriceSpread(i, bestBidPrice)
-				if bidPrice.IsZero() {
-					s.logger.Warnf("no valid bid price, skip quoting")
-					break
 				}
 
 				if i == 0 {
@@ -1485,7 +1507,17 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 		}
 		if !disableMakerAsk {
 			for i := 0; i < s.NumLayers; i++ {
-				askQuantity, err := s.getInitialLayerQuantity(i)
+				askPrice := askPriceSpread(i, bestAskPrice)
+				if askPrice.IsZero() {
+					s.logger.Warnf("no valid ask price, skip quoting")
+					break
+				}
+
+				quotePrice := fixedpoint.Zero
+				if s.UseQuoteQuantity {
+					quotePrice = askPrice
+				}
+				askQuantity, err := s.getInitialLayerQuantity(i, quotePrice)
 				if err != nil {
 					return err
 				}
@@ -1493,12 +1525,6 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 				// apply D2 size scale
 				if sizeScale < 1.0 {
 					askQuantity = askQuantity.Mul(fixedpoint.NewFromFloat(sizeScale))
-				}
-
-				askPrice := askPriceSpread(i, bestAskPrice)
-				if askPrice.IsZero() {
-					s.logger.Warnf("no valid ask price, skip quoting")
-					break
 				}
 
 				if i == 0 {
@@ -1545,19 +1571,6 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 		s.logger.Infof("%s source book ticker: ask/bid = %s/%s (%s)", s.Symbol, bestAskPrice.String(), bestBidPrice.String(), calculateSpread(bestAskPrice, bestBidPrice).Percentage())
 		if !disableMakerBid {
 			for i := 0; i < s.NumLayers; i++ {
-				bidQuantity, err := s.getInitialLayerQuantity(i)
-				if err != nil {
-					return err
-				}
-
-				// apply D2 size scale
-				if sizeScale < 1.0 {
-					bidQuantity = bidQuantity.Mul(fixedpoint.NewFromFloat(sizeScale))
-				}
-
-				// for maker bid orders
-				coverBidDepth(bidQuantity)
-
 				bidPrice := fixedpoint.Zero
 				if s.SyntheticHedge != nil && s.SyntheticHedge.Enabled {
 					// note: the accumulativeBidQuantity is not used yet,
@@ -1575,6 +1588,28 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 					s.logger.Warnf("no valid bid price, skip quoting")
 					break
 				}
+
+				quotePrice := fixedpoint.Zero
+				if s.UseQuoteQuantity {
+					quotePrice = bidPrice
+				}
+
+				bidQuantity, err := s.getInitialLayerQuantity(i, quotePrice)
+				if err != nil {
+					return err
+				}
+
+				// apply D2 size scale
+				if sizeScale < 1.0 {
+					bidQuantity = bidQuantity.Mul(fixedpoint.NewFromFloat(sizeScale))
+				}
+
+				// for maker bid orders
+				coverQuantity := bidQuantity
+				if s.UseQuoteQuantity {
+					coverQuantity = bidQuantity.Mul(bidPrice)
+				}
+				coverBidDepth(coverQuantity)
 
 				if i == 0 {
 					s.logger.Infof("maker best bid price %f", bidPrice.Float64())
@@ -1626,18 +1661,6 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 		// for maker ask orders
 		if !disableMakerAsk {
 			for i := 0; i < s.NumLayers; i++ {
-				askQuantity, err := s.getInitialLayerQuantity(i)
-				if err != nil {
-					return err
-				}
-
-				// apply D2 size scale
-				if sizeScale < 1.0 {
-					askQuantity = askQuantity.Mul(fixedpoint.NewFromFloat(sizeScale))
-				}
-
-				coverAskDepth(askQuantity)
-
 				askPrice := fixedpoint.Zero
 				if s.SyntheticHedge != nil && s.SyntheticHedge.Enabled {
 					if _, ask, ok := s.SyntheticHedge.GetQuotePrices(); ok {
@@ -1653,6 +1676,26 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 					s.logger.Warnf("no valid ask price, skip quoting")
 					break
 				}
+
+				quotePrice := fixedpoint.Zero
+				if s.UseQuoteQuantity {
+					quotePrice = askPrice
+				}
+				askQuantity, err := s.getInitialLayerQuantity(i, quotePrice)
+				if err != nil {
+					return err
+				}
+
+				// apply D2 size scale
+				if sizeScale < 1.0 {
+					askQuantity = askQuantity.Mul(fixedpoint.NewFromFloat(sizeScale))
+				}
+
+				coverQuantity := askQuantity
+				if s.UseQuoteQuantity {
+					coverQuantity = askQuantity.Mul(askPrice)
+				}
+				coverAskDepth(coverQuantity)
 
 				if i == 0 {
 					s.logger.Infof("maker best ask price %f", askPrice.Float64())

--- a/pkg/strategy/xmaker/strategy_test.go
+++ b/pkg/strategy/xmaker/strategy_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/c9s/bbgo/pkg/bbgo"
 	"github.com/c9s/bbgo/pkg/dynamic"
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 	. "github.com/c9s/bbgo/pkg/testing/testhelper"
@@ -112,4 +114,162 @@ func Test_EmbeddedConfigFlatten(t *testing.T) {
 
 	// config metrics still register for promoted fields
 	assert.NoError(t, dynamic.InitializeConfigMetrics(ID, "xmaker:BTCUSDT:temp", s))
+}
+
+func newLinearLayerScale(domain, rng [2]float64) *bbgo.LayerScale {
+	return &bbgo.LayerScale{
+		LayerRule: &bbgo.SlideRule{
+			LinearScale: &bbgo.LinearScale{
+				Domain: domain,
+				Range:  rng,
+			},
+		},
+	}
+}
+
+func TestStrategy_getInitialLayerQuantity_QuantityScale(t *testing.T) {
+	// layer 1 -> 10, layer 3 -> 30 (linear)
+	price := fixedpoint.NewFromFloat(100.0)
+
+	t.Run("quote scale disabled: quantity scale is already in base currency", func(t *testing.T) {
+		s := &Strategy{
+			logger: logrus.New(),
+			StrategyConfig: StrategyConfig{
+				QuantityScale: newLinearLayerScale([2]float64{1, 3}, [2]float64{10, 30}),
+			},
+		}
+
+		q, err := s.getInitialLayerQuantity(0, price)
+		assert.NoError(t, err)
+		assert.InDelta(t, 10.0, q.Float64(), 1e-8)
+
+		q, err = s.getInitialLayerQuantity(1, price)
+		assert.NoError(t, err)
+		assert.InDelta(t, 20.0, q.Float64(), 1e-8)
+	})
+
+	t.Run("quote scale enabled: quantity scale is in quote currency and converted to base", func(t *testing.T) {
+		s := &Strategy{
+			logger: logrus.New(),
+			StrategyConfig: StrategyConfig{
+				QuantityScale:    newLinearLayerScale([2]float64{1, 3}, [2]float64{10, 30}),
+				UseQuoteQuantity: true,
+			},
+		}
+
+		// layer 1 -> quote 10 -> base 10/100 = 0.1
+		q, err := s.getInitialLayerQuantity(0, price)
+		assert.NoError(t, err)
+		assert.InDelta(t, 0.1, q.Float64(), 1e-8)
+
+		// layer 2 -> quote 20 -> base 20/100 = 0.2
+		q, err = s.getInitialLayerQuantity(1, price)
+		assert.NoError(t, err)
+		assert.InDelta(t, 0.2, q.Float64(), 1e-8)
+	})
+
+	t.Run("quote scale enabled but price is zero: no conversion is applied", func(t *testing.T) {
+		s := &Strategy{
+			logger: logrus.New(),
+			StrategyConfig: StrategyConfig{
+				QuantityScale:    newLinearLayerScale([2]float64{1, 3}, [2]float64{10, 30}),
+				UseQuoteQuantity: true,
+			},
+		}
+
+		q, err := s.getInitialLayerQuantity(0, fixedpoint.Zero)
+		assert.NoError(t, err)
+		assert.InDelta(t, 10.0, q.Float64(), 1e-8)
+	})
+}
+
+func TestStrategy_getInitialLayerQuantity_SimpleMultiplier(t *testing.T) {
+	price := fixedpoint.NewFromFloat(100.0)
+
+	t.Run("no multiplier, quote scale disabled: quantity is fixed", func(t *testing.T) {
+		s := &Strategy{
+			logger: logrus.New(),
+			StrategyConfig: StrategyConfig{
+				Quantity: fixedpoint.NewFromFloat(10.0),
+			},
+		}
+
+		for i := 0; i < 3; i++ {
+			q, err := s.getInitialLayerQuantity(i, price)
+			assert.NoError(t, err)
+			assert.InDelta(t, 10.0, q.Float64(), 1e-8)
+		}
+	})
+
+	t.Run("multiplier applied for layers after the first, quote scale disabled", func(t *testing.T) {
+		s := &Strategy{
+			logger: logrus.New(),
+			StrategyConfig: StrategyConfig{
+				Quantity:           fixedpoint.NewFromFloat(10.0),
+				QuantityMultiplier: fixedpoint.NewFromFloat(1.1),
+			},
+		}
+
+		q, err := s.getInitialLayerQuantity(0, price)
+		assert.NoError(t, err)
+		assert.InDelta(t, 10.0, q.Float64(), 1e-8)
+
+		q, err = s.getInitialLayerQuantity(1, price)
+		assert.NoError(t, err)
+		assert.InDelta(t, 10.0*1.1*1.1, q.Float64(), 1e-8)
+
+		q, err = s.getInitialLayerQuantity(2, price)
+		assert.NoError(t, err)
+		assert.InDelta(t, 10.0*1.1*1.1*1.1, q.Float64(), 1e-8)
+	})
+
+	t.Run("quote scale enabled: fixed quantity is in quote currency and converted to base", func(t *testing.T) {
+		s := &Strategy{
+			logger: logrus.New(),
+			StrategyConfig: StrategyConfig{
+				Quantity:         fixedpoint.NewFromFloat(1000.0),
+				UseQuoteQuantity: true,
+			},
+		}
+
+		// 1000 quote / 100 price = 10 base
+		q, err := s.getInitialLayerQuantity(0, price)
+		assert.NoError(t, err)
+		assert.InDelta(t, 10.0, q.Float64(), 1e-8)
+	})
+
+	t.Run("quote scale and multiplier both enabled", func(t *testing.T) {
+		s := &Strategy{
+			logger: logrus.New(),
+			StrategyConfig: StrategyConfig{
+				Quantity:           fixedpoint.NewFromFloat(1000.0),
+				QuantityMultiplier: fixedpoint.NewFromFloat(1.1),
+				UseQuoteQuantity:   true,
+			},
+		}
+
+		// layer 0: 1000/100 = 10, multiplier not applied
+		q, err := s.getInitialLayerQuantity(0, price)
+		assert.NoError(t, err)
+		assert.InDelta(t, 10.0, q.Float64(), 1e-8)
+
+		// layer 1: (1000/100) * 1.1^2 = 12.1
+		q, err = s.getInitialLayerQuantity(1, price)
+		assert.NoError(t, err)
+		assert.InDelta(t, 10.0*1.1*1.1, q.Float64(), 1e-8)
+	})
+
+	t.Run("quote scale enabled but price is zero: no conversion is applied", func(t *testing.T) {
+		s := &Strategy{
+			logger: logrus.New(),
+			StrategyConfig: StrategyConfig{
+				Quantity:         fixedpoint.NewFromFloat(1000.0),
+				UseQuoteQuantity: true,
+			},
+		}
+
+		q, err := s.getInitialLayerQuantity(0, fixedpoint.Zero)
+		assert.NoError(t, err)
+		assert.InDelta(t, 1000.0, q.Float64(), 1e-8)
+	})
 }

--- a/pkg/strategy/xmaker/strategy_test.go
+++ b/pkg/strategy/xmaker/strategy_test.go
@@ -216,11 +216,11 @@ func TestStrategy_getInitialLayerQuantity_SimpleMultiplier(t *testing.T) {
 
 		q, err = s.getInitialLayerQuantity(1, price)
 		assert.NoError(t, err)
-		assert.InDelta(t, 10.0*1.1*1.1, q.Float64(), 1e-8)
+		assert.InDelta(t, 10.0*1.1, q.Float64(), 1e-8)
 
 		q, err = s.getInitialLayerQuantity(2, price)
 		assert.NoError(t, err)
-		assert.InDelta(t, 10.0*1.1*1.1*1.1, q.Float64(), 1e-8)
+		assert.InDelta(t, 10.0*1.1*1.1, q.Float64(), 1e-8)
 	})
 
 	t.Run("quote scale enabled: fixed quantity is in quote currency and converted to base", func(t *testing.T) {
@@ -256,7 +256,7 @@ func TestStrategy_getInitialLayerQuantity_SimpleMultiplier(t *testing.T) {
 		// layer 1: (1000/100) * 1.1^2 = 12.1
 		q, err = s.getInitialLayerQuantity(1, price)
 		assert.NoError(t, err)
-		assert.InDelta(t, 10.0*1.1*1.1, q.Float64(), 1e-8)
+		assert.InDelta(t, 10.0*1.1, q.Float64(), 1e-8)
 	})
 
 	t.Run("quote scale enabled but price is zero: no conversion is applied", func(t *testing.T) {


### PR DESCRIPTION
- Add `EnableQuoteQuantity` config option to xmaker, when enabled:
    - allowing `quantityScale` to be interpreted as a **quote-currency** amount per layer (e.g. USDT) instead of base-currency quantity. When enabled, the scaled value is divided by the layer's quote price to derive the actual base-currency order quantity.
    - `quantity` will be interpreted as a **quote-currency** amount and the multiplier is applied to the quote amount. 
    - `depthQuantity` for the pricing is in **quote-currency** under this mode

