### PR TITLE
FEATURE: [xmaker] asset borrowable check for margin 

### DIFF
--- a/pkg/bbgo/config_test.go
+++ b/pkg/bbgo/config_test.go
@@ -79,11 +79,17 @@ func TestLoadConfig(t *testing.T) {
 							"exchange":                  "max",
 							"envVarPrefix":              "MAX",
 							"marginInfoUpdaterInterval": "3m0s",
+							// json.Unmarshal decodes numbers into float64, so we need to use float64 here to match the unmarshaled value.
+							"marginInfoUpdaterBatchSize": float64(3),
+							"marginInfoUpdaterCooldown":  "9m0s",
 						},
 						"binance": map[string]interface{}{
 							"exchange":                  "binance",
 							"envVarPrefix":              "BINANCE",
 							"marginInfoUpdaterInterval": "5m0s",
+							// json.Unmarshal decodes numbers into float64, so we need to use float64 here to match the unmarshaled value.
+							"marginInfoUpdaterBatchSize": float64(5),
+							"marginInfoUpdaterCooldown":  "15m0s",
 						},
 					},
 					"build": map[string]interface{}{

--- a/pkg/bbgo/margin_info_updater.go
+++ b/pkg/bbgo/margin_info_updater.go
@@ -20,6 +20,9 @@ type MarginInfoUpdater struct {
 
 	assets map[string]fixedpoint.Value
 
+	doneAssets        map[string]struct{}
+	lastResetDoneTime time.Time
+
 	maxBorrowableCallbacks []MaxBorrowableCallback
 
 	mu sync.Mutex
@@ -29,8 +32,9 @@ func NewMarginInfoUpdater(
 	service types.MarginBorrowRepayService,
 ) *MarginInfoUpdater {
 	return &MarginInfoUpdater{
-		assets:  make(map[string]fixedpoint.Value),
-		service: service,
+		assets:     make(map[string]fixedpoint.Value),
+		doneAssets: make(map[string]struct{}),
+		service:    service,
 	}
 }
 
@@ -38,17 +42,23 @@ func NewMarginInfoUpdater(
 func (m *MarginInfoUpdater) Run(
 	ctx context.Context,
 	interval types.Duration,
+	batchSize int,
+	coolDown time.Duration,
 ) {
 	ticker := time.NewTicker(timejitter.Milliseconds(interval.Duration(), 500))
 	defer ticker.Stop()
 
-	m.Update(ctx)
+	m.Update(ctx, batchSize)
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
-			m.Update(ctx)
+		case now := <-ticker.C:
+			if !m.lastResetDoneTime.IsZero() && now.Sub(m.lastResetDoneTime) <= coolDown {
+				// still in cooldown period, skip this update cycle
+				continue
+			}
+			m.Update(ctx, batchSize)
 		}
 	}
 }
@@ -76,11 +86,23 @@ func (m *MarginInfoUpdater) GetMaxBorrowable(asset string) (fixedpoint.Value, bo
 // Update queries the max borrowable amount for each asset and emit update events.
 func (m *MarginInfoUpdater) Update(
 	ctx context.Context,
+	batchSize int,
 ) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	pending := make([]string, 0, len(m.assets))
 	for asset := range m.assets {
+		if _, done := m.doneAssets[asset]; !done {
+			pending = append(pending, asset)
+		}
+	}
+
+	if batchSize > len(pending) {
+		batchSize = len(pending)
+	}
+
+	for _, asset := range pending[:batchSize] {
 		maxBorrowable, err := m.service.QueryMarginAssetMaxBorrowable(
 			ctx,
 			asset,
@@ -92,7 +114,14 @@ func (m *MarginInfoUpdater) Update(
 		}
 
 		m.assets[asset] = maxBorrowable
+		m.doneAssets[asset] = struct{}{}
 
 		m.EmitMaxBorrowable(asset, maxBorrowable)
+	}
+
+	// once every asset has been refreshed, reset to begin a new cycle.
+	if len(m.doneAssets) >= len(m.assets) {
+		m.doneAssets = make(map[string]struct{})
+		m.lastResetDoneTime = time.Now()
 	}
 }

--- a/pkg/bbgo/margin_info_updater_test.go
+++ b/pkg/bbgo/margin_info_updater_test.go
@@ -1,0 +1,247 @@
+package bbgo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+)
+
+// mockMarginBorrowRepayService is a stub types.MarginBorrowRepayService whose
+// QueryMarginAssetMaxBorrowable returns a preconfigured amount per asset (and an
+// optional error), while recording how many times each asset was queried.
+type mockMarginBorrowRepayService struct {
+	mu sync.Mutex
+
+	maxBorrowable map[string]fixedpoint.Value
+	errs          map[string]error
+	queryCount    map[string]int
+}
+
+func newMockMarginBorrowRepayService(maxBorrowable map[string]fixedpoint.Value) *mockMarginBorrowRepayService {
+	return &mockMarginBorrowRepayService{
+		maxBorrowable: maxBorrowable,
+		errs:          make(map[string]error),
+		queryCount:    make(map[string]int),
+	}
+}
+
+func (m *mockMarginBorrowRepayService) RepayMarginAsset(
+	_ context.Context, _ string, _ fixedpoint.Value,
+) error {
+	return nil
+}
+
+func (m *mockMarginBorrowRepayService) BorrowMarginAsset(
+	_ context.Context, _ string, _ fixedpoint.Value,
+) error {
+	return nil
+}
+
+func (m *mockMarginBorrowRepayService) QueryMarginAssetMaxBorrowable(
+	_ context.Context, asset string,
+) (fixedpoint.Value, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.queryCount[asset]++
+	if err := m.errs[asset]; err != nil {
+		return fixedpoint.Zero, err
+	}
+	return m.maxBorrowable[asset], nil
+}
+
+func (m *mockMarginBorrowRepayService) getQueryCount(asset string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.queryCount[asset]
+}
+
+func TestMarginInfoUpdater_GetMaxBorrowable(t *testing.T) {
+	svc := newMockMarginBorrowRepayService(map[string]fixedpoint.Value{
+		"BTC": fixedpoint.NewFromFloat(1.5),
+	})
+	updater := NewMarginInfoUpdater(svc)
+
+	t.Run("untracked asset is not found", func(t *testing.T) {
+		amount, ok := updater.GetMaxBorrowable("BTC")
+		assert.False(t, ok, "asset was never added")
+		assert.True(t, amount.IsZero())
+	})
+
+	t.Run("tracked but not yet refreshed reports zero", func(t *testing.T) {
+		updater.AddBorrowableAssets("BTC")
+
+		amount, ok := updater.GetMaxBorrowable("BTC")
+		assert.True(t, ok, "asset is tracked once added")
+		assert.True(t, amount.IsZero(), "amount defaults to zero before the first Update")
+	})
+
+	t.Run("reports the queried amount after Update", func(t *testing.T) {
+		updater.Update(context.Background(), 1)
+
+		amount, ok := updater.GetMaxBorrowable("BTC")
+		assert.True(t, ok)
+		assert.Equal(t, "1.5", amount.String())
+	})
+}
+
+func TestMarginInfoUpdater_Update(t *testing.T) {
+	t.Run("updates every asset and emits a callback per asset", func(t *testing.T) {
+		values := map[string]fixedpoint.Value{
+			"BTC": fixedpoint.NewFromFloat(1),
+			"ETH": fixedpoint.NewFromFloat(2),
+			"SOL": fixedpoint.NewFromFloat(3),
+		}
+		svc := newMockMarginBorrowRepayService(values)
+		updater := NewMarginInfoUpdater(svc)
+
+		emitted := map[string]fixedpoint.Value{}
+		updater.OnMaxBorrowable(func(asset string, amount fixedpoint.Value) {
+			emitted[asset] = amount
+		})
+
+		for asset := range values {
+			updater.AddBorrowableAssets(asset)
+		}
+
+		// batch size >= number of assets => all done in one pass
+		updater.Update(context.Background(), len(values))
+
+		for asset, want := range values {
+			amount, ok := updater.GetMaxBorrowable(asset)
+			assert.True(t, ok)
+			assert.Equal(t, want.String(), amount.String(), "GetMaxBorrowable(%s)", asset)
+			assert.Equal(t, want.String(), emitted[asset].String(), "emitted(%s)", asset)
+		}
+		assert.Len(t, emitted, len(values))
+	})
+
+	t.Run("more assets than batch size: all updated across cycles", func(t *testing.T) {
+		const (
+			assetCount = 5
+			batchSize  = 2
+		)
+
+		values := make(map[string]fixedpoint.Value, assetCount)
+		for i := 0; i < assetCount; i++ {
+			values[fmt.Sprintf("A%d", i)] = fixedpoint.NewFromFloat(float64(i + 1))
+		}
+
+		svc := newMockMarginBorrowRepayService(values)
+		updater := NewMarginInfoUpdater(svc)
+
+		emitCount := map[string]int{}
+		updater.OnMaxBorrowable(func(asset string, amount fixedpoint.Value) {
+			emitCount[asset]++
+		})
+
+		for asset := range values {
+			updater.AddBorrowableAssets(asset)
+		}
+
+		// A single Update only processes batchSize assets.
+		updater.Update(context.Background(), batchSize)
+		assert.Len(t, updater.doneAssets, batchSize, "only one batch processed per Update")
+
+		// ceil(5/2) = 3 Update calls are needed to cover every asset. Run the two
+		// remaining passes to complete the cycle.
+		updater.Update(context.Background(), batchSize)
+		updater.Update(context.Background(), batchSize)
+
+		// Every asset must have been refreshed exactly once with the correct value.
+		for asset, want := range values {
+			amount, ok := updater.GetMaxBorrowable(asset)
+			assert.True(t, ok, "GetMaxBorrowable(%s) found", asset)
+			assert.Equal(t, want.String(), amount.String(), "GetMaxBorrowable(%s)", asset)
+			assert.Equal(t, 1, svc.getQueryCount(asset), "queried once per cycle: %s", asset)
+			assert.Equal(t, 1, emitCount[asset], "emitted once per cycle: %s", asset)
+		}
+
+		// After the whole set is covered, the cycle resets so the next Update
+		// begins refreshing from scratch.
+		assert.Empty(t, updater.doneAssets, "doneAssets reset after a full cycle")
+		assert.False(t, updater.lastResetDoneTime.IsZero(), "reset time recorded")
+	})
+
+	t.Run("second cycle re-queries every asset", func(t *testing.T) {
+		values := map[string]fixedpoint.Value{
+			"BTC": fixedpoint.NewFromFloat(1),
+			"ETH": fixedpoint.NewFromFloat(2),
+			"SOL": fixedpoint.NewFromFloat(3),
+		}
+		svc := newMockMarginBorrowRepayService(values)
+		updater := NewMarginInfoUpdater(svc)
+
+		for asset := range values {
+			updater.AddBorrowableAssets(asset)
+		}
+
+		// first cycle
+		updater.Update(context.Background(), len(values))
+		assert.Empty(t, updater.doneAssets, "cycle completes and resets")
+
+		// second cycle: each asset should be queried again
+		updater.Update(context.Background(), len(values))
+		for asset := range values {
+			assert.Equal(t, 2, svc.getQueryCount(asset), "queried again in the next cycle: %s", asset)
+		}
+	})
+
+	t.Run("query error keeps the asset pending and blocks the reset", func(t *testing.T) {
+		values := map[string]fixedpoint.Value{
+			"BTC": fixedpoint.NewFromFloat(1),
+			"ETH": fixedpoint.NewFromFloat(2),
+		}
+		svc := newMockMarginBorrowRepayService(values)
+		svc.errs["ETH"] = fmt.Errorf("boom")
+		updater := NewMarginInfoUpdater(svc)
+
+		emitted := map[string]fixedpoint.Value{}
+		updater.OnMaxBorrowable(func(asset string, amount fixedpoint.Value) {
+			emitted[asset] = amount
+		})
+
+		updater.AddBorrowableAssets("BTC", "ETH")
+
+		// large batch so both are attempted in one pass
+		updater.Update(context.Background(), 10)
+
+		// BTC succeeded; ETH errored so it is neither recorded as done nor emitted.
+		btc, ok := updater.GetMaxBorrowable("BTC")
+		assert.True(t, ok)
+		assert.Equal(t, "1", btc.String())
+		assert.Contains(t, emitted, "BTC")
+		assert.NotContains(t, emitted, "ETH")
+
+		// ETH stays pending, so the cycle has not completed and does not reset.
+		_, done := updater.doneAssets["ETH"]
+		assert.False(t, done, "errored asset is not marked done")
+		assert.True(t, updater.lastResetDoneTime.IsZero(), "reset must not happen while an asset is pending")
+
+		// Once the error clears, a subsequent Update finishes the cycle.
+		svc.mu.Lock()
+		delete(svc.errs, "ETH")
+		svc.mu.Unlock()
+
+		updater.Update(context.Background(), 10)
+		eth, ok := updater.GetMaxBorrowable("ETH")
+		assert.True(t, ok)
+		assert.Equal(t, "2", eth.String())
+		assert.Equal(t, "2", emitted["ETH"].String())
+		assert.Empty(t, updater.doneAssets, "cycle resets after the retry succeeds")
+	})
+
+	t.Run("no assets is a no-op", func(t *testing.T) {
+		svc := newMockMarginBorrowRepayService(nil)
+		updater := NewMarginInfoUpdater(svc)
+
+		assert.NotPanics(t, func() {
+			updater.Update(context.Background(), 5)
+		})
+	})
+}

--- a/pkg/bbgo/session.go
+++ b/pkg/bbgo/session.go
@@ -31,7 +31,9 @@ import (
 
 const defaultMaxSessionTradeBufferSize = 3500
 
-const defaultMarginInfoUpdaterInterval = types.Duration(5 * time.Minute)
+const defaultMarginInfoUpdaterInterval = types.Duration(2 * time.Minute)
+const defaultMarginInfoUpdateBatchSize = 10
+const defaultMarginInfoUpdaterCooldown = types.Duration(10 * time.Minute)
 
 var KLinePreloadLimit int64 = 1000
 
@@ -141,7 +143,9 @@ type ExchangeSessionConfig struct {
 	SubAccount   string             `json:"subAccount,omitempty" yaml:"subAccount,omitempty"`
 
 	// Margin Assets Configs
-	MarginInfoUpdaterInterval types.Duration `json:"marginInfoUpdaterInterval" yaml:"marginInfoUpdaterInterval"`
+	MarginInfoUpdaterInterval  types.Duration `json:"marginInfoUpdaterInterval" yaml:"marginInfoUpdaterInterval"`
+	MarginInfoUpdaterBatchSize int            `json:"marginInfoUpdaterBatchSize" yaml:"marginInfoUpdaterBatchSize"`
+	MarginInfoUpdaterCooldown  types.Duration `json:"marginInfoUpdaterCooldown" yaml:"marginInfoUpdaterCooldown"`
 
 	MakerFeeRateConfig *fixedpoint.Value `json:"makerFeeRate,omitempty" yaml:"makerFeeRate"`
 	TakerFeeRateConfig *fixedpoint.Value `json:"takerFeeRate,omitempty" yaml:"takerFeeRate"`
@@ -677,6 +681,12 @@ func (session *ExchangeSession) Init(ctx context.Context, environ *Environment) 
 		if session.MarginInfoUpdaterInterval == 0 {
 			session.MarginInfoUpdaterInterval = defaultMarginInfoUpdaterInterval
 		}
+		if session.MarginInfoUpdaterBatchSize == 0 {
+			session.MarginInfoUpdaterBatchSize = defaultMarginInfoUpdateBatchSize
+		}
+		if session.MarginInfoUpdaterCooldown == 0 {
+			session.MarginInfoUpdaterCooldown = defaultMarginInfoUpdaterCooldown
+		}
 
 		if service, ok := session.Exchange.(types.MarginBorrowRepayService); ok {
 			marginUpdater := NewMarginInfoUpdater(service)
@@ -685,7 +695,12 @@ func (session *ExchangeSession) Init(ctx context.Context, environ *Environment) 
 			session.UserDataStream.OnStart(func() {
 				session.logger.Infof("starting margin info updater with update interval: %s", session.MarginInfoUpdaterInterval.Duration())
 
-				go session.marginInfoUpdater.Run(ctx, session.MarginInfoUpdaterInterval)
+				go session.marginInfoUpdater.Run(
+					ctx,
+					session.MarginInfoUpdaterInterval,
+					session.MarginInfoUpdaterBatchSize,
+					session.MarginInfoUpdaterCooldown.Duration(),
+				)
 			})
 		}
 	}

--- a/pkg/bbgo/testdata/strategy.yaml
+++ b/pkg/bbgo/testdata/strategy.yaml
@@ -4,10 +4,15 @@ sessions:
     exchange: max
     envVarPrefix: MAX
     marginInfoUpdaterInterval: 3m0s
+    marginInfoUpdaterBatchSize: 3
+    marginInfoUpdaterCooldown: 9m0s
   binance:
     exchange: binance
     envVarPrefix: BINANCE
     marginInfoUpdaterInterval: 5m0s
+    marginInfoUpdaterBatchSize: 5
+    marginInfoUpdaterCooldown: 15m0s
+
 
 exchangeStrategies:
 - on: ["binance"]

--- a/pkg/strategy/xmaker/borrowable.go
+++ b/pkg/strategy/xmaker/borrowable.go
@@ -1,0 +1,174 @@
+package xmaker
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
+
+	"github.com/c9s/bbgo/pkg/bbgo"
+	"github.com/c9s/bbgo/pkg/types"
+)
+
+// borrowEligibilityWarnLimiter rate-limits the warning emitted when a hedge
+// asset is not borrowable on the margin hedge exchange (borrowability is
+// near-static, so the warning does not need to fire on every quote cycle).
+var borrowEligibilityWarnLimiter = rate.NewLimiter(rate.Every(3*time.Minute), 1)
+
+type BorrowableAssetResult struct {
+	BaseBorrowable  bool
+	QuoteBorrowable bool
+}
+
+type AssetsBorrowablity map[string]bool
+
+func addBorrowableAssets(session *bbgo.ExchangeSession, market types.Market) {
+	updater := session.GetMarginInfoUpdater()
+	if updater == nil {
+		return
+	}
+	updater.AddBorrowableAssets(market.BaseCurrency, market.QuoteCurrency)
+}
+
+// getBorrowableAssetResult reads the cached borrowability result for the given hedge market
+func getBorrowableAssetResult(session *bbgo.ExchangeSession, market types.Market, logger logrus.FieldLogger) *BorrowableAssetResult {
+	updater := session.GetMarginInfoUpdater()
+	if updater == nil {
+		return nil
+	}
+	baseBorrowable, baseFound := updater.GetMaxBorrowable(market.BaseCurrency)
+	quoteBorrowable, quoteFound := updater.GetMaxBorrowable(market.QuoteCurrency)
+	if !baseFound || !quoteFound {
+		// return nil to disable the borrowablity check.
+		logger.Warnf("at least one of the assets is missing from the borrowable assets result on %s: %s", session.Name, market.Symbol)
+		return nil
+	}
+
+	return &BorrowableAssetResult{
+		BaseBorrowable:  baseBorrowable.Sign() > 0,
+		QuoteBorrowable: quoteBorrowable.Sign() > 0,
+	}
+}
+
+func (s *Strategy) simpleHedgeBorrowableCheck(oriDisableMakerBid, oriDisableMakerAsk bool) (bool, bool) {
+	// When hedging on a margin account, a maker bid hedge borrows the base
+	// currency and a maker ask hedge borrows the quote currency. If the hedge
+	// exchange currently disallows borrowing an asset, disable the affected maker
+	// side so we stop quoting a hedge we cannot cover.
+	disableMakerBid := oriDisableMakerBid
+	disableMakerAsk := oriDisableMakerAsk
+	if !s.hedgeSession.Margin || (disableMakerBid && disableMakerAsk) {
+		// both sides are already disabled, no need to check borrowable assets
+		return disableMakerBid, disableMakerAsk
+	}
+
+	if borrowable := getBorrowableAssetResult(s.hedgeSession, s.hedgeMarket, s.logger); borrowable != nil {
+		account := s.hedgeSession.Account
+		baseBalance, _ := account.Balance(s.hedgeMarket.BaseCurrency)
+		quoteBalance, _ := account.Balance(s.hedgeMarket.QuoteCurrency)
+		if !borrowable.BaseBorrowable && baseBalance.Available.IsZero() {
+			// base is not borrowable (ask) and we have 0 balance -> not able to hedge maker bid orders -> disable maker bid orders
+			s.logger.Warnf(
+				"unable to hedge maker bid orders on %s, base borrowable: %v, base balance: %s",
+				s.hedgeSession.ExchangeName, borrowable.BaseBorrowable, baseBalance.String(),
+			)
+			disableMakerBid = true
+		}
+		if !borrowable.QuoteBorrowable && quoteBalance.Available.IsZero() {
+			// quote is not borrowable (bid) and we have 0 balance -> not able to hedge maker ask orders -> disable maker ask orders
+			s.logger.Warnf(
+				"unable to hedge maker ask orders on %s, quote borrowable: %v, quote balance: %s",
+				s.hedgeSession.ExchangeName, borrowable.QuoteBorrowable, quoteBalance.String(),
+			)
+			disableMakerAsk = true
+		}
+
+		if borrowEligibilityWarnLimiter.Allow() {
+			if !borrowable.BaseBorrowable {
+				s.logger.Warnf(
+					"%s base currency %s is not borrowable on %s, disabling maker bid orders...",
+					s.Symbol, s.hedgeMarket.BaseCurrency, s.hedgeSession.ExchangeName,
+				)
+			}
+			if !borrowable.QuoteBorrowable {
+				s.logger.Warnf(
+					"%s quote currency %s is not borrowable on %s, disabling maker ask orders...",
+					s.Symbol, s.hedgeMarket.QuoteCurrency, s.hedgeSession.ExchangeName,
+				)
+			}
+		}
+	} else {
+		s.logger.Warnf(
+			"unable to get borrowable asset result on %s, no borrowable check performed",
+			s.hedgeSession.ExchangeName,
+		)
+	}
+	return disableMakerBid, disableMakerAsk
+}
+
+func (s *Strategy) splitHedgeBorrowableCheck(oriDisableMakerBid, oriDisableMakerAsk bool) (bool, bool) {
+	disableMakerBid := oriDisableMakerBid
+	disableMakerAsk := oriDisableMakerAsk
+	if disableMakerBid && disableMakerAsk {
+		// both sides are already disabled, no need to check borrowable assets
+		return disableMakerBid, disableMakerAsk
+	}
+
+	// split hedge is enabled, we need to check there is at least one hedge session is available to place the hedge orders
+	var availableAskSessions []string
+	var availableBidSessions []string
+	for _, hedgeMarket := range s.SplitHedge.hedgeMarketInstances {
+		if !hedgeMarket.session.Margin {
+			availableAskSessions = append(availableAskSessions, hedgeMarket.session.Name)
+			availableBidSessions = append(availableBidSessions, hedgeMarket.session.Name)
+			continue
+		}
+		if borrowable := getBorrowableAssetResult(hedgeMarket.session, hedgeMarket.market, s.logger); borrowable != nil {
+			account := hedgeMarket.session.Account
+			baseBalance, _ := account.Balance(hedgeMarket.market.BaseCurrency)
+			quoteBalance, _ := account.Balance(hedgeMarket.market.QuoteCurrency)
+			if borrowable.BaseBorrowable || baseBalance.Available.Sign() > 0 {
+				// base borrowable on hedge market or we have available base balance (ask) -> we can hedge bid orders on maker market
+				availableAskSessions = append(availableAskSessions, hedgeMarket.session.Name)
+			} else {
+				s.logger.Warnf(
+					"unable to hedge maker bid orders on %s, base borrowable: %v, base balance: %s",
+					hedgeMarket.session.Name, borrowable.BaseBorrowable, baseBalance.String(),
+				)
+			}
+			if borrowable.QuoteBorrowable || quoteBalance.Available.Sign() > 0 {
+				// quote borrowable on hedge market or we have available quote balance (bid) -> we can hedge ask orders on maker market
+				availableBidSessions = append(availableBidSessions, hedgeMarket.session.Name)
+			} else {
+				s.logger.Warnf(
+					"unable to hedge maker ask orders on %s, quote borrowable: %v, quote balance: %s",
+					hedgeMarket.session.Name, borrowable.QuoteBorrowable, quoteBalance.String(),
+				)
+			}
+		} else {
+			// we cannot get the borrowable asset result, we assume the hedge market is available for both ask and bid
+			s.logger.Warnf("unable to get borrowable asset result on %s, assume both assets are borrowable", hedgeMarket.session.Name)
+			availableAskSessions = append(availableAskSessions, hedgeMarket.session.Name)
+			availableBidSessions = append(availableBidSessions, hedgeMarket.session.Name)
+		}
+	}
+	if len(availableAskSessions) == 0 {
+		// no hedge session is available to place the ask orders -> can not hedge maker bid orders -> disable maker bid
+		disableMakerBid = true
+	}
+	if len(availableBidSessions) == 0 {
+		// no hedge session is available to place the bid orders -> can not hedge maker ask orders -> disable maker ask
+		disableMakerAsk = true
+	}
+
+	if borrowEligibilityWarnLimiter.Allow() {
+		if len(availableAskSessions) == 0 {
+			s.logger.Warn("split hedge has no available hedge markets to place maker ask orders, disable maker ask quoting")
+		}
+		if len(availableBidSessions) == 0 {
+			s.logger.Warn("split hedge has no available hedge markets to place maker bid orders, disable maker bid quoting")
+		}
+	}
+
+	return disableMakerBid, disableMakerAsk
+}

--- a/pkg/strategy/xmaker/borrowable_test.go
+++ b/pkg/strategy/xmaker/borrowable_test.go
@@ -1,0 +1,148 @@
+package xmaker
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/bbgo/pkg/bbgo"
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	. "github.com/c9s/bbgo/pkg/testing/testhelper"
+)
+
+// mockMarginBorrowRepayService is a stub implementation of
+// types.MarginBorrowRepayService that returns preconfigured max borrowable
+// amounts, letting us populate a MarginInfoUpdater without hitting an exchange.
+type mockMarginBorrowRepayService struct {
+	maxBorrowable map[string]fixedpoint.Value
+}
+
+func (m *mockMarginBorrowRepayService) RepayMarginAsset(
+	_ context.Context, _ string, _ fixedpoint.Value,
+) error {
+	return nil
+}
+
+func (m *mockMarginBorrowRepayService) BorrowMarginAsset(
+	_ context.Context, _ string, _ fixedpoint.Value,
+) error {
+	return nil
+}
+
+func (m *mockMarginBorrowRepayService) QueryMarginAssetMaxBorrowable(
+	_ context.Context, asset string,
+) (fixedpoint.Value, error) {
+	return m.maxBorrowable[asset], nil
+}
+
+// setMarginInfoUpdater assigns the unexported marginInfoUpdater field on the
+// session via unsafe, since bbgo exposes only a getter.
+func setMarginInfoUpdater(session *bbgo.ExchangeSession, updater *bbgo.MarginInfoUpdater) {
+	field := reflect.ValueOf(session).Elem().FieldByName("marginInfoUpdater")
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(updater))
+}
+
+// newBorrowableUpdater builds a MarginInfoUpdater whose GetMaxBorrowable reports
+// the given per-asset amounts (assets present in the map are "found").
+func newBorrowableUpdater(values map[string]fixedpoint.Value) *bbgo.MarginInfoUpdater {
+	svc := &mockMarginBorrowRepayService{maxBorrowable: values}
+	updater := bbgo.NewMarginInfoUpdater(svc)
+
+	assets := make([]string, 0, len(values))
+	for asset := range values {
+		assets = append(assets, asset)
+	}
+	updater.AddBorrowableAssets(assets...)
+	updater.Update(context.Background(), len(assets))
+	return updater
+}
+
+func Test_getBorrowableAssetResult(t *testing.T) {
+	market := Market("BTCUSDT") // base: BTC, quote: USDT
+	logger := logrus.New()
+
+	t.Run("nil updater disables the check", func(t *testing.T) {
+		// a non-margin session has no updater -> returns nil
+		session := &bbgo.ExchangeSession{}
+		assert.Nil(t, getBorrowableAssetResult(session, market, logger))
+	})
+
+	t.Run("missing asset disables the check", func(t *testing.T) {
+		// only the base currency is tracked, the quote lookup is "not found"
+		updater := newBorrowableUpdater(map[string]fixedpoint.Value{
+			"BTC": Number(1),
+		})
+		session := &bbgo.ExchangeSession{}
+		setMarginInfoUpdater(session, updater)
+
+		assert.Nil(t, getBorrowableAssetResult(session, market, logger))
+	})
+
+	t.Run("both assets missing disables the check", func(t *testing.T) {
+		updater := newBorrowableUpdater(map[string]fixedpoint.Value{
+			"ETH": Number(1),
+		})
+		session := &bbgo.ExchangeSession{}
+		setMarginInfoUpdater(session, updater)
+
+		assert.Nil(t, getBorrowableAssetResult(session, market, logger))
+	})
+
+	testCases := []struct {
+		name            string
+		base            fixedpoint.Value
+		quote           fixedpoint.Value
+		wantBaseBorrow  bool
+		wantQuoteBorrow bool
+	}{
+		{
+			name:            "both borrowable",
+			base:            Number(1.5),
+			quote:           Number(1000),
+			wantBaseBorrow:  true,
+			wantQuoteBorrow: true,
+		},
+		{
+			name:            "only base borrowable",
+			base:            Number(1.5),
+			quote:           fixedpoint.Zero,
+			wantBaseBorrow:  true,
+			wantQuoteBorrow: false,
+		},
+		{
+			name:            "only quote borrowable",
+			base:            fixedpoint.Zero,
+			quote:           Number(1000),
+			wantBaseBorrow:  false,
+			wantQuoteBorrow: true,
+		},
+		{
+			name:            "neither borrowable",
+			base:            fixedpoint.Zero,
+			quote:           fixedpoint.Zero,
+			wantBaseBorrow:  false,
+			wantQuoteBorrow: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			updater := newBorrowableUpdater(map[string]fixedpoint.Value{
+				market.BaseCurrency:  tc.base,
+				market.QuoteCurrency: tc.quote,
+			})
+			session := &bbgo.ExchangeSession{}
+			setMarginInfoUpdater(session, updater)
+
+			result := getBorrowableAssetResult(session, market, logger)
+			if assert.NotNil(t, result) {
+				assert.Equal(t, tc.wantBaseBorrow, result.BaseBorrowable, "base borrowable")
+				assert.Equal(t, tc.wantQuoteBorrow, result.QuoteBorrowable, "quote borrowable")
+			}
+		})
+	}
+}

--- a/pkg/strategy/xmaker/strategy.go
+++ b/pkg/strategy/xmaker/strategy.go
@@ -1439,6 +1439,8 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 	if s.SplitHedge != nil && s.SplitHedge.Enabled {
 		s.logger.Infof("%s splitHedge source price ask/bid = %s/%s (%s)", s.Symbol, bestAskPrice.String(), bestBidPrice.String(), calculateSpread(bestAskPrice, bestBidPrice).Percentage())
 
+		disableMakerBid, disableMakerAsk = s.splitHedgeBorrowableCheck(disableMakerBid, disableMakerAsk)
+
 		if !disableMakerBid {
 			for i := 0; i < s.NumLayers; i++ {
 				bidPrice := bidPriceSpread(i, bestBidPrice)
@@ -1566,7 +1568,12 @@ func (s *Strategy) updateQuote(ctx context.Context) error {
 
 			}
 		}
+	} else if s.SyntheticHedge != nil && s.SyntheticHedge.Enabled {
+		// TODO: borrowable check for synthetic hedge
+		s.logger.Debugf("no borrowable check for synthetic hedge...")
 	} else {
+		disableMakerBid, disableMakerAsk = s.simpleHedgeBorrowableCheck(disableMakerBid, disableMakerAsk)
+
 		// default maker order generation
 		s.logger.Infof("%s source book ticker: ask/bid = %s/%s (%s)", s.Symbol, bestAskPrice.String(), bestBidPrice.String(), calculateSpread(bestAskPrice, bestBidPrice).Percentage())
 		if !disableMakerBid {
@@ -3189,6 +3196,36 @@ func (s *Strategy) CrossRun(
 	} else {
 		s.orderStore.BindStream(s.hedgeSession.UserDataStream)
 		s.tradeCollector.BindStream(s.hedgeSession.UserDataStream)
+	}
+
+	// setup borrowable asset workers
+	var borrowableMarkets []*HedgeMarket
+	if s.SplitHedge != nil && s.SplitHedge.Enabled {
+		for _, hedgeMarket := range s.SplitHedge.hedgeMarketInstances {
+			if !hedgeMarket.session.Margin {
+				continue
+			}
+			borrowableMarkets = append(borrowableMarkets, hedgeMarket)
+		}
+	} else if s.SyntheticHedge != nil && s.SyntheticHedge.Enabled {
+		for _, hedgeMarket := range []*HedgeMarket{s.SyntheticHedge.sourceMarket, s.SyntheticHedge.fiatMarket} {
+			if !hedgeMarket.session.Margin {
+				continue
+			}
+			borrowableMarkets = append(borrowableMarkets, hedgeMarket)
+		}
+	} else if s.hedgeSession.Margin {
+		addBorrowableAssets(
+			s.hedgeSession,
+			s.hedgeMarket,
+		)
+	}
+	for _, hedgeMarket := range borrowableMarkets {
+		market := hedgeMarket.market
+		addBorrowableAssets(
+			hedgeMarket.session,
+			market,
+		)
 	}
 
 	s.sourceUserDataConnectivity = s.hedgeSession.UserDataConnectivity


### PR DESCRIPTION
- bbgo margin info updater: batch update
    - update the assets margin info in batches
    - in order to control the API weight usage
- xmaker: add borrowable checks before placing quoting orders
    - add borrowable checks for
        - direct hedge
        - split hedge
    - support for synthetic hedge is future work