### PR TITLE
FEATURE: [bbgo] trade-driven mode for margin info updater

### DIFF
--- a/pkg/bbgo/config_test.go
+++ b/pkg/bbgo/config_test.go
@@ -80,16 +80,20 @@ func TestLoadConfig(t *testing.T) {
 							"envVarPrefix":              "MAX",
 							"marginInfoUpdaterInterval": "3m0s",
 							// json.Unmarshal decodes numbers into float64, so we need to use float64 here to match the unmarshaled value.
-							"marginInfoUpdaterBatchSize": float64(3),
-							"marginInfoUpdaterCooldown":  "9m0s",
+							"marginInfoUpdaterBatchSize":         float64(3),
+							"marginInfoUpdaterCooldown":          "9m0s",
+							"marginInfoUpdaterTradesBufferCount": float64(30),
+							"marginInfoUpdaterBindSession":       false,
 						},
 						"binance": map[string]interface{}{
 							"exchange":                  "binance",
 							"envVarPrefix":              "BINANCE",
 							"marginInfoUpdaterInterval": "5m0s",
 							// json.Unmarshal decodes numbers into float64, so we need to use float64 here to match the unmarshaled value.
-							"marginInfoUpdaterBatchSize": float64(5),
-							"marginInfoUpdaterCooldown":  "15m0s",
+							"marginInfoUpdaterBatchSize":         float64(5),
+							"marginInfoUpdaterCooldown":          "15m0s",
+							"marginInfoUpdaterTradesBufferCount": float64(30),
+							"marginInfoUpdaterBindSession":       false,
 						},
 					},
 					"build": map[string]interface{}{

--- a/pkg/bbgo/margin_info_updater.go
+++ b/pkg/bbgo/margin_info_updater.go
@@ -2,6 +2,7 @@ package bbgo
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -14,14 +15,43 @@ import (
 
 type MaxBorrowableCallback func(asset string, amount fixedpoint.Value)
 
+type MarginInfoUpdaterConfig struct {
+	Interval          types.Duration `json:"marginInfoUpdaterInterval" yaml:"marginInfoUpdaterInterval"`
+	BatchSize         int            `json:"marginInfoUpdaterBatchSize" yaml:"marginInfoUpdaterBatchSize"`
+	CoolDown          types.Duration `json:"marginInfoUpdaterCooldown" yaml:"marginInfoUpdaterCooldown"`
+	TradesBufferCount int            `json:"marginInfoUpdaterTradesBufferCount" yaml:"marginInfoUpdaterTradesBufferCount"`
+	BindSession       bool           `json:"marginInfoUpdaterBindSession" yaml:"marginInfoUpdaterBindSession"`
+}
+
+func (c *MarginInfoUpdaterConfig) Defaults() {
+	if c.Interval == 0 {
+		c.Interval = defaultMarginInfoUpdaterInterval
+	}
+	if c.BatchSize == 0 {
+		c.BatchSize = defaultMarginInfoUpdateBatchSize
+	}
+	if c.CoolDown == 0 {
+		c.CoolDown = defaultMarginInfoUpdaterCooldown
+	}
+	if c.TradesBufferCount == 0 {
+		c.TradesBufferCount = 30
+	}
+}
+
 //go:generate callbackgen -type MarginInfoUpdater
 type MarginInfoUpdater struct {
 	service types.MarginBorrowRepayService
+	config  MarginInfoUpdaterConfig
 
 	assets map[string]fixedpoint.Value
 
 	doneAssets        map[string]struct{}
 	lastResetDoneTime time.Time
+
+	boundSession    *ExchangeSession
+	firstTradeTimes map[string]time.Time
+	tradeCounts     map[string]int
+	dirtyAssets     map[string]struct{}
 
 	maxBorrowableCallbacks []MaxBorrowableCallback
 
@@ -30,35 +60,32 @@ type MarginInfoUpdater struct {
 
 func NewMarginInfoUpdater(
 	service types.MarginBorrowRepayService,
+	config MarginInfoUpdaterConfig,
 ) *MarginInfoUpdater {
 	return &MarginInfoUpdater{
 		assets:     make(map[string]fixedpoint.Value),
 		doneAssets: make(map[string]struct{}),
 		service:    service,
+		config:     config,
 	}
 }
 
 // Run starts the update workers for the given interval.
-func (m *MarginInfoUpdater) Run(
-	ctx context.Context,
-	interval types.Duration,
-	batchSize int,
-	coolDown time.Duration,
-) {
-	ticker := time.NewTicker(timejitter.Milliseconds(interval.Duration(), 500))
+func (m *MarginInfoUpdater) Run(ctx context.Context) {
+	ticker := time.NewTicker(timejitter.Milliseconds(m.config.Interval.Duration(), 500))
 	defer ticker.Stop()
 
-	m.Update(ctx, batchSize)
+	m.Update(ctx)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case now := <-ticker.C:
-			if !m.lastResetDoneTime.IsZero() && now.Sub(m.lastResetDoneTime) <= coolDown {
+			if !m.lastResetDoneTime.IsZero() && now.Sub(m.lastResetDoneTime) <= m.config.CoolDown.Duration() {
 				// still in cooldown period, skip this update cycle
 				continue
 			}
-			m.Update(ctx, batchSize)
+			m.Update(ctx)
 		}
 	}
 }
@@ -84,20 +111,16 @@ func (m *MarginInfoUpdater) GetMaxBorrowable(asset string) (fixedpoint.Value, bo
 }
 
 // Update queries the max borrowable amount for each asset and emit update events.
-func (m *MarginInfoUpdater) Update(
-	ctx context.Context,
-	batchSize int,
-) {
+func (m *MarginInfoUpdater) Update(ctx context.Context) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	pending := make([]string, 0, len(m.assets))
-	for asset := range m.assets {
-		if _, done := m.doneAssets[asset]; !done {
-			pending = append(pending, asset)
-		}
+	pending := m.getPendingAssets()
+	if len(pending) == 0 {
+		return
 	}
 
+	batchSize := m.config.BatchSize
 	if batchSize > len(pending) {
 		batchSize = len(pending)
 	}
@@ -115,6 +138,9 @@ func (m *MarginInfoUpdater) Update(
 
 		m.assets[asset] = maxBorrowable
 		m.doneAssets[asset] = struct{}{}
+		if m.dirtyAssets != nil {
+			delete(m.dirtyAssets, asset)
+		}
 
 		m.EmitMaxBorrowable(asset, maxBorrowable)
 	}
@@ -124,4 +150,90 @@ func (m *MarginInfoUpdater) Update(
 		m.doneAssets = make(map[string]struct{})
 		m.lastResetDoneTime = time.Now()
 	}
+}
+
+func (m *MarginInfoUpdater) Bind(session *ExchangeSession) error {
+	if session.PublicOnly {
+		return fmt.Errorf("cannot bind margin info updater to public only session: %s", session.Name)
+	}
+	if m.boundSession != nil {
+		return fmt.Errorf("margin info updater is already bound to session: %s", m.boundSession.Name)
+	}
+	// initialize the required fields for tracking trade updates and dirty assets
+	m.boundSession = session
+	m.firstTradeTimes = make(map[string]time.Time)
+	m.tradeCounts = make(map[string]int)
+	m.dirtyAssets = make(map[string]struct{})
+
+	// mark all assets as dirty so that they will be updated on the first run of the updater
+	for asset := range m.assets {
+		m.dirtyAssets[asset] = struct{}{}
+	}
+
+	session.UserDataStream.OnTradeUpdate(func(trade types.Trade) {
+		market, found := session.Market(trade.Symbol)
+		if !found {
+			return
+		}
+		_, baseFound := m.assets[market.BaseCurrency]
+		_, quoteFound := m.assets[market.QuoteCurrency]
+		if !baseFound && !quoteFound {
+			return
+		}
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		// first trade for this symbol
+		if _, found := m.firstTradeTimes[trade.Symbol]; !found {
+			m.firstTradeTimes[trade.Symbol] = trade.Time.Time()
+			m.tradeCounts[trade.Symbol] = 1
+			return
+		}
+
+		m.tradeCounts[trade.Symbol]++
+		numTrades := m.tradeCounts[trade.Symbol]
+		firstTradeTime := m.firstTradeTimes[trade.Symbol]
+		shouldMarkDirty := numTrades >= m.config.TradesBufferCount || trade.Time.Time().Sub(firstTradeTime) >= m.config.CoolDown.Duration()
+		if shouldMarkDirty {
+			if baseFound {
+				m.dirtyAssets[market.BaseCurrency] = struct{}{}
+			}
+			if quoteFound {
+				m.dirtyAssets[market.QuoteCurrency] = struct{}{}
+			}
+			m.firstTradeTimes[trade.Symbol] = trade.Time.Time()
+			m.tradeCounts[trade.Symbol] = 1
+		}
+	})
+
+	return nil
+}
+
+func (m *MarginInfoUpdater) getPendingAssets() []string {
+	if m.boundSession != nil {
+		return m.getPendingAssetsBoundSession()
+	}
+	return m.getPendingAssetsDefault()
+}
+
+func (m *MarginInfoUpdater) getPendingAssetsBoundSession() []string {
+	pending := make([]string, 0, len(m.assets))
+	for asset := range m.assets {
+		_, done := m.doneAssets[asset]
+		_, dirty := m.dirtyAssets[asset]
+		if !done && dirty {
+			pending = append(pending, asset)
+		}
+	}
+	return pending
+}
+
+func (m *MarginInfoUpdater) getPendingAssetsDefault() []string {
+	pending := make([]string, 0, len(m.assets))
+	for asset := range m.assets {
+		if _, done := m.doneAssets[asset]; !done {
+			pending = append(pending, asset)
+		}
+	}
+	return pending
 }

--- a/pkg/bbgo/margin_info_updater_test.go
+++ b/pkg/bbgo/margin_info_updater_test.go
@@ -65,7 +65,11 @@ func TestMarginInfoUpdater_GetMaxBorrowable(t *testing.T) {
 	svc := newMockMarginBorrowRepayService(map[string]fixedpoint.Value{
 		"BTC": fixedpoint.NewFromFloat(1.5),
 	})
-	updater := NewMarginInfoUpdater(svc)
+	config := MarginInfoUpdaterConfig{
+		BatchSize: 1,
+	}
+	config.Defaults()
+	updater := NewMarginInfoUpdater(svc, config)
 
 	t.Run("untracked asset is not found", func(t *testing.T) {
 		amount, ok := updater.GetMaxBorrowable("BTC")
@@ -82,7 +86,7 @@ func TestMarginInfoUpdater_GetMaxBorrowable(t *testing.T) {
 	})
 
 	t.Run("reports the queried amount after Update", func(t *testing.T) {
-		updater.Update(context.Background(), 1)
+		updater.Update(context.Background())
 
 		amount, ok := updater.GetMaxBorrowable("BTC")
 		assert.True(t, ok)
@@ -97,8 +101,12 @@ func TestMarginInfoUpdater_Update(t *testing.T) {
 			"ETH": fixedpoint.NewFromFloat(2),
 			"SOL": fixedpoint.NewFromFloat(3),
 		}
+		config := MarginInfoUpdaterConfig{
+			BatchSize: len(values),
+		}
+		config.Defaults()
 		svc := newMockMarginBorrowRepayService(values)
-		updater := NewMarginInfoUpdater(svc)
+		updater := NewMarginInfoUpdater(svc, config)
 
 		emitted := map[string]fixedpoint.Value{}
 		updater.OnMaxBorrowable(func(asset string, amount fixedpoint.Value) {
@@ -110,7 +118,7 @@ func TestMarginInfoUpdater_Update(t *testing.T) {
 		}
 
 		// batch size >= number of assets => all done in one pass
-		updater.Update(context.Background(), len(values))
+		updater.Update(context.Background())
 
 		for asset, want := range values {
 			amount, ok := updater.GetMaxBorrowable(asset)
@@ -133,7 +141,11 @@ func TestMarginInfoUpdater_Update(t *testing.T) {
 		}
 
 		svc := newMockMarginBorrowRepayService(values)
-		updater := NewMarginInfoUpdater(svc)
+		config := MarginInfoUpdaterConfig{
+			BatchSize: batchSize,
+		}
+		config.Defaults()
+		updater := NewMarginInfoUpdater(svc, config)
 
 		emitCount := map[string]int{}
 		updater.OnMaxBorrowable(func(asset string, amount fixedpoint.Value) {
@@ -145,13 +157,13 @@ func TestMarginInfoUpdater_Update(t *testing.T) {
 		}
 
 		// A single Update only processes batchSize assets.
-		updater.Update(context.Background(), batchSize)
+		updater.Update(context.Background())
 		assert.Len(t, updater.doneAssets, batchSize, "only one batch processed per Update")
 
 		// ceil(5/2) = 3 Update calls are needed to cover every asset. Run the two
 		// remaining passes to complete the cycle.
-		updater.Update(context.Background(), batchSize)
-		updater.Update(context.Background(), batchSize)
+		updater.Update(context.Background())
+		updater.Update(context.Background())
 
 		// Every asset must have been refreshed exactly once with the correct value.
 		for asset, want := range values {
@@ -175,18 +187,22 @@ func TestMarginInfoUpdater_Update(t *testing.T) {
 			"SOL": fixedpoint.NewFromFloat(3),
 		}
 		svc := newMockMarginBorrowRepayService(values)
-		updater := NewMarginInfoUpdater(svc)
+		config := MarginInfoUpdaterConfig{
+			BatchSize: len(values),
+		}
+		config.Defaults()
+		updater := NewMarginInfoUpdater(svc, config)
 
 		for asset := range values {
 			updater.AddBorrowableAssets(asset)
 		}
 
 		// first cycle
-		updater.Update(context.Background(), len(values))
+		updater.Update(context.Background())
 		assert.Empty(t, updater.doneAssets, "cycle completes and resets")
 
 		// second cycle: each asset should be queried again
-		updater.Update(context.Background(), len(values))
+		updater.Update(context.Background())
 		for asset := range values {
 			assert.Equal(t, 2, svc.getQueryCount(asset), "queried again in the next cycle: %s", asset)
 		}
@@ -199,7 +215,11 @@ func TestMarginInfoUpdater_Update(t *testing.T) {
 		}
 		svc := newMockMarginBorrowRepayService(values)
 		svc.errs["ETH"] = fmt.Errorf("boom")
-		updater := NewMarginInfoUpdater(svc)
+		config := MarginInfoUpdaterConfig{
+			BatchSize: 10,
+		}
+		config.Defaults()
+		updater := NewMarginInfoUpdater(svc, config)
 
 		emitted := map[string]fixedpoint.Value{}
 		updater.OnMaxBorrowable(func(asset string, amount fixedpoint.Value) {
@@ -209,7 +229,7 @@ func TestMarginInfoUpdater_Update(t *testing.T) {
 		updater.AddBorrowableAssets("BTC", "ETH")
 
 		// large batch so both are attempted in one pass
-		updater.Update(context.Background(), 10)
+		updater.Update(context.Background())
 
 		// BTC succeeded; ETH errored so it is neither recorded as done nor emitted.
 		btc, ok := updater.GetMaxBorrowable("BTC")
@@ -228,7 +248,7 @@ func TestMarginInfoUpdater_Update(t *testing.T) {
 		delete(svc.errs, "ETH")
 		svc.mu.Unlock()
 
-		updater.Update(context.Background(), 10)
+		updater.Update(context.Background())
 		eth, ok := updater.GetMaxBorrowable("ETH")
 		assert.True(t, ok)
 		assert.Equal(t, "2", eth.String())
@@ -238,10 +258,13 @@ func TestMarginInfoUpdater_Update(t *testing.T) {
 
 	t.Run("no assets is a no-op", func(t *testing.T) {
 		svc := newMockMarginBorrowRepayService(nil)
-		updater := NewMarginInfoUpdater(svc)
+		config := MarginInfoUpdaterConfig{
+			BatchSize: 5,
+		}
+		updater := NewMarginInfoUpdater(svc, config)
 
 		assert.NotPanics(t, func() {
-			updater.Update(context.Background(), 5)
+			updater.Update(context.Background())
 		})
 	})
 }

--- a/pkg/bbgo/order_executor_general.go
+++ b/pkg/bbgo/order_executor_general.go
@@ -107,18 +107,20 @@ func NewGeneralOrderExecutor(
 	if executor.position != nil && session.Margin {
 		market := executor.position.Market
 		marginInfoUpdater := session.GetMarginInfoUpdater()
-		marginInfoUpdater.AddBorrowableAssets(market.BaseCurrency, market.QuoteCurrency)
-		marginInfoUpdater.OnMaxBorrowable(func(asset string, amount fixedpoint.Value) {
-			switch asset {
-			case market.BaseCurrency:
-				log.Infof("updating margin base asset %s max borrowable amount: %f", asset, amount.Float64())
-				executor.marginBaseMaxBorrowable = amount
-			case market.QuoteCurrency:
-				log.Infof("updating margin quote asset %s max borrowable amount: %f", asset, amount.Float64())
-				executor.marginQuoteMaxBorrowable = amount
-			default:
-			}
-		})
+		if marginInfoUpdater != nil {
+			marginInfoUpdater.AddBorrowableAssets(market.BaseCurrency, market.QuoteCurrency)
+			marginInfoUpdater.OnMaxBorrowable(func(asset string, amount fixedpoint.Value) {
+				switch asset {
+				case market.BaseCurrency:
+					log.Infof("updating margin base asset %s max borrowable amount: %f", asset, amount.Float64())
+					executor.marginBaseMaxBorrowable = amount
+				case market.QuoteCurrency:
+					log.Infof("updating margin quote asset %s max borrowable amount: %f", asset, amount.Float64())
+					executor.marginQuoteMaxBorrowable = amount
+				default:
+				}
+			})
+		}
 	}
 
 	return executor

--- a/pkg/bbgo/session.go
+++ b/pkg/bbgo/session.go
@@ -143,9 +143,8 @@ type ExchangeSessionConfig struct {
 	SubAccount   string             `json:"subAccount,omitempty" yaml:"subAccount,omitempty"`
 
 	// Margin Assets Configs
-	MarginInfoUpdaterInterval  types.Duration `json:"marginInfoUpdaterInterval" yaml:"marginInfoUpdaterInterval"`
-	MarginInfoUpdaterBatchSize int            `json:"marginInfoUpdaterBatchSize" yaml:"marginInfoUpdaterBatchSize"`
-	MarginInfoUpdaterCooldown  types.Duration `json:"marginInfoUpdaterCooldown" yaml:"marginInfoUpdaterCooldown"`
+	// we embed the config struct here for backward compatibility
+	MarginInfoUpdaterConfig `yaml:",inline"`
 
 	MakerFeeRateConfig *fixedpoint.Value `json:"makerFeeRate,omitempty" yaml:"makerFeeRate"`
 	TakerFeeRateConfig *fixedpoint.Value `json:"takerFeeRate,omitempty" yaml:"takerFeeRate"`
@@ -678,29 +677,21 @@ func (session *ExchangeSession) Init(ctx context.Context, environ *Environment) 
 
 	// session-wide max borrowable updating worker
 	if !session.PublicOnly && session.Margin {
-		if session.MarginInfoUpdaterInterval == 0 {
-			session.MarginInfoUpdaterInterval = defaultMarginInfoUpdaterInterval
-		}
-		if session.MarginInfoUpdaterBatchSize == 0 {
-			session.MarginInfoUpdaterBatchSize = defaultMarginInfoUpdateBatchSize
-		}
-		if session.MarginInfoUpdaterCooldown == 0 {
-			session.MarginInfoUpdaterCooldown = defaultMarginInfoUpdaterCooldown
-		}
+		session.MarginInfoUpdaterConfig.Defaults()
 
 		if service, ok := session.Exchange.(types.MarginBorrowRepayService); ok {
-			marginUpdater := NewMarginInfoUpdater(service)
+			marginUpdater := NewMarginInfoUpdater(service, session.MarginInfoUpdaterConfig)
+			if session.MarginInfoUpdaterConfig.BindSession {
+				if err := marginUpdater.Bind(session); err != nil {
+					return fmt.Errorf("failed to bind margin info updater: %w", err)
+				}
+			}
 			session.marginInfoUpdater = marginUpdater
 
 			session.UserDataStream.OnStart(func() {
-				session.logger.Infof("starting margin info updater with update interval: %s", session.MarginInfoUpdaterInterval.Duration())
+				session.logger.Infof("starting margin info updater with config: %+v", session.MarginInfoUpdaterConfig)
 
-				go session.marginInfoUpdater.Run(
-					ctx,
-					session.MarginInfoUpdaterInterval,
-					session.MarginInfoUpdaterBatchSize,
-					session.MarginInfoUpdaterCooldown.Duration(),
-				)
+				go session.marginInfoUpdater.Run(ctx)
 			})
 		}
 	}

--- a/pkg/bbgo/testdata/strategy.yaml
+++ b/pkg/bbgo/testdata/strategy.yaml
@@ -6,12 +6,16 @@ sessions:
     marginInfoUpdaterInterval: 3m0s
     marginInfoUpdaterBatchSize: 3
     marginInfoUpdaterCooldown: 9m0s
+    marginInfoUpdaterTradesBufferCount: 30
+    marginInfoUpdaterBindSession: false
   binance:
     exchange: binance
     envVarPrefix: BINANCE
     marginInfoUpdaterInterval: 5m0s
     marginInfoUpdaterBatchSize: 5
     marginInfoUpdaterCooldown: 15m0s
+    marginInfoUpdaterTradesBufferCount: 30
+    marginInfoUpdaterBindSession: false
 
 
 exchangeStrategies:

--- a/pkg/strategy/xmaker/borrowable_test.go
+++ b/pkg/strategy/xmaker/borrowable_test.go
@@ -50,14 +50,17 @@ func setMarginInfoUpdater(session *bbgo.ExchangeSession, updater *bbgo.MarginInf
 // the given per-asset amounts (assets present in the map are "found").
 func newBorrowableUpdater(values map[string]fixedpoint.Value) *bbgo.MarginInfoUpdater {
 	svc := &mockMarginBorrowRepayService{maxBorrowable: values}
-	updater := bbgo.NewMarginInfoUpdater(svc)
+	config := bbgo.MarginInfoUpdaterConfig{
+		BatchSize: len(values),
+	}
+	updater := bbgo.NewMarginInfoUpdater(svc, config)
 
 	assets := make([]string, 0, len(values))
 	for asset := range values {
 		assets = append(assets, asset)
 	}
 	updater.AddBorrowableAssets(assets...)
-	updater.Update(context.Background(), len(assets))
+	updater.Update(context.Background())
 	return updater
 }
 


### PR DESCRIPTION
## Summary

Refactors `MarginInfoUpdater` to use a unified configuration struct (`MarginInfoUpdaterConfig`) and introduces optional session binding (`BindSession`) with trade-driven dirty-asset tracking to refresh margin borrow limits on demand. Also adds nil-safety checks in `GeneralOrderExecutor`.

## Key Changes

### Margin Info Updater & Session Binding
- **Configuration Struct**: Introduced `MarginInfoUpdaterConfig` (with a `Defaults()` helper) consolidating `Interval`, `BatchSize`, `CoolDown`, `TradesBufferCount` (default: 30), and `BindSession` (default: false).
- **API Simplification**: Updated `NewMarginInfoUpdater` to accept `MarginInfoUpdaterConfig`. Simplified `Run(ctx)` and `Update(ctx)` signatures to use values from the updater's internal configuration.
- **Trade-Driven Dirty Tracking (`Bind`)**: Added `MarginInfoUpdater.Bind(session *ExchangeSession)`:
  - Listens to `session.UserDataStream.OnTradeUpdate`.
  - Tracks trade count and elapsed time per symbol.
  - Marks tracked base/quote assets as dirty when `TradesBufferCount` is reached or when elapsed time since the first trade exceeds `CoolDown`.
  - When bound to a session, `Update()` prioritizes assets that are marked dirty and not yet updated in the current cycle (`getPendingAssetsBoundSession`).
  - Clears assets from the dirty set once refreshed.

### Session Integration
- Embedded `MarginInfoUpdaterConfig` into `ExchangeSessionConfig` (`yaml:",inline"`).
- In `ExchangeSession.Init`, initialized config defaults and automatically binds the updater to the session if `BindSession` is enabled.
- Simplified the goroutine invocation to `session.marginInfoUpdater.Run(ctx)`.

### Safety & Bug Fixes
- Added a nil check on `session.GetMarginInfoUpdater()` in `NewGeneralOrderExecutor` before configuring callbacks to prevent nil pointer dereferences when margin updater is uninitialized.

### Tests & Configuration
- Updated unit tests in `margin_info_updater_test.go` and `borrowable_test.go` to match the new constructor and method signatures.
- Updated `config_test.go` and `testdata/strategy.yaml` to include expectations for `marginInfoUpdaterTradesBufferCount` and `marginInfoUpdaterBindSession`.
