### PR TITLE
FEATURE: [xfundingv2] concurrent active rounds

### DIFF
--- a/pkg/strategy/xfundingv2/market_selector.go
+++ b/pkg/strategy/xfundingv2/market_selector.go
@@ -27,8 +27,6 @@ type MarketSelectionConfig struct {
 	FuturesDirection types.PositionType `json:"futuresDirection"`
 
 	MaxHoldingDuration types.Duration `json:"maxHoldingDuration"`
-	// TradeBalanceRatio is the ratio of the asset balance to be invested on the spot market.
-	TradeBalanceRatio fixedpoint.Value `json:"tradeBalanceRatio"`
 
 	// Minimum annualized funding rate to consider (e.g., 0.10 = 10%)
 	// recommended to default to 5%
@@ -56,9 +54,6 @@ func (c *MarketSelectionConfig) Defaults() {
 	}
 	if c.MaxHoldingDuration == 0 {
 		c.MaxHoldingDuration = types.Duration(time.Hour * 48)
-	}
-	if c.TradeBalanceRatio.IsZero() {
-		c.TradeBalanceRatio = fixedpoint.NewFromFloat(0.8)
 	}
 	if c.MinAnnualizedRate.IsZero() {
 		c.MinAnnualizedRate = fixedpoint.NewFromFloat(0.05) // 5%

--- a/pkg/strategy/xfundingv2/market_selector.go
+++ b/pkg/strategy/xfundingv2/market_selector.go
@@ -132,6 +132,9 @@ func (s *MarketSelector) SelectMarkets(ctx context.Context, symbols []string) ([
 	if err != nil {
 		return nil, err
 	}
+	if len(symbols) == 0 {
+		return nil, nil
+	}
 
 	// Step 2: Get funding info
 	fundingInfos, err := queryFundingInfo(ctx, s.service)

--- a/pkg/strategy/xfundingv2/market_selector.go
+++ b/pkg/strategy/xfundingv2/market_selector.go
@@ -33,6 +33,10 @@ type MarketSelectionConfig struct {
 	// Minimum annualized funding rate to consider (e.g., 0.10 = 10%)
 	// recommended to default to 5%
 	MinAnnualizedRate fixedpoint.Value `json:"minAnnualizedRate"`
+	// AnnualizedRateStep is the step size for the required annualized rate for new market candidates.
+	// For example, if there is already an active round with 10% annualized rate, and the step is 1%,
+	// then the next market candidate must have at least 11% annualized rate to be considered.
+	AnnualizedRateStep fixedpoint.Value `json:"annualizedRateStep"`
 
 	MinCollateralRate fixedpoint.Value `json:"minCollateralRate"`
 
@@ -58,6 +62,9 @@ func (c *MarketSelectionConfig) Defaults() {
 	}
 	if c.MinAnnualizedRate.IsZero() {
 		c.MinAnnualizedRate = fixedpoint.NewFromFloat(0.05) // 5%
+	}
+	if c.MinAnnualizedRate.IsZero() {
+		c.MinAnnualizedRate = fixedpoint.NewFromFloat(0.02) // 2%
 	}
 	if c.MinCollateralRate.IsZero() {
 		c.MinCollateralRate = fixedpoint.NewFromFloat(0.95)
@@ -108,8 +115,10 @@ type FuturesInfoService interface {
 // MarketSelector selects the best market based on funding rate and liquidity
 type MarketSelector struct {
 	MarketSelectionConfig
-	service FuturesInfoService
-	logger  logrus.FieldLogger
+
+	activeRounds map[string]*ArbitrageRound
+	service      FuturesInfoService
+	logger       logrus.FieldLogger
 }
 
 // NewMarketSelector creates a new MarketSelector
@@ -175,13 +184,15 @@ func (s *MarketSelector) SelectMarkets(ctx context.Context, symbols []string) ([
 			continue
 		}
 		annualized := AnnualizedRate(idx.LastFundingRate, info.FundingIntervalHours)
+		numActiveRounds := fixedpoint.NewFromInt(int64(len(s.activeRounds)))
+		requiredAnnualizedRate := s.MinAnnualizedRate.Add(s.AnnualizedRateStep.Mul(numActiveRounds))
 		labels := prometheus.Labels{
 			"symbol": idx.Symbol,
 		}
 		annualizedFundingRateMetrics.With(labels).Set(annualized.Float64())
 		fundingRateMetrics.With(labels).Set(idx.LastFundingRate.Float64())
 
-		if annualized.Abs().Compare(s.MinAnnualizedRate) < 0 {
+		if annualized.Abs().Compare(requiredAnnualizedRate) < 0 {
 			continue
 		}
 
@@ -226,6 +237,11 @@ func (s *MarketSelector) SelectMarkets(ctx context.Context, symbols []string) ([
 	}
 
 	return candidates, nil
+}
+
+func (s *MarketSelector) SetActiveRounds(rounds map[string]*ArbitrageRound) *MarketSelector {
+	s.activeRounds = rounds
+	return s
 }
 
 // queryFundingRates queries funding rates for the given symbols

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1263,7 +1263,9 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 	// Only open new round when there is none
 	// TODO: support multiple rounds for different symbols concurrently (e.g BTCUSDT and ETHUSDT)
 	if len(s.allRounds()) == 0 {
-		candidates, err := s.preliminaryMarketSelector.SelectMarkets(ctx, s.candidateSymbols)
+		candidates, err := s.preliminaryMarketSelector.
+			SetActiveRounds(s.ActiveRounds).
+			SelectMarkets(ctx, s.candidateSymbols)
 		if err != nil {
 			s.logger.WithError(err).Warn("failed to select market candidates")
 			return

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1267,94 +1267,90 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 		return
 	}
 
-	// Only open new round when there is none
-	// TODO: support multiple rounds for different symbols concurrently (e.g BTCUSDT and ETHUSDT)
-	if len(s.allRounds()) == 0 {
-		candidates, err := s.preliminaryMarketSelector.
-			SetActiveRounds(s.ActiveRounds).
-			SelectMarkets(ctx, s.candidateSymbols)
-		if err != nil {
-			s.logger.WithError(err).Warn("failed to select market candidates")
-			return
-		}
-		if len(candidates) == 0 {
-			// no candidates, nothing to do
-			return
-		}
-		s.logger.Debugf("candidates: %+v", candidates)
+	candidates, err := s.preliminaryMarketSelector.
+		SetActiveRounds(s.ActiveRounds).
+		SelectMarkets(ctx, s.candidateSymbols)
+	if err != nil {
+		s.logger.WithError(err).Warn("failed to select market candidates")
+		return
+	}
+	if len(candidates) == 0 {
+		// no candidates, nothing to do
+		return
+	}
+	s.logger.Debugf("candidates: %+v", candidates)
 
-		var legitCandidates []MarketCandidate
-		for _, candidate := range candidates {
-			if s.canOpenRound(candidate.Symbol, currentTime) {
-				legitCandidates = append(legitCandidates, candidate)
-			}
+	var legitCandidates []MarketCandidate
+	for _, candidate := range candidates {
+		if s.canOpenRound(candidate.Symbol, currentTime) {
+			legitCandidates = append(legitCandidates, candidate)
 		}
-		s.logger.Debugf("legit candidates: %+v", legitCandidates)
-		selectedCandidate := s.selectMostProfitableMarket(legitCandidates)
-		if selectedCandidate == nil {
-			// no profitable candidate found, nothing to do
+	}
+	s.logger.Debugf("legit candidates: %+v", legitCandidates)
+	selectedCandidate := s.selectMostProfitableMarket(legitCandidates)
+	if selectedCandidate == nil {
+		// no profitable candidate found, nothing to do
+		return
+	}
+	s.logger.Debugf("most profitable candidate for new round: %+v", selectedCandidate)
+
+	// open new round if the estimated break-even holding interval is within the max holding hours
+	if selectedCandidate.MinHoldingDuration <= s.MarketSelectionConfig.MaxHoldingDuration.Duration() {
+		spotExecutor := s.spotGeneralOrderExecutors[selectedCandidate.Symbol]
+		spotTwap, err := NewTWAPWorker(ctx, selectedCandidate.Symbol, s.spotSession, spotExecutor, s.TWAPWorkerConfig)
+		spotTwap.SetLogger(s.logger)
+		spotTwap.Executor().SetDryRun(s.DryRun)
+		if err != nil || spotTwap == nil {
+			s.logger.WithError(err).Errorf("failed to create TWAP worker for spot %s", selectedCandidate.Symbol)
 			return
 		}
-		s.logger.Debugf("most profitable candidate for new round: %+v", selectedCandidate)
-
-		// open new round if the estimated break-even holding interval is within the max holding hours
-		if selectedCandidate.MinHoldingDuration <= s.MarketSelectionConfig.MaxHoldingDuration.Duration() {
-			spotExecutor := s.spotGeneralOrderExecutors[selectedCandidate.Symbol]
-			spotTwap, err := NewTWAPWorker(ctx, selectedCandidate.Symbol, s.spotSession, spotExecutor, s.TWAPWorkerConfig)
-			spotTwap.SetLogger(s.logger)
-			spotTwap.Executor().SetDryRun(s.DryRun)
-			if err != nil || spotTwap == nil {
-				s.logger.WithError(err).Errorf("failed to create TWAP worker for spot %s", selectedCandidate.Symbol)
-				return
-			}
-			spotTwap.SetTargetPosition(selectedCandidate.TargetFuturesPosition.Neg())
-			futuresExecutor := s.futuresGeneralOrderExecutors[selectedCandidate.Symbol]
-			futuresTwap, err := NewTWAPWorker(ctx, selectedCandidate.Symbol, s.futuresSession, futuresExecutor, s.TWAPWorkerConfig)
-			futuresTwap.SetLogger(s.logger)
-			futuresTwap.Executor().SetDryRun(s.DryRun)
-			if err != nil || futuresTwap == nil {
-				s.logger.WithError(err).Errorf("failed to create TWAP worker for futures %s", selectedCandidate.Symbol)
-				return
-			}
-			round := NewArbitrageRound(
-				selectedCandidate.PremiumIndex,
-				s.spotSession.Exchange.Name(),
-				s.futuresSession.Exchange.Name(),
-				selectedCandidate.MinHoldingIntervals,
-				selectedCandidate.FundingIntervalHours,
-				s.Leverage,
-				spotTwap,
-				futuresTwap,
-				s.futuresService,
-				s.MarketSelectionConfig.FuturesDirection,
-				s.RoundRebalanceInterval.Duration(),
-			)
-			round.SetLogger(s.logger)
-			round.SetSpotExchangeFeeRates(
-				s.costEstimator.GetSpotFeeRate(),
-			)
-			round.SetFuturesExchangeFeeRates(
-				s.costEstimator.GetFuturesFeeRate(),
-			)
-			round.SetSlackAlert(s.SlackAlert)
-			roundAnnualizedTriggerRateMetrics.With(
-				prometheus.Labels{
-					"strategy_id": s.InstanceID(),
-					"symbol":      selectedCandidate.Symbol,
-				},
-			).Set(round.AnnualizedRate().Float64())
-			// enqueue the new round to pending rounds for further processing
-			s.PendingRounds[selectedCandidate.Symbol] = &PendingRound{
-				Round: round,
-			}
-			bbgo.Notify("🆕 Created new pending round: %s", round.SpotSymbol())
-		} else {
-			s.logger.Debugf("selected candidate %s min holding duration too long: %s > %s, skipping",
-				selectedCandidate.Symbol,
-				selectedCandidate.MinHoldingDuration,
-				s.MarketSelectionConfig.MaxHoldingDuration.Duration(),
-			)
+		spotTwap.SetTargetPosition(selectedCandidate.TargetFuturesPosition.Neg())
+		futuresExecutor := s.futuresGeneralOrderExecutors[selectedCandidate.Symbol]
+		futuresTwap, err := NewTWAPWorker(ctx, selectedCandidate.Symbol, s.futuresSession, futuresExecutor, s.TWAPWorkerConfig)
+		futuresTwap.SetLogger(s.logger)
+		futuresTwap.Executor().SetDryRun(s.DryRun)
+		if err != nil || futuresTwap == nil {
+			s.logger.WithError(err).Errorf("failed to create TWAP worker for futures %s", selectedCandidate.Symbol)
+			return
 		}
+		round := NewArbitrageRound(
+			selectedCandidate.PremiumIndex,
+			s.spotSession.Exchange.Name(),
+			s.futuresSession.Exchange.Name(),
+			selectedCandidate.MinHoldingIntervals,
+			selectedCandidate.FundingIntervalHours,
+			s.Leverage,
+			spotTwap,
+			futuresTwap,
+			s.futuresService,
+			s.MarketSelectionConfig.FuturesDirection,
+			s.RoundRebalanceInterval.Duration(),
+		)
+		round.SetLogger(s.logger)
+		round.SetSpotExchangeFeeRates(
+			s.costEstimator.GetSpotFeeRate(),
+		)
+		round.SetFuturesExchangeFeeRates(
+			s.costEstimator.GetFuturesFeeRate(),
+		)
+		round.SetSlackAlert(s.SlackAlert)
+		roundAnnualizedTriggerRateMetrics.With(
+			prometheus.Labels{
+				"strategy_id": s.InstanceID(),
+				"symbol":      selectedCandidate.Symbol,
+			},
+		).Set(round.AnnualizedRate().Float64())
+		// enqueue the new round to pending rounds for further processing
+		s.PendingRounds[selectedCandidate.Symbol] = &PendingRound{
+			Round: round,
+		}
+		bbgo.Notify("🆕 Created new pending round: %s", round.SpotSymbol())
+	} else {
+		s.logger.Debugf("selected candidate %s min holding duration too long: %s > %s, skipping",
+			selectedCandidate.Symbol,
+			selectedCandidate.MinHoldingDuration,
+			s.MarketSelectionConfig.MaxHoldingDuration.Duration(),
+		)
 	}
 }
 

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1770,7 +1770,7 @@ func (s *Strategy) newDebugLogger() *logrus.Entry {
 
 func (s *Strategy) notifyStats() {
 	var activeRoundNotifications []any
-	for _, round := range s.ActiveRounds {
+	for _, round := range s.sortedActiveRounds() {
 		spotPrice, futuresPrice, ok := s.getLastPrices(
 			round.SpotSymbol(),
 			round.FuturesSymbol(),
@@ -1806,6 +1806,17 @@ func (s *Strategy) notifyStats() {
 		bbgo.Notify("Pending Rounds", pendingRoundNotifications...)
 	}
 
+}
+
+func (s *Strategy) sortedActiveRounds() []*ArbitrageRound {
+	var rounds []*ArbitrageRound
+	for _, round := range s.ActiveRounds {
+		rounds = append(rounds, round)
+	}
+	sort.Slice(rounds, func(i, j int) bool {
+		return rounds[i].StartedAt().Before(rounds[j].StartedAt())
+	})
+	return rounds
 }
 
 func (s *Strategy) runFundingIncomeWorker(ctx context.Context) {

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -92,6 +92,8 @@ type Strategy struct {
 	// Market selection criteria
 	MarketSelectionConfig *MarketSelectionConfig      `json:"marketSelection,omitempty"`
 	MaxPositionExposure   map[string]fixedpoint.Value `json:"maxPositionExposure"`
+	// TradeBalanceRatio is the ratio of the asset balance to be invested on the spot market.
+	TradeBalanceRatio fixedpoint.Value `json:"tradeBalanceRatio"`
 
 	HaltRoundNotificationInterval types.Duration `json:"haltRoundNotificationInterval"`
 	haltNotificationLimiters      map[string]*rate.Limiter
@@ -203,6 +205,11 @@ func (s *Strategy) Defaults() error {
 		s.MarketSelectionConfig = &MarketSelectionConfig{}
 	}
 	s.MarketSelectionConfig.Defaults()
+
+	if s.TradeBalanceRatio.IsZero() {
+		s.TradeBalanceRatio = fixedpoint.NewFromFloat(0.8)
+	}
+
 	if s.QuoteCurrency == "" {
 		s.QuoteCurrency = "USDT"
 	}
@@ -1375,6 +1382,8 @@ func (s *Strategy) filterMarketByCapSize(ctx context.Context, symbols []string) 
 		}
 		if _, found := topAssets[market.BaseCurrency]; found {
 			candidateSymbols = append(candidateSymbols, symbol)
+		} else {
+			bbgo.Notify("skipping %s as it's not in the top cap assets", symbol)
 		}
 	}
 	return candidateSymbols
@@ -1388,7 +1397,7 @@ func (s *Strategy) filterMarketBothListed(symbols []string) []string {
 		if spotOk && futuresOk {
 			candidateSymbols = append(candidateSymbols, symbol)
 		} else {
-			s.logger.Infof("skipping %s as it's not listed on both spot and futures", symbol)
+			bbgo.Notify("skipping %s as it's not listed on both spot and futures", symbol)
 		}
 	}
 	return candidateSymbols
@@ -1421,7 +1430,7 @@ func (s *Strategy) filterMarketCollateralRate(ctx context.Context, symbols []str
 		if rate.Compare(s.MarketSelectionConfig.MinCollateralRate) >= 0 {
 			candidateSymbols = append(candidateSymbols, market.Symbol)
 		} else {
-			s.logger.Infof("skipping %s due to low collateral rate: %s", market.Symbol, rate.String())
+			bbgo.Notify("skipping %s due to low collateral rate: %s", market.Symbol, rate.String())
 		}
 	}
 	return candidateSymbols
@@ -1460,7 +1469,7 @@ func (s *Strategy) selectMostProfitableMarket(candidates []MarketCandidate) *Mar
 			if !ok {
 				continue
 			}
-			totalQuoteAmount := quoteBalance.Available.Mul(s.MarketSelectionConfig.TradeBalanceRatio)
+			totalQuoteAmount := s.quoteAmountForBet(quoteBalance.Available)
 			// long spot -> trade on the sell side of the order book
 			// targetSize = totalQuoteAmount / (price * feeRateFactor)
 			sellBook := s.spotOrderBooks[candidate.Symbol].SideBook(types.SideTypeSell)
@@ -1487,7 +1496,7 @@ func (s *Strategy) selectMostProfitableMarket(candidates []MarketCandidate) *Mar
 			}
 			// totalQuoteAmount = price * totalBase and targetSize = totalQuoteAmount / (price * feeRateFactor)
 			// so targetSize = totalBase / feeRateFactor
-			totalBase := baseBalance.Available.Mul(s.MarketSelectionConfig.TradeBalanceRatio)
+			totalBase := baseBalance.Available.Mul(s.TradeBalanceRatio)
 			targetSize = totalBase.Div(feeRateFactor)
 			// long futures -> trade on the sell side of the order book
 			sellBook := s.futuresOrderBooks[candidate.Symbol].SideBook(types.SideTypeSell)
@@ -1544,6 +1553,15 @@ func (s *Strategy) selectMostProfitableMarket(candidates []MarketCandidate) *Mar
 	bestCandidate.MinHoldingDuration = time.Duration(numHoldingHours) * time.Hour
 	bestCandidate.TargetFuturesPosition = targetPosition
 	return bestCandidate
+}
+
+func (s *Strategy) quoteAmountForBet(quoteAvailable fixedpoint.Value) fixedpoint.Value {
+	remainingCandidates := len(s.candidateSymbols) - len(s.ActiveRounds)
+	if remainingCandidates == 1 {
+		// the last symbol, use all the available quote balance for the bet
+		return quoteAvailable
+	}
+	return quoteAvailable.Mul(s.TradeBalanceRatio)
 }
 
 func (s *Strategy) calculateMinHoldingIntervals(candidate MarketCandidate, bestPrice, targetPosition fixedpoint.Value) (fixedpoint.Value, error) {

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1267,9 +1267,16 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 		return
 	}
 
+	var legitSymbols []string
+	for _, symbol := range s.candidateSymbols {
+		if s.canOpenRound(symbol, currentTime) {
+			legitSymbols = append(legitSymbols, symbol)
+		}
+	}
+
 	candidates, err := s.preliminaryMarketSelector.
 		SetActiveRounds(s.ActiveRounds).
-		SelectMarkets(ctx, s.candidateSymbols)
+		SelectMarkets(ctx, legitSymbols)
 	if err != nil {
 		s.logger.WithError(err).Warn("failed to select market candidates")
 		return
@@ -1280,14 +1287,7 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 	}
 	s.logger.Debugf("candidates: %+v", candidates)
 
-	var legitCandidates []MarketCandidate
-	for _, candidate := range candidates {
-		if s.canOpenRound(candidate.Symbol, currentTime) {
-			legitCandidates = append(legitCandidates, candidate)
-		}
-	}
-	s.logger.Debugf("legit candidates: %+v", legitCandidates)
-	selectedCandidate := s.selectMostProfitableMarket(legitCandidates)
+	selectedCandidate := s.selectMostProfitableMarket(candidates)
 	if selectedCandidate == nil {
 		// no profitable candidate found, nothing to do
 		return

--- a/pkg/strategy/xfundingv2/strategy_test.go
+++ b/pkg/strategy/xfundingv2/strategy_test.go
@@ -39,9 +39,9 @@ func newTestSession(markets types.MarketMap, balances types.BalanceMap) *bbgo.Ex
 func newDefaultTestStrategy() *Strategy {
 	return &Strategy{
 		MarketSelectionConfig: &MarketSelectionConfig{
-			FuturesDirection:  types.PositionShort,
-			TradeBalanceRatio: Number("0.5"),
+			FuturesDirection: types.PositionShort,
 		},
+		TradeBalanceRatio:   Number("0.5"),
 		MaxPositionExposure: make(map[string]fixedpoint.Value),
 		costEstimator:       NewCostEstimator(),
 		logger:              logrus.StandardLogger(),
@@ -64,7 +64,7 @@ func TestSelectMostProfitableMarket(t *testing.T) {
 	t.Run("short futures selects candidate with shortest breakeven interval", func(t *testing.T) {
 		s := newDefaultTestStrategy()
 		s.MarketSelectionConfig.FuturesDirection = types.PositionShort
-		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+		s.TradeBalanceRatio = Number("1.0")
 
 		markets := types.MarketMap{
 			"BTCUSDT": btcMarket,
@@ -127,7 +127,7 @@ func TestSelectMostProfitableMarket(t *testing.T) {
 	t.Run("long futures selects candidate with shortest breakeven interval", func(t *testing.T) {
 		s := newDefaultTestStrategy()
 		s.MarketSelectionConfig.FuturesDirection = types.PositionLong
-		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+		s.TradeBalanceRatio = Number("1.0")
 
 		markets := types.MarketMap{
 			"BTCUSDT": btcMarket,
@@ -285,7 +285,7 @@ func TestSelectMostProfitableMarket(t *testing.T) {
 	t.Run("max position exposure caps short futures position", func(t *testing.T) {
 		s := newDefaultTestStrategy()
 		s.MarketSelectionConfig.FuturesDirection = types.PositionShort
-		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+		s.TradeBalanceRatio = Number("1.0")
 		s.MaxPositionExposure = map[string]fixedpoint.Value{
 			"ETH": Number("0.5"),
 		}
@@ -328,7 +328,7 @@ func TestSelectMostProfitableMarket(t *testing.T) {
 	t.Run("max position exposure caps long futures position", func(t *testing.T) {
 		s := newDefaultTestStrategy()
 		s.MarketSelectionConfig.FuturesDirection = types.PositionLong
-		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+		s.TradeBalanceRatio = Number("1.0")
 		s.MaxPositionExposure = map[string]fixedpoint.Value{
 			"ETH": Number("0.5"),
 		}
@@ -371,7 +371,7 @@ func TestSelectMostProfitableMarket(t *testing.T) {
 	t.Run("zero funding rate candidate is skipped", func(t *testing.T) {
 		s := newDefaultTestStrategy()
 		s.MarketSelectionConfig.FuturesDirection = types.PositionShort
-		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+		s.TradeBalanceRatio = Number("1.0")
 
 		markets := types.MarketMap{"BTCUSDT": btcMarket}
 		balances := types.BalanceMap{
@@ -409,7 +409,7 @@ func TestSelectMostProfitableMarket(t *testing.T) {
 	t.Run("single candidate returns that candidate", func(t *testing.T) {
 		s := newDefaultTestStrategy()
 		s.MarketSelectionConfig.FuturesDirection = types.PositionShort
-		s.MarketSelectionConfig.TradeBalanceRatio = Number("1.0")
+		s.TradeBalanceRatio = Number("1.0")
 
 		markets := types.MarketMap{"ETHUSDT": ethMarket}
 		balances := types.BalanceMap{


### PR DESCRIPTION
- Stepped required annualized rate
    - the next arbitrage round must have higher annualized rate to the last one
    - step size is controlled by `annualizedRateStep`
- Concurrent active rounds support
    - concurrently run active rounds of different symbols
- revise the `tradeBalanceRatio` logics
    - if the symbol to be considered is the last one, use up all the quote balance available