### PR TITLE
refactor(tradeid): use atomic.Uint64 counter

### DIFF
--- a/pkg/tradeid/tradeid.go
+++ b/pkg/tradeid/tradeid.go
@@ -11,10 +11,10 @@ type Generator interface {
 
 type productionGenerator struct{}
 
-var counter uint64
+var counter atomic.Uint64
 
 func (g *productionGenerator) Generate() uint64 {
-	c := atomic.AddUint64(&counter, 1)
+	c := counter.Add(1)
 	ts := uint64(time.Now().UnixMilli())
 	return ts*1000 + c
 }


### PR DESCRIPTION
Use `atomic.Uint64` for the process-wide trade ID counter. This keeps the atomic guarantee attached to the value's type and replaces the pointer-based `atomic.AddUint64` call with `counter.Add(1)`.

The generated ID formula and counter semantics are unchanged. `go test ./pkg/tradeid` passes.