### PR TITLE
FIX: [fixedpoint] correct Trunc to truncate toward zero for negative values

### DIFF
--- a/pkg/fixedpoint/convert.go
+++ b/pkg/fixedpoint/convert.go
@@ -36,7 +36,7 @@ const (
 
 // Trunc returns the integer portion (truncating any fractional part)
 func (v Value) Trunc() Value {
-	return NewFromFloat(math.Floor(v.Float64()))
+	return NewFromFloat(math.Trunc(v.Float64()))
 }
 
 func (v Value) Round(r int, mode RoundingMode) Value {

--- a/pkg/fixedpoint/convert_test.go
+++ b/pkg/fixedpoint/convert_test.go
@@ -122,3 +122,31 @@ func Test_FormatString(t *testing.T) {
 		})
 	}
 }
+
+func Test_Trunc(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{input: "0", expected: "0"},
+		{input: "1", expected: "1"},
+		{input: "-1", expected: "-1"},
+		{input: "1.5", expected: "1"},
+		{input: "-1.5", expected: "-1"},
+		{input: "0.5", expected: "0"},
+		{input: "-0.5", expected: "0"},
+		{input: "1.00000001", expected: "1"},
+		{input: "-1.00000001", expected: "-1"},
+		{input: "123.456", expected: "123"},
+		{input: "-123.456", expected: "-123"},
+		{input: "0.00000001", expected: "0"},
+		{input: "-0.00000001", expected: "0"},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("trunc(%s) = %s", c.input, c.expected), func(t *testing.T) {
+			v := MustNewFromString(c.input)
+			assert.Equal(t, c.expected, v.Trunc().String())
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`fixedpoint.Trunc` truncated negative values toward **negative infinity** instead of toward zero. For example `trunc(-1.5)` produced `-2` where the expected toward-zero semantics give `-1`. Since this type underpins price/quantity math, the floor-vs-trunc discrepancy is financially meaningful (it can silently inflate a negative quantity by one unit).

## Fix

Correct the negative path to truncate toward zero (1-line change in `pkg/fixedpoint/convert.go`).

## Test

`Test_Trunc` covers positive, negative, sub-unit, and boundary cases (`trunc(-1.5) = -1`, `trunc(-0.5) = 0`, `trunc(-123.456) = -123`, etc.). 5 negative cases failed before the fix; all 13 pass after.

`go test ./pkg/fixedpoint/ -run Trunc -count=1 -v`

Note: happy to adjust if any existing strategy intentionally relied on floor semantics for negatives. I did not find one, but it is worth a maintainer confirm.
