### PR TITLE
FEATURE: [bbgo] dynamically adjust min holding intervals in xfundingv2

### DIFF
--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -98,6 +98,9 @@ func NewArbitrageRound(
 	}
 	fundingIntervalStart := fundingRate.NextFundingTime.Add(-time.Duration(fundingIntervalHours) * time.Hour)
 	fundingIntervalEnd := fundingRate.NextFundingTime.Add(-time.Second)
+	if minHoldingIntervals <= 0 {
+		minHoldingIntervals = 1
+	}
 	return &ArbitrageRound{
 		syncState: ArbitrageRoundSyncState{
 			ID:                          uuid.NewString(),

--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -503,7 +503,41 @@ func (r *ArbitrageRound) NumHoldingIntervals(currentTime time.Time) int {
 	return int(elapsed / intervalDuration)
 }
 
-func (r *ArbitrageRound) MinHoldingIntervals() int {
+func (r *ArbitrageRound) MinHoldingIntervals(currentTime time.Time, spotPrice, futuresPrice fixedpoint.Value) int {
+	// only enable the dynamic adjustment of min holding intervals when there are
+	// 1. a valid spot and futures price
+	// 2. enough funding fee records to calculate the average funding income
+	if spotPrice.IsZero() || futuresPrice.IsZero() || len(r.syncState.FundingFeeRecords) <= 6 {
+		return r.syncState.MinHoldingIntervals
+	}
+
+	// adjust the min holding intervals based on the current total PnL
+	// hold the position until the total PnL breaks even with the average funding income
+	avgFeeIncome := r.AvgFundingIncome()
+	totalPnL := r.UnrealizedPnL(spotPrice, futuresPrice).TotalPnL()
+	if totalPnL.Sign() > 0 || avgFeeIncome.Sign() <= 0 {
+		return r.syncState.MinHoldingIntervals
+	}
+
+	oriMinHoldingIntervals := r.syncState.MinHoldingIntervals
+	breakEvenIntervals := fixedpoint.Max(
+		totalPnL.Abs().Div(avgFeeIncome).Round(0, fixedpoint.Up),
+		fixedpoint.One,
+	).Int()
+	numHoldingIntervals := r.NumHoldingIntervals(currentTime)
+	remainingIntervals := r.syncState.MinHoldingIntervals - numHoldingIntervals
+
+	if remainingIntervals >= breakEvenIntervals {
+		return r.syncState.MinHoldingIntervals
+	}
+
+	r.syncState.MinHoldingIntervals += breakEvenIntervals - remainingIntervals
+	r.logger.Infof(
+		"[ArbitrageRound] adjusted min holding intervals (%s): %d -> %d",
+		r.SpotSymbol(),
+		oriMinHoldingIntervals,
+		r.syncState.MinHoldingIntervals,
+	)
 	return r.syncState.MinHoldingIntervals
 }
 
@@ -667,16 +701,11 @@ func (n *roundNotification) SlackAttachment() slack.Attachment {
 			fields = append(fields, unrealizedPnLFields(unrealizedPnL)...)
 		}
 	}
-	if len(n.ArbitrageRound.syncState.FundingFeeRecords) > 0 {
-		feeIncomeTotal := fixedpoint.Zero
-		numRecords := fixedpoint.Zero
-		for _, fee := range n.ArbitrageRound.syncState.FundingFeeRecords {
-			feeIncomeTotal = feeIncomeTotal.Add(fee.Amount)
-			numRecords = numRecords.Add(fixedpoint.One)
-		}
+	avgFundingIncome := n.ArbitrageRound.AvgFundingIncome()
+	if !avgFundingIncome.IsZero() {
 		fields = append(fields, slack.AttachmentField{
 			Title: "Average Funding Income",
-			Value: feeIncomeTotal.Div(numRecords).String(),
+			Value: avgFundingIncome.String(),
 			Short: true,
 		})
 	}
@@ -959,6 +988,23 @@ func (r *ArbitrageRound) syncFundingFeeRecords(ctx context.Context, currentTime 
 	}
 	r.logger.Debugf("synced funding fee records: %+v", r.syncState.FundingFeeRecords)
 	return nil
+}
+
+func (r *ArbitrageRound) AvgFundingIncome() fixedpoint.Value {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.syncState.FundingFeeRecords) == 0 {
+		return fixedpoint.Zero
+	}
+
+	feeIncomeTotal := fixedpoint.Zero
+	numRecords := fixedpoint.Zero
+	for _, fee := range r.syncState.FundingFeeRecords {
+		feeIncomeTotal = feeIncomeTotal.Add(fee.Amount)
+		numRecords = numRecords.Add(fixedpoint.One)
+	}
+	return feeIncomeTotal.Div(numRecords)
 }
 
 func (r *ArbitrageRound) Start(ctx context.Context,

--- a/pkg/strategy/xfundingv2/round_test.go
+++ b/pkg/strategy/xfundingv2/round_test.go
@@ -194,6 +194,166 @@ func TestArbitrageRound_NumHoldingIntervals(t *testing.T) {
 	})
 }
 
+// seedFundingRecords populates the round with n funding-fee records, each with
+// the given amount. This drives both AvgFundingIncome() (== amount) and the
+// len(FundingFeeRecords) > 6 gate that enables the dynamic adjustment path in
+// MinHoldingIntervals.
+func seedFundingRecords(round *ArbitrageRound, n int, amount fixedpoint.Value) {
+	for i := 1; i <= n; i++ {
+		round.syncState.FundingFeeRecords[int64(i)] = FundingFee{
+			RoundID: round.syncState.ID,
+			Asset:   "USDT",
+			Amount:  amount,
+			Txn:     int64(i),
+		}
+	}
+}
+
+// seedLegTrade registers an order on the worker's executor and records a single
+// fill for it. ArbitrageRound.realizedPnL() rebuilds the leg positions from
+// Executor().AllTrades(), and AddTrade only keeps a trade whose order is known,
+// so the order must be inserted first.
+func seedLegTrade(worker *TWAPWorker, trade types.Trade) {
+	exec := worker.Executor()
+	order := types.Order{
+		OrderID:     trade.OrderID,
+		SubmitOrder: types.SubmitOrder{Symbol: trade.Symbol, Side: trade.Side},
+	}
+	exec.syncState.Orders[trade.OrderID] = order.AsQuery()
+	exec.AddTrade(trade)
+}
+
+// seedHedgedPosition opens a 1-unit spot-long / futures-short hedge at basisPrice
+// on both legs. With no exchange fee rates configured, the round's unrealized PnL
+// at mark prices (spotPrice, futuresPrice) is exactly
+//
+//	(spotPrice - basisPrice) + (basisPrice - futuresPrice) == spotPrice - futuresPrice
+//
+// which lets a subtest dial the total PnL to a known value.
+func seedHedgedPosition(round *ArbitrageRound, basisPrice fixedpoint.Value) {
+	seedLegTrade(round.spotWorker, makeTrade(1, 1, types.SideTypeBuy, basisPrice, Number(1.0)))
+	seedLegTrade(round.futuresWorker, makeTrade(101, 101, types.SideTypeSell, basisPrice, Number(1.0)))
+}
+
+func TestArbitrageRound_MinHoldingIntervals(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Funding at 08:00 UTC, 8h interval → FundingIntervalStart = 00:00 UTC.
+	nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+	startAt := time.Date(2024, 1, 1, 0, 30, 0, 0, time.UTC)
+	// FundingIntervalStart (00:00) → NumHoldingIntervals(intervalStart) == 0.
+	intervalStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// 08:00 is exactly one 8h interval after FundingIntervalStart.
+	afterOneInterval := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+
+	spotPrice := Number(90.0)
+	futuresPrice := Number(100.0)
+
+	t.Run("returns configured value when spot price is zero", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		seedFundingRecords(round, 7, Number(1.0))
+		seedHedgedPosition(round, Number(100.0))
+
+		result := round.MinHoldingIntervals(afterOneInterval, fixedpoint.Zero, futuresPrice)
+		assert.Equal(t, 3, result)
+		assert.Equal(t, 3, round.syncState.MinHoldingIntervals, "min holding intervals must not be mutated")
+	})
+
+	t.Run("returns configured value when futures price is zero", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		seedFundingRecords(round, 7, Number(1.0))
+		seedHedgedPosition(round, Number(100.0))
+
+		result := round.MinHoldingIntervals(afterOneInterval, spotPrice, fixedpoint.Zero)
+		assert.Equal(t, 3, result)
+		assert.Equal(t, 3, round.syncState.MinHoldingIntervals, "min holding intervals must not be mutated")
+	})
+
+	t.Run("returns configured value without enough funding records", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartAt = startAt
+		// Only 6 records (<= 6) → dynamic adjustment disabled even though the
+		// hedged position would otherwise be at a loss.
+		seedFundingRecords(round, 6, Number(1.0))
+		seedHedgedPosition(round, Number(100.0))
+
+		result := round.MinHoldingIntervals(afterOneInterval, spotPrice, futuresPrice)
+		assert.Equal(t, 3, result)
+		assert.Equal(t, 3, round.syncState.MinHoldingIntervals, "min holding intervals must not be mutated")
+	})
+
+	t.Run("returns configured value when total pnl is positive", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartAt = startAt
+		// No open position → unrealized PnL is zero, so total PnL is just the
+		// positive funding income (7 * 1.0).
+		seedFundingRecords(round, 7, Number(1.0))
+
+		result := round.MinHoldingIntervals(afterOneInterval, spotPrice, futuresPrice)
+		assert.Equal(t, 3, result)
+		assert.Equal(t, 3, round.syncState.MinHoldingIntervals, "min holding intervals must not be mutated")
+	})
+
+	t.Run("returns configured value when average funding income is non-positive", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartAt = startAt
+		// Negative funding income → avgFeeIncome <= 0, so no adjustment even though
+		// the hedged position is at a loss (total PnL is negative here).
+		seedFundingRecords(round, 7, Number(-1.0))
+		seedHedgedPosition(round, Number(100.0))
+
+		result := round.MinHoldingIntervals(afterOneInterval, spotPrice, futuresPrice)
+		assert.Equal(t, 3, result)
+		assert.Equal(t, 3, round.syncState.MinHoldingIntervals, "min holding intervals must not be mutated")
+	})
+
+	t.Run("does not adjust when remaining intervals cover breakeven", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartAt = startAt
+		// avgFeeIncome = 1.0, funding income = 7.0, unrealized = 90 - 100 = -10
+		// → total PnL = -3 → breakEvenIntervals = ceil(3/1) = 3.
+		seedFundingRecords(round, 7, Number(1.0))
+		seedHedgedPosition(round, Number(100.0))
+
+		// currentTime at FundingIntervalStart → NumHoldingIntervals = 0,
+		// remaining = 3 - 0 = 3 >= breakEven (3) → no adjustment.
+		result := round.MinHoldingIntervals(intervalStart, spotPrice, futuresPrice)
+		assert.Equal(t, 3, result)
+		assert.Equal(t, 3, round.syncState.MinHoldingIntervals, "min holding intervals must not be mutated")
+	})
+
+	t.Run("adjusts min holding intervals upward when breakeven exceeds remaining", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartAt = startAt
+		// Same total PnL = -3 → breakEvenIntervals = 3.
+		seedFundingRecords(round, 7, Number(1.0))
+		seedHedgedPosition(round, Number(100.0))
+
+		// currentTime one interval in → NumHoldingIntervals = 1,
+		// remaining = 3 - 1 = 2 < breakEven (3)
+		// → adjusted = 3 + (3 - 2) = 4.
+		result := round.MinHoldingIntervals(afterOneInterval, spotPrice, futuresPrice)
+		assert.Equal(t, 4, result)
+		assert.Equal(t, 4, round.syncState.MinHoldingIntervals, "adjusted value must be persisted")
+	})
+
+	t.Run("adjusts by the full breakeven shortfall for a larger loss", func(t *testing.T) {
+		round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+		round.syncState.StartAt = startAt
+		// unrealized = 85 - 100 = -15, funding income = 7.0
+		// → total PnL = -8 → breakEvenIntervals = ceil(8/1) = 8.
+		seedFundingRecords(round, 7, Number(1.0))
+		seedHedgedPosition(round, Number(100.0))
+
+		// NumHoldingIntervals = 1, remaining = 2 < breakEven (8)
+		// → adjusted = 3 + (8 - 2) = 9.
+		result := round.MinHoldingIntervals(afterOneInterval, Number(85.0), futuresPrice)
+		assert.Equal(t, 9, result)
+		assert.Equal(t, 9, round.syncState.MinHoldingIntervals, "adjusted value must be persisted")
+	})
+}
+
 func TestArbitrageRound_TotalFundingIncome(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1185,7 +1185,7 @@ func (s *Strategy) transitOpeningOrReadyRoundToClosing(round *ArbitrageRound, in
 		round.FuturesSymbol(),
 	)
 
-	withinMinHoldingTime := round.NumHoldingIntervals(currentTime) < round.MinHoldingIntervals()
+	withinMinHoldingTime := round.NumHoldingIntervals(currentTime) < round.MinHoldingIntervals(currentTime, spotPrice, futuresPrice)
 	if round.TriggeredFundingRate().Sign()*index.LastFundingRate.Sign() <= 0 {
 		// the funding rate has flipped
 		rateDiffAbs := index.LastFundingRate.Sub(round.TriggeredFundingRate()).Abs()

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -405,13 +405,6 @@ func (s *Strategy) CrossRun(
 	// cleanup pending rounds on startup
 	s.PendingRounds = make(map[string]*PendingRound)
 
-	// hotfix: fix 0 min holding intervals
-	for _, round := range s.ActiveRounds {
-		if round.syncState.MinHoldingIntervals == 0 {
-			round.syncState.MinHoldingIntervals = 1
-		}
-	}
-
 	s.spotSession = sessions[s.SpotSession]
 	s.futuresSession = sessions[s.FuturesSession]
 


### PR DESCRIPTION
### Summary of Changes

#### 1. Dynamic Minimum Holding Intervals
- Updated `ArbitrageRound.MinHoldingIntervals` to accept `currentTime`, `spotPrice`, and `futuresPrice`.
- Implemented dynamic adjustment logic:
  - Validates market prices and checks that sufficient funding fee records exist (`> 6`).
  - If current total PnL is negative and average funding income is positive, calculates the intervals needed to break even (`ceil(|totalPnL| / avgFeeIncome)`).
  - Automatically extends `syncState.MinHoldingIntervals` if the remaining holding intervals are insufficient to cover the breakeven period.

#### 2. `AvgFundingIncome` Refactoring
- Added thread-safe `AvgFundingIncome()` method to `ArbitrageRound`.
- Replaced inline average funding income calculation in `SlackAttachment()` with the new method.

#### 3. Strategy Integration
- Updated `transitOpeningOrReadyRoundToClosing` in `pkg/strategy/xfundingv2/strategy.go` to pass the current time and spot/futures prices to `MinHoldingIntervals`.

#### 4. Unit Tests
- Added unit tests in `TestArbitrageRound_MinHoldingIntervals` covering edge cases (zero prices, insufficient funding records, positive PnL, negative average funding income, sufficient remaining intervals) and upward adjustments for breakeven shortfalls.
- Added test helper utilities (`seedFundingRecords`, `seedLegTrade`, `seedHedgedPosition`).
