### PR TITLE
FIX: [xfundingv2] format last funding rate as percentage in slack notification

### DIFF
--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -733,7 +733,7 @@ func (n *roundNotification) SlackAttachment() slack.Attachment {
 		},
 		{
 			Title: "Last Funding Rate",
-			Value: n.lastFundingRate.String(),
+			Value: n.lastFundingRate.Percentage(),
 			Short: true,
 		},
 		{

--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -801,6 +801,7 @@ func (n *roundNotification) SlackAttachment() slack.Attachment {
 		Text:   text,
 		Color:  n.stateColor(),
 		Fields: fields,
+		Footer: fmt.Sprintf("last updated at %s", n.LastUpdateTime().Format(time.RFC3339)),
 	}
 }
 

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1154,6 +1154,7 @@ func (s *Strategy) transitRound(ctx context.Context, round *ArbitrageRound, curr
 
 	index, err := s.futuresService.QueryPremiumIndex(timedCtx, round.FuturesSymbol())
 	if err != nil {
+		s.logger.WithError(err).Warnf("failed to query premium index for round: %s", round.String())
 		return
 	}
 	// update the last funding rate for the round metrics


### PR DESCRIPTION
## Summary

- **Format Last Funding Rate as Percentage**: Updated `roundNotification.SlackAttachment()` to display `lastFundingRate` as a formatted percentage using `.Percentage()` instead of `.String()`.
- **Log Failed Premium Index Queries**: Added a warning log in `Strategy.transitRound()` when `QueryPremiumIndex` encounters an error.
