### PR TITLE
FIX: [xfundingv2] conditionally display last funding rate in Slack notification

### DIFF
--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -731,22 +731,28 @@ func (n *roundNotification) SlackAttachment() slack.Attachment {
 			Value: n.AnnualizedRate().Percentage(),
 			Short: true,
 		},
-		{
-			Title: "Last Funding Rate",
-			Value: n.lastFundingRate.Percentage(),
-			Short: true,
-		},
-		{
-			Title: "Annualized Last Funding Rate",
-			Value: AnnualizedRate(n.lastFundingRate, n.syncState.FundingIntervalHours).Percentage(),
-			Short: true,
-		},
-		{
-			Title: "Start Time",
-			Value: n.syncState.StartAt.Format(time.RFC3339),
-			Short: true,
-		},
 	}...)
+
+	if !n.lastFundingRate.IsZero() {
+		fields = append(fields, []slack.AttachmentField{
+			{
+				Title: "Last Funding Rate",
+				Value: n.lastFundingRate.Percentage(),
+				Short: true,
+			},
+			{
+				Title: "Annualized Last Funding Rate",
+				Value: AnnualizedRate(n.lastFundingRate, n.syncState.FundingIntervalHours).Percentage(),
+				Short: true,
+			},
+		}...)
+	}
+
+	fields = append(fields, slack.AttachmentField{
+		Title: "Start Time",
+		Value: n.syncState.StartAt.Format(time.RFC3339),
+		Short: true,
+	})
 
 	switch n.State() {
 	case RoundClosing:


### PR DESCRIPTION
## Summary
Conditionally include the "Last Funding Rate" and "Annualized Last Funding Rate" fields in round Slack notifications only when `lastFundingRate` is non-zero.

## Changes
- **`pkg/strategy/xfundingv2/round.go`**: Updated `SlackAttachment()` to check `!n.lastFundingRate.IsZero()` before appending the "Last Funding Rate" and "Annualized Last Funding Rate" attachment fields.
