### PR TITLE
FIX: [xfundingv2] fix round transition condition

### DIFF
--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -1132,7 +1132,7 @@ func (s *Strategy) tick(ctx context.Context, tickTime time.Time) {
 
 func (s *Strategy) transitRound(ctx context.Context, round *ArbitrageRound, currentTime time.Time) {
 	// still in the first funding interval, do not transit
-	if round.NumHoldingIntervals(currentTime) <= 1 {
+	if round.NumHoldingIntervals(currentTime) < 1 {
 		if round.LastUpdateTime().IsZero() {
 			round.SetUpdateTime(currentTime)
 		}


### PR DESCRIPTION
### Summary

Allow arbitrage rounds to transition after completing at least one holding interval by updating the interval threshold check from `<= 1` to `< 1` in `transitRound`.

### Changes

- **`pkg/strategy/xfundingv2/strategy.go`**: Update the transition guard condition in `transitRound` to only skip transitions when `round.NumHoldingIntervals(currentTime) < 1`.
