### PR TITLE
docs: fix spelling in autobuy and changelog comments

### DIFF
--- a/config/autobuy.yaml
+++ b/config/autobuy.yaml
@@ -1,7 +1,7 @@
 ---
 exchangeStrategies:
   - on: max
-    # automaticaly buy coins when the balance is lower than the threshold
+    # automatically buy coins when the balance is lower than the threshold
     autobuy:
       symbol: MAXTWD
       schedule: "@every 1s"

--- a/utils/changelog.sh
+++ b/utils/changelog.sh
@@ -25,7 +25,7 @@ PREVIOUS_TAG=${TAGS[1]}
 PREVIOUS_TAG=$LATEST_TAG
 LATEST_TAG=main
 
-# Get a log of commits that occured between two tags
+# Get a log of commits that occurred between two tags
 # We only get the commit hash so we don't have to deal with a bunch of ugly parsing
 # See Pretty format placeholders at https://git-scm.com/docs/pretty-formats
 COMMITS=$(git log $PREVIOUS_TAG..$LATEST_TAG --pretty=format:"%H")


### PR DESCRIPTION
Corrects `automaticaly` in the autobuy example configuration and `occured` in the changelog helper's explanation of the commit range. 
