### PR TITLE
FIX: [exchange] retry order cancellation on MAX nonce errors

### DIFF
--- a/pkg/exchange/max/exchange.go
+++ b/pkg/exchange/max/exchange.go
@@ -495,7 +495,10 @@ func (e *Exchange) CancelOrders(ctx context.Context, orders ...types.Order) (err
 			req := e.v3client.NewCancelWalletOrderAllRequest(walletType)
 			req.GroupID(groupID)
 
-			if _, err := req.Do(ctx); err != nil {
+			if err := retryOnNonceError(ctx, func() error {
+				_, err := req.Do(ctx)
+				return err
+			}); err != nil {
 				log.WithError(err).Errorf("group id %d order cancel error", groupID)
 				err2 = err
 			}
@@ -515,7 +518,10 @@ func (e *Exchange) CancelOrders(ctx context.Context, orders ...types.Order) (err
 			return fmt.Errorf("order id or client order id is not defined, order=%+v", o)
 		}
 
-		if _, err := req.Do(ctx); err != nil {
+		if err := retryOnNonceError(ctx, func() error {
+			_, err := req.Do(ctx)
+			return err
+		}); err != nil {
 			log.WithError(err).WithFields(logFields).Errorf("order cancel error")
 			err2 = err
 		}

--- a/pkg/exchange/max/nonce.go
+++ b/pkg/exchange/max/nonce.go
@@ -1,0 +1,64 @@
+package max
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/c9s/requestgen"
+	"github.com/cenkalti/backoff/v4"
+
+	maxapi "github.com/c9s/bbgo/pkg/exchange/max/maxapi"
+)
+
+// isMaxNonceError reports whether err is a MAX nonce-gate rejection:
+//
+//	2006 = the nonce has already been used by access key
+//	2007 = invalid nonce
+//
+// These are rejected during nonce validation, before the request reaches the
+// matching/cancel engine, so resending with a fresh nonce is safe (no duplicate
+// action).
+func isMaxNonceError(err error) bool {
+	var responseErr *requestgen.ErrResponse
+	if !errors.As(err, &responseErr) {
+		return false
+	}
+
+	if responseErr.StatusCode < 400 || !responseErr.IsJSON() {
+		return false
+	}
+
+	var maxErr maxapi.ErrorResponse
+	if decodeErr := responseErr.DecodeJSON(&maxErr); decodeErr != nil {
+		return false
+	}
+
+	return maxErr.Err.Code == 2006 || maxErr.Err.Code == 2007
+}
+
+// retryOnNonceError re-invokes op with a fresh nonce when MAX rejects the
+// request with a nonce-gate error (2006/2007). Any other error (or success)
+// stops immediately; the original error is returned unwrapped.
+func retryOnNonceError(ctx context.Context, op func() error) error {
+	timedCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	return backoff.Retry(func() error {
+		if err := op(); err != nil {
+			if isMaxNonceError(err) {
+				// retry with a fresh nonce
+				return err
+			}
+
+			// any other error stops immediately, returned unwrapped
+			return backoff.Permanent(err)
+		}
+
+		return nil
+	}, backoff.WithContext(
+		backoff.WithMaxRetries(
+			backoff.NewExponentialBackOff(),
+			3),
+		timedCtx))
+}

--- a/pkg/exchange/max/nonce_test.go
+++ b/pkg/exchange/max/nonce_test.go
@@ -1,0 +1,100 @@
+package max
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/c9s/requestgen"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c9s/bbgo/pkg/testing/httptesting"
+)
+
+// newMaxErrResponse builds a *requestgen.ErrResponse carrying a JSON MAX error
+// body ({"error":{"code":N,...}}) with the given HTTP status code.
+func newMaxErrResponse(t *testing.T, statusCode, errCode int) *requestgen.ErrResponse {
+	t.Helper()
+
+	payload := map[string]any{
+		"error": map[string]any{
+			"code":    errCode,
+			"message": "mock max error",
+		},
+	}
+
+	resp, err := requestgen.NewResponse(httptesting.BuildResponseJson(statusCode, payload))
+	assert.NoError(t, err)
+	return &requestgen.ErrResponse{Response: resp, Body: resp.Body}
+}
+
+// newNonJSONErrResponse builds a *requestgen.ErrResponse with a non-JSON body.
+func newNonJSONErrResponse(t *testing.T, statusCode int) *requestgen.ErrResponse {
+	t.Helper()
+
+	resp, err := requestgen.NewResponse(httptesting.BuildResponseString(statusCode, "internal server error"))
+	assert.NoError(t, err)
+	return &requestgen.ErrResponse{Response: resp, Body: resp.Body}
+}
+
+func TestIsMaxNonceError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "2006 nonce already used", err: newMaxErrResponse(t, 400, 2006), want: true},
+		{name: "2007 invalid nonce", err: newMaxErrResponse(t, 400, 2007), want: true},
+		{name: "2016 amount too small", err: newMaxErrResponse(t, 400, 2016), want: false},
+		{name: "2018 can not lock fund", err: newMaxErrResponse(t, 400, 2018), want: false},
+		{name: "non-4xx status", err: newMaxErrResponse(t, 200, 2006), want: false},
+		{name: "non-JSON body", err: newNonJSONErrResponse(t, 500), want: false},
+		{name: "not an ErrResponse", err: io.EOF, want: false},
+		{name: "nil error", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isMaxNonceError(tt.err))
+		})
+	}
+}
+
+func TestRetryOnNonceError_RetriesThenSucceeds(t *testing.T) {
+	calls := 0
+	err := retryOnNonceError(context.Background(), func() error {
+		calls++
+		if calls == 1 {
+			return newMaxErrResponse(t, 400, 2006)
+		}
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, calls, "should retry once with a fresh nonce and then succeed")
+}
+
+func TestRetryOnNonceError_StopsOnOtherError(t *testing.T) {
+	t.Run("non-nonce max error", func(t *testing.T) {
+		calls := 0
+		nonNonceErr := newMaxErrResponse(t, 400, 2016)
+		err := retryOnNonceError(context.Background(), func() error {
+			calls++
+			return nonNonceErr
+		})
+
+		assert.ErrorIs(t, err, nonNonceErr)
+		assert.Equal(t, 1, calls, "non-nonce errors must not be retried")
+	})
+
+	t.Run("transport error", func(t *testing.T) {
+		calls := 0
+		err := retryOnNonceError(context.Background(), func() error {
+			calls++
+			return io.EOF
+		})
+
+		assert.ErrorIs(t, err, io.EOF)
+		assert.Equal(t, 1, calls, "non-nonce errors must not be retried")
+	})
+}


### PR DESCRIPTION
## Summary

Adds automatic retry logic with exponential backoff for MAX exchange order cancellation requests when encountering nonce-gate rejection errors.

## Changes

- **Nonce Error Handling (`pkg/exchange/max/nonce.go`)**:
  - Added `isMaxNonceError` to identify MAX API responses with error codes `2006` ("nonce has already been used") and `2007` ("invalid nonce").
  - Added `retryOnNonceError` to retry operations using exponential backoff (up to 3 retries within a 5-second timeout) when a nonce error occurs.
- **Order Cancellation Retry (`pkg/exchange/max/exchange.go`)**:
  - Wrapped both wallet/group order cancellation (`NewCancelWalletOrderAllRequest`) and individual order cancellation requests in `CancelOrders` with `retryOnNonceError`.
- **Unit Tests (`pkg/exchange/max/nonce_test.go`)**:
  - Added `TestIsMaxNonceError` covering nonce error codes (2006, 2007), non-nonce codes, non-4xx status, non-JSON responses, and non-HTTP errors.
  - Added `TestRetryOnNonceError_RetriesThenSucceeds` and `TestRetryOnNonceError_StopsOnOtherError` to verify retry behavior and error handling.
