### PR TITLE
FEATURE: [xfundingv2] add exit PnL ratio and consecutive negative funding closing conditions

### DIFF
--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -3,6 +3,7 @@ package xfundingv2
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -532,6 +533,25 @@ func (r *ArbitrageRound) MinHoldingIntervals(currentTime time.Time, spotPrice, f
 		)
 	}
 	return r.syncState.MinHoldingIntervals
+}
+
+func (r *ArbitrageRound) FundingRecordsDescending(limit int) []FundingFee {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var records []FundingFee
+	for _, record := range r.syncState.FundingFeeRecords {
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].Time.After(records[j].Time)
+	})
+
+	if limit < 0 || len(records) <= limit {
+		return records
+	}
+
+	return records[:limit]
 }
 
 // dynamicHoldingIntervals adjusts the min holding intervals based on the current total PnL

--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -670,15 +670,17 @@ func (n *roundNotification) SlackAttachment() slack.Attachment {
 		},
 	}...)
 
+	spotTarget := n.spotWorker.TargetPosition()
+	futuresTarget := n.futuresWorker.TargetPosition()
 	fields = append(fields, []slack.AttachmentField{
 		{
 			Title: "Spot Filled Position",
-			Value: fmt.Sprintf("%s@%s", n.spotWorker.FilledPosition().String(), spotAvgCost.String()),
+			Value: fmt.Sprintf("%s(%s)@%s", n.spotWorker.FilledPosition().String(), spotTarget.String(), spotAvgCost.String()),
 			Short: true,
 		},
 		{
 			Title: "Futures Filled Position",
-			Value: fmt.Sprintf("%s@%s", n.futuresWorker.FilledPosition().String(), futuresAvgCost.String()),
+			Value: fmt.Sprintf("%s(%s)@%s", n.futuresWorker.FilledPosition().String(), futuresTarget.String(), futuresAvgCost.String()),
 			Short: true,
 		},
 	}...)

--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -1687,6 +1687,8 @@ func (r *ArbitrageRound) Tick(ctx context.Context, currentTime time.Time, spotOr
 					"failed to tick %s spot worker at %s",
 					r.SpotSymbol(), currentTime.Format(time.RFC3339),
 				)
+		} else {
+			r.logger.Infof("spot worker ticked: %s", r.String())
 		}
 	}
 	if tickFutures {
@@ -1697,6 +1699,8 @@ func (r *ArbitrageRound) Tick(ctx context.Context, currentTime time.Time, spotOr
 					"failed to tick %s futures worker at %s",
 					r.FuturesSymbol(), currentTime.Format(time.RFC3339),
 				)
+		} else {
+			r.logger.Infof("futures worker ticked: %s", r.String())
 		}
 	}
 

--- a/pkg/strategy/xfundingv2/round_pnl.go
+++ b/pkg/strategy/xfundingv2/round_pnl.go
@@ -48,6 +48,10 @@ func (p *RoundRealizedPnL) TotalPnL() fixedpoint.Value {
 	)
 }
 
+func (p *RoundRealizedPnL) SpotNotional() fixedpoint.Value {
+	return p.SpotPosition.AverageCost.Mul(p.SpotPosition.Base).Abs()
+}
+
 func (r *ArbitrageRound) RealizedPnL() *RoundRealizedPnL {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/strategy/xfundingv2/round_record_test.go
+++ b/pkg/strategy/xfundingv2/round_record_test.go
@@ -206,6 +206,7 @@ func TestRoundInsertService_ActiveRoundSnapshot(t *testing.T) {
 			FuturesPnL:           fixedpoint.NewFromFloat(0.3),
 			FuturesNetPnL:        fixedpoint.NewFromFloat(0.1),
 			NetPnL:               fixedpoint.NewFromFloat(3.5),
+			StartedAt:            time.Now().Add(-24 * time.Hour),
 		},
 		SpotPosition:         fixedpoint.NewFromFloat(1.0),
 		FuturesPosition:      fixedpoint.NewFromFloat(-1.0),

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -81,9 +81,11 @@ type Strategy struct {
 
 	// round closing conditions
 	// TODO: move all the closing conditions into a separate struct
-	MaxClosingLossRatio fixedpoint.Value `json:"maxClosingLossRatio"`
-	MinExitRate         fixedpoint.Value `json:"minExitRate"`
-	HardMinExitRate     fixedpoint.Value `json:"hardMinExitRate"`
+	MaxClosingLossRatio              fixedpoint.Value `json:"maxClosingLossRatio"`
+	MinExitRate                      fixedpoint.Value `json:"minExitRate"`
+	HardMinExitRate                  fixedpoint.Value `json:"hardMinExitRate"`
+	ExitPnLRatio                     fixedpoint.Value `json:"exitPnLRatio"`
+	ConsecutiveNegFundingIncomeLimit int              `json:"consecutiveNegFundingIncomeLimit"`
 
 	// TickSymbol is the symbol used for ticking the strategy, default to the first candidate symbol
 	TickSymbol   string         `json:"tickSymbol"`
@@ -232,6 +234,14 @@ func (s *Strategy) Defaults() error {
 
 	if s.HardMinExitRate.IsZero() {
 		s.HardMinExitRate = s.MinExitRate.Div(fixedpoint.Two)
+	}
+
+	if s.ExitPnLRatio.IsZero() {
+		s.ExitPnLRatio = fixedpoint.NewFromFloat(0.0005) // 0.05%
+	}
+
+	if s.ConsecutiveNegFundingIncomeLimit == 0 {
+		s.ConsecutiveNegFundingIncomeLimit = 3
 	}
 
 	if s.TradeBalanceRatio.IsZero() {
@@ -1174,10 +1184,18 @@ func (s *Strategy) transitRound(ctx context.Context, round *ArbitrageRound, curr
 func (s *Strategy) transitOpeningOrReadyRoundToClosing(round *ArbitrageRound, index *types.PremiumIndex, currentTime time.Time) {
 	// if the current funding rate is still favorable, stay in current state, otherwise transit to closing
 	lastAnnualizedFundingRate := AnnualizedRate(index.LastFundingRate, round.syncState.FundingIntervalHours)
-	spotPrice, futuresPrice, _ := s.getLastPrices(
+	spotPrice, futuresPrice, pricesOk := s.getLastPrices(
 		round.SpotSymbol(),
 		round.FuturesSymbol(),
 	)
+
+	if !pricesOk {
+		s.logger.Warnf(
+			"[transitOpeningOrReadyRoundToClosing] failed to get last prices, skipping transit: %s",
+			round.String(),
+		)
+		return
+	}
 
 	withinMinHoldingTime := round.NumHoldingIntervals(currentTime) < round.MinHoldingIntervals(currentTime, spotPrice, futuresPrice)
 	if round.TriggeredFundingRate().Sign()*index.LastFundingRate.Sign() <= 0 {
@@ -1252,7 +1270,29 @@ func (s *Strategy) transitOpeningOrReadyRoundToClosing(round *ArbitrageRound, in
 			round.SetClosing(currentTime, s.TWAPWorkerConfig.ClosingDuration, futuresPrice)
 			return
 		}
-	} else if lastAnnualizedFundingRate.Abs().Compare(s.MinExitRate) <= 0 && !withinMinHoldingTime {
+	}
+
+	negFundingIncomeCnt := 0
+	for _, record := range round.FundingRecordsDescending(3) {
+		if record.Amount.Sign() < 0 {
+			negFundingIncomeCnt++
+		}
+	}
+	if negFundingIncomeCnt >= s.ConsecutiveNegFundingIncomeLimit {
+		bbgo.Notify(
+			"⚠️ Consecutive negative funding income detected (%s), transit state %s -> closing: %s",
+			negFundingIncomeCnt, round.State(), round.String(),
+			round.NewNotification(spotPrice, futuresPrice),
+		)
+		round.SetClosing(currentTime, s.TWAPWorkerConfig.ClosingDuration, futuresPrice)
+		return
+	}
+
+	if round.State() != RoundReady {
+		return
+	}
+
+	if lastAnnualizedFundingRate.Abs().Compare(s.MinExitRate) <= 0 && !withinMinHoldingTime {
 		// check hard min exit rate
 		if lastAnnualizedFundingRate.Abs().Compare(s.HardMinExitRate) <= 0 {
 			bbgo.Notify("⚠️ Last funding rate %s(annualized %s) is below the hard min exit rate %s, transit state %s -> closing: %s",
@@ -1263,10 +1303,12 @@ func (s *Strategy) transitOpeningOrReadyRoundToClosing(round *ArbitrageRound, in
 			return
 		}
 		// check min exit rate and total PnL
-		totalPnL := round.UnrealizedPnL(spotPrice, futuresPrice).TotalPnL()
-		if totalPnL.Sign() > 0 {
-			// the round is generating profit but the funding rate is below the min exit rate, transit to closing
-			bbgo.Notify("⚠️ Last funding rate %s(annualized %s) is below the min exit rate %s with total PnL %s, transit state %s -> closing: %s",
+		unrealizedPnL := round.UnrealizedPnL(spotPrice, futuresPrice)
+		spotNotional := unrealizedPnL.SpotNotional()
+		totalPnL := unrealizedPnL.TotalPnL()
+		if totalPnL.Sign() > 0 && totalPnL.Div(spotNotional).Compare(s.ExitPnLRatio) >= 0 {
+			// the round is generating profit but the funding rate is below the soft min exit rate, transit to closing
+			bbgo.Notify("⚠️ Last funding rate %s(annualized %s) is below the soft min exit rate %s with total PnL %s, transit state %s -> closing: %s",
 				index.LastFundingRate, lastAnnualizedFundingRate, s.MinExitRate, totalPnL, round.State(), round.String(),
 				round.NewNotification(spotPrice, futuresPrice),
 			)


### PR DESCRIPTION
## Summary
Adds enhanced exit conditions and safety guards to `xfundingv2` arbitrage rounds, including consecutive negative funding fee detection, a minimum PnL ratio threshold for soft exit rates, and price validation before state transitions.

## Key Changes

- **Consecutive Negative Funding Fee Exit**:
  - Added `ArbitrageRound.FundingRecordsDescending(limit)` to retrieve recent funding fee records sorted by time descending.
  - Added `ConsecutiveNegFundingIncomeLimit` (defaults to 3) to `Strategy`. Rounds automatically transition to closing if recent negative funding fee count reaches the limit.

- **Profit Ratio Threshold for Soft Min Exit Rate**:
  - Added `RoundRealizedPnL.SpotNotional()` to calculate total spot notional value (`AverageCost * Base.Abs()`).
  - Added `ExitPnLRatio` (defaults to 0.05%) to `Strategy`. When funding rate drops below `MinExitRate`, the round will only exit if `totalPnL / spotNotional >= ExitPnLRatio`.

- **Safety & State Transition Guards**:
  - Validates `pricesOk` from `getLastPrices` in `transitOpeningOrReadyRoundToClosing`; logs a warning and aborts transition if prices cannot be retrieved.
  - Added a state guard ensuring only rounds in `RoundReady` proceed to the min exit rate evaluations.

- **Tests**:
  - Updated `ActiveRoundSnapshot` test fixture in `round_record_test.go` with `StartedAt`.
