### PR TITLE
FEATURE: [xfundingv2] support removing active rounds on startup

### DIFF
--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -60,8 +60,13 @@ type Strategy struct {
 	// lock before update the strategy state, such as current round, selected market, etc
 	mu sync.Mutex
 
-	DryRun              bool `json:"dryRun"`
-	ClosingAllOnStartup bool `json:"closingAllOnStartup"`
+	DryRun                 bool     `json:"dryRun"`
+	ClosingAllOnStartup    bool     `json:"closingAllOnStartup"`
+	RemoveOnStartupSymbols []string `json:"removeOnStartupSymbols"`
+
+	// AppliedStartupRemovals records the symbols whose active rounds have already been
+	// removed on a previous startup for the current RemoveOnStartupSymbols config.
+	AppliedStartupRemovals map[string]struct{} `persistence:"appliedStartupRemovals"`
 
 	InstanceTag string `json:"instanceTag"`
 
@@ -414,6 +419,9 @@ func (s *Strategy) CrossRun(
 
 	// cleanup pending rounds on startup
 	s.PendingRounds = make(map[string]*PendingRound)
+
+	// remove the symbols that are configured to be removed on startup
+	s.removeRoundsOnStartup()
 
 	s.spotSession = sessions[s.SpotSession]
 	s.futuresSession = sessions[s.FuturesSession]
@@ -2110,4 +2118,51 @@ func (s *Strategy) closeDelistedRounds(currentTime time.Time) {
 		}
 	}
 
+}
+
+func (s *Strategy) removeRoundsOnStartup() {
+	if bbgo.IsBackTesting {
+		return
+	}
+	if s.AppliedStartupRemovals == nil {
+		s.AppliedStartupRemovals = make(map[string]struct{})
+	}
+
+	configured := make(map[string]struct{}, len(s.RemoveOnStartupSymbols))
+	for _, symbol := range s.RemoveOnStartupSymbols {
+		configured[symbol] = struct{}{}
+	}
+
+	// prune symbols that are no longer configured so that re-adding them later triggers
+	// the removal again. This is what removes the need for the two-step reset: to remove a
+	// round again (same or different symbol) the operator just edits RemoveOnStartupSymbols.
+	for symbol := range s.AppliedStartupRemovals {
+		if _, ok := configured[symbol]; !ok {
+			delete(s.AppliedStartupRemovals, symbol)
+		}
+	}
+
+	for _, symbol := range s.RemoveOnStartupSymbols {
+		// already removed on a previous startup with the same config; skip so we don't
+		// delete a round that was legitimately re-opened on the same symbol after removal.
+		if _, done := s.AppliedStartupRemovals[symbol]; done {
+			continue
+		}
+		// mark as handled regardless of whether an active round currently exists, so that
+		// a round opened later on the same symbol is not deleted on the next restart.
+		s.AppliedStartupRemovals[symbol] = struct{}{}
+
+		round, found := s.ActiveRounds[symbol]
+		if !found {
+			s.logger.Warnf("no active round found for symbol %s to remove on startup", symbol)
+			continue
+		}
+		s.logger.Warnf(
+			"removing active round on startup for symbol %s: %s",
+			symbol, round.String(),
+		)
+		delete(s.ActiveRounds, symbol)
+		delete(s.SpotPositions, round.SpotSymbol())
+		delete(s.FuturesPositions, round.FuturesSymbol())
+	}
 }

--- a/pkg/strategy/xfundingv2/strategy_test.go
+++ b/pkg/strategy/xfundingv2/strategy_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 
 	"github.com/c9s/bbgo/pkg/bbgo"
 	"github.com/c9s/bbgo/pkg/fixedpoint"
@@ -444,5 +445,107 @@ func TestSelectMostProfitableMarket(t *testing.T) {
 		assert.NotNil(t, result)
 		assert.Equal(t, "ETHUSDT", result.Symbol)
 		assert.Equal(t, 8, result.FundingIntervalHours)
+	})
+}
+
+func TestRemoveRoundsOnStartup(t *testing.T) {
+	// helper to build a strategy with the given active-round symbols populated.
+	newStrategyWithRounds := func(t *testing.T, ctrl *gomock.Controller, symbols ...string) *Strategy {
+		s := newDefaultTestStrategy()
+		s.ActiveRounds = make(map[string]*ArbitrageRound)
+		s.SpotPositions = make(map[string]*types.Position)
+		s.FuturesPositions = make(map[string]*types.Position)
+		nextFundingTime := time.Now().Add(time.Hour)
+		for _, symbol := range symbols {
+			round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+			s.ActiveRounds[symbol] = round
+			s.SpotPositions[symbol] = &types.Position{}
+			s.FuturesPositions[symbol] = &types.Position{}
+		}
+		return s
+	}
+
+	t.Run("removes configured active round once and records it", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		s := newStrategyWithRounds(t, ctrl, "BTCUSDT", "ETHUSDT")
+		s.RemoveOnStartupSymbols = []string{"BTCUSDT"}
+
+		s.removeRoundsOnStartup()
+
+		_, btcActive := s.ActiveRounds["BTCUSDT"]
+		assert.False(t, btcActive, "BTCUSDT round should be removed")
+		_, ethActive := s.ActiveRounds["ETHUSDT"]
+		assert.True(t, ethActive, "ETHUSDT round should be untouched")
+		_, btcSpot := s.SpotPositions["BTCUSDT"]
+		assert.False(t, btcSpot, "BTCUSDT spot position should be cleared")
+		_, btcFutures := s.FuturesPositions["BTCUSDT"]
+		assert.False(t, btcFutures, "BTCUSDT futures position should be cleared")
+		assert.Contains(t, s.AppliedStartupRemovals, "BTCUSDT")
+	})
+
+	t.Run("does not delete a re-opened round on subsequent startup", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// first startup removes BTCUSDT and records it in the persisted set.
+		s := newStrategyWithRounds(t, ctrl, "BTCUSDT")
+		s.RemoveOnStartupSymbols = []string{"BTCUSDT"}
+		s.removeRoundsOnStartup()
+
+		// simulate a restart: the persisted set survives, and a new BTCUSDT round was
+		// legitimately opened again while running (still configured for removal).
+		newRound, _ := newTestArbitrageRound(t, ctrl, 8, 3, time.Now().Add(time.Hour))
+		s.ActiveRounds["BTCUSDT"] = newRound
+		s.removeRoundsOnStartup()
+
+		_, btcActive := s.ActiveRounds["BTCUSDT"]
+		assert.True(t, btcActive, "re-opened BTCUSDT round must be preserved on restart")
+	})
+
+	t.Run("re-adding a symbol after config change triggers removal again", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// startup 1: remove BTCUSDT.
+		s := newStrategyWithRounds(t, ctrl, "BTCUSDT")
+		s.RemoveOnStartupSymbols = []string{"BTCUSDT"}
+		s.removeRoundsOnStartup()
+		assert.Contains(t, s.AppliedStartupRemovals, "BTCUSDT")
+
+		// startup 2: operator drops BTCUSDT from config -> it is pruned from the set,
+		// so no two-step "empty config" restart is required.
+		s.RemoveOnStartupSymbols = nil
+		s.removeRoundsOnStartup()
+		assert.NotContains(t, s.AppliedStartupRemovals, "BTCUSDT")
+
+		// startup 3: operator re-adds BTCUSDT (a new round exists again) -> removed again.
+		newRound, _ := newTestArbitrageRound(t, ctrl, 8, 3, time.Now().Add(time.Hour))
+		s.ActiveRounds["BTCUSDT"] = newRound
+		s.RemoveOnStartupSymbols = []string{"BTCUSDT"}
+		s.removeRoundsOnStartup()
+		_, btcActive := s.ActiveRounds["BTCUSDT"]
+		assert.False(t, btcActive, "BTCUSDT round should be removed again after re-adding to config")
+	})
+
+	t.Run("switching to a different symbol removes only the new one", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		s := newStrategyWithRounds(t, ctrl, "BTCUSDT", "ETHUSDT")
+
+		// startup 1: remove BTCUSDT.
+		s.RemoveOnStartupSymbols = []string{"BTCUSDT"}
+		s.removeRoundsOnStartup()
+
+		// startup 2: switch config directly to ETHUSDT -> BTCUSDT pruned, ETHUSDT removed.
+		s.RemoveOnStartupSymbols = []string{"ETHUSDT"}
+		s.removeRoundsOnStartup()
+
+		_, ethActive := s.ActiveRounds["ETHUSDT"]
+		assert.False(t, ethActive, "ETHUSDT round should be removed after switching config")
+		assert.Contains(t, s.AppliedStartupRemovals, "ETHUSDT")
+		assert.NotContains(t, s.AppliedStartupRemovals, "BTCUSDT")
 	})
 }


### PR DESCRIPTION
### Summary of Changes

* **Configurable Startup Round Removal**: Added `RemoveOnStartupSymbols []string` to `Strategy`, allowing operators to specify active rounds and associated spot/futures positions to be removed during startup.
* **Persisted Removal Tracking**: Introduced `AppliedStartupRemovals map[string]struct{}` (persisted state) to record processed removals, preventing newly re-opened rounds for the same symbol from being accidentally deleted on subsequent restarts.
* **Dynamic Pruning & Re-triggering**: Startup cleanup logic automatically prunes removed entries that are omitted from `RemoveOnStartupSymbols`, allowing operators to re-trigger removal simply by updating the configuration without needing a multi-step reset.
* **Lifecycle Integration**: Hooked `removeRoundsOnStartup()` into `CrossRun` to execute during initialization (skipped during backtesting).
* **Unit Tests**: Added `TestRemoveRoundsOnStartup` covering single-execution removal, preservation of re-opened rounds across restarts, config updates/re-additions, and symbol switching.
