### PR TITLE
TEST: redesign order book benchmarks + tune skiplist levels

### DIFF
--- a/pkg/types/orderbook_test.go
+++ b/pkg/types/orderbook_test.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"math/rand"
+	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,120 +11,221 @@ import (
 	"github.com/c9s/bbgo/pkg/fixedpoint"
 )
 
-func prepareOrderBookBenchmarkData() (asks, bids PriceVolumeSlice) {
-	for p := 0.0; p < 1000.0; p++ {
-		asks = append(asks, PriceVolume{fixedpoint.NewFromFloat(1000 + p), fixedpoint.One})
-		bids = append(bids, PriceVolume{fixedpoint.NewFromFloat(1000 - 0.1 - p), fixedpoint.One})
-	}
-	return
+// orderBookBackend names an OrderBook implementation and how to construct an empty one,
+// so every benchmark below can run the identical workload against all three backends.
+type orderBookBackend struct {
+	name string
+	new  func(symbol string) OrderBook
 }
 
+var orderBookBackends = []orderBookBackend{
+	{"SliceOrderBook", func(symbol string) OrderBook { return NewSliceOrderBook(symbol) }},
+	{"RBTOrderBook", func(symbol string) OrderBook { return NewRBOrderBook(symbol) }},
+	{"SkipListOrderBook", func(symbol string) OrderBook { return NewSkipListOrderBook(symbol) }},
+}
+
+// orderBookDepths are the book sizes (price levels per side) the benchmarks run at.
+// Real books on liquid pairs sit in the thousands of levels, so the small-book case is
+// kept only as a baseline for comparison against the large ones.
+var orderBookDepths = []int{1000, 5000, 8000}
+
+const benchmarkMidPrice = 30000.0
+
+// benchmarkTick is the price increment between two adjacent levels. At 8000 levels per
+// side this spans 80 price units around the mid price, which is a realistic tick density.
+const benchmarkTick = 0.01
+
+// makeOrderBookSnapshot builds a full book snapshot with the given number of price levels
+// per side. Bids descend from just below the mid price and asks ascend from just above it,
+// which is the order both the slice and the tree backends expect from a snapshot.
+func makeOrderBookSnapshot(symbol string, levels int) SliceOrderBook {
+	book := SliceOrderBook{
+		Symbol: symbol,
+		Bids:   make(PriceVolumeSlice, 0, levels),
+		Asks:   make(PriceVolumeSlice, 0, levels),
+	}
+
+	for i := 0; i < levels; i++ {
+		offset := float64(i) * benchmarkTick
+		book.Bids = append(book.Bids, PriceVolume{
+			Price:  fixedpoint.NewFromFloat(benchmarkMidPrice - benchmarkTick - offset),
+			Volume: fixedpoint.One,
+		})
+		book.Asks = append(book.Asks, PriceVolume{
+			Price:  fixedpoint.NewFromFloat(benchmarkMidPrice + benchmarkTick + offset),
+			Volume: fixedpoint.One,
+		})
+	}
+
+	return book
+}
+
+// benchmarkDeltaLevels is the number of price levels touched by a single incremental
+// update, roughly the size of one websocket diff message.
+const benchmarkDeltaLevels = 20
+
+// benchmarkDeltaBatches is how many distinct pre-generated update batches are cycled
+// through, so the benchmark does not repeat the exact same write over and over.
+const benchmarkDeltaBatches = 64
+
+// makeVolumeDeltas pre-generates update batches that only change the volume of existing
+// price levels. The book size never changes, so the measurement stays stable no matter
+// how many iterations the benchmark runs.
+func makeVolumeDeltas(symbol string, snapshot SliceOrderBook) []SliceOrderBook {
+	rnd := rand.New(rand.NewSource(1))
+	levels := len(snapshot.Bids)
+
+	deltas := make([]SliceOrderBook, 0, benchmarkDeltaBatches)
+	for i := 0; i < benchmarkDeltaBatches; i++ {
+		delta := SliceOrderBook{
+			Symbol: symbol,
+			Bids:   make(PriceVolumeSlice, 0, benchmarkDeltaLevels),
+			Asks:   make(PriceVolumeSlice, 0, benchmarkDeltaLevels),
+		}
+
+		for j := 0; j < benchmarkDeltaLevels; j++ {
+			// bias towards the top of the book, which is where real updates cluster
+			idx := rnd.Intn(levels) * rnd.Intn(levels) / levels
+			volume := fixedpoint.NewFromFloat(1 + rnd.Float64())
+			delta.Bids = append(delta.Bids, PriceVolume{Price: snapshot.Bids[idx].Price, Volume: volume})
+			delta.Asks = append(delta.Asks, PriceVolume{Price: snapshot.Asks[idx].Price, Volume: volume})
+		}
+
+		// a delta is applied in book order by every backend, so sort it the same way
+		sort.Slice(delta.Bids, func(a, b int) bool { return delta.Bids[a].Price.Compare(delta.Bids[b].Price) > 0 })
+		sort.Slice(delta.Asks, func(a, b int) bool { return delta.Asks[a].Price.Compare(delta.Asks[b].Price) < 0 })
+		deltas = append(deltas, delta)
+	}
+
+	return deltas
+}
+
+// makeChurnDeltas pre-generates update batches that delete price levels and then put them
+// back. Batches alternate between a delete pass (zero volume) and the matching restore
+// pass, so the book oscillates between two sizes instead of growing or draining without
+// bound over the course of the benchmark.
+func makeChurnDeltas(symbol string, snapshot SliceOrderBook) []SliceOrderBook {
+	rnd := rand.New(rand.NewSource(2))
+	levels := len(snapshot.Bids)
+
+	deltas := make([]SliceOrderBook, 0, benchmarkDeltaBatches)
+	for i := 0; i < benchmarkDeltaBatches; i += 2 {
+		remove := SliceOrderBook{
+			Symbol: symbol,
+			Bids:   make(PriceVolumeSlice, 0, benchmarkDeltaLevels),
+			Asks:   make(PriceVolumeSlice, 0, benchmarkDeltaLevels),
+		}
+		restore := SliceOrderBook{
+			Symbol: symbol,
+			Bids:   make(PriceVolumeSlice, 0, benchmarkDeltaLevels),
+			Asks:   make(PriceVolumeSlice, 0, benchmarkDeltaLevels),
+		}
+
+		for j := 0; j < benchmarkDeltaLevels; j++ {
+			idx := rnd.Intn(levels)
+			bid, ask := snapshot.Bids[idx], snapshot.Asks[idx]
+			remove.Bids = append(remove.Bids, PriceVolume{Price: bid.Price, Volume: fixedpoint.Zero})
+			remove.Asks = append(remove.Asks, PriceVolume{Price: ask.Price, Volume: fixedpoint.Zero})
+			restore.Bids = append(restore.Bids, bid)
+			restore.Asks = append(restore.Asks, ask)
+		}
+
+		deltas = append(deltas, remove, restore)
+	}
+
+	return deltas
+}
+
+// benchmarkBackends runs fn against every backend at every configured depth, naming the
+// sub-benchmarks "<Backend>/<levels>" so the results group per implementation.
+func benchmarkBackends(b *testing.B, fn func(b *testing.B, backend orderBookBackend, snapshot SliceOrderBook)) {
+	b.Helper()
+
+	for _, backend := range orderBookBackends {
+		b.Run(backend.name, func(b *testing.B) {
+			for _, levels := range orderBookDepths {
+				snapshot := makeOrderBookSnapshot("BTCUSDT", levels)
+				b.Run(strconv.Itoa(levels), func(b *testing.B) {
+					fn(b, backend, snapshot)
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkOrderBook_Load measures loading a full snapshot into an empty book, which is
+// what happens on every stream (re)connect.
 func BenchmarkOrderBook_Load(b *testing.B) {
-	var asks, bids = prepareOrderBookBenchmarkData()
-	for p := 0.0; p < 1000.0; p++ {
-		asks = append(asks, PriceVolume{fixedpoint.NewFromFloat(1000 + p), fixedpoint.One})
-		bids = append(bids, PriceVolume{fixedpoint.NewFromFloat(1000 - 0.1 - p), fixedpoint.One})
-	}
-
-	b.Run("RBTOrderBook", func(b *testing.B) {
-		book := NewRBOrderBook("ETHUSDT")
+	benchmarkBackends(b, func(b *testing.B, backend orderBookBackend, snapshot SliceOrderBook) {
+		book := backend.new(snapshot.Symbol)
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			for _, ask := range asks {
-				book.Asks.Upsert(ask.Price, ask.Volume)
-			}
-			for _, bid := range bids {
-				book.Bids.Upsert(bid.Price, bid.Volume)
-			}
-		}
-	})
-
-	b.Run("SkipListOrderBook", func(b *testing.B) {
-		book := NewSkipListOrderBook("ETHUSDT")
-		for i := 0; i < b.N; i++ {
-			for _, ask := range asks {
-				book.Asks.Set(ask.Price, ask.Volume)
-			}
-			for _, bid := range bids {
-				book.Bids.Set(bid.Price, bid.Volume)
-			}
-		}
-	})
-
-	b.Run("OrderBook", func(b *testing.B) {
-		book := &SliceOrderBook{}
-		for i := 0; i < b.N; i++ {
-			for _, ask := range asks {
-				book.Asks = book.Asks.Upsert(ask, false)
-			}
-			for _, bid := range bids {
-				book.Bids = book.Bids.Upsert(bid, true)
-			}
+			book.Load(snapshot)
 		}
 	})
 }
 
-func BenchmarkOrderBook_UpdateAndInsert(b *testing.B) {
-	var asks, bids = prepareOrderBookBenchmarkData()
-	for p := 0.0; p < 1000.0; p += 2 {
-		asks = append(asks, PriceVolume{fixedpoint.NewFromFloat(1000 + p), fixedpoint.One})
-		bids = append(bids, PriceVolume{fixedpoint.NewFromFloat(1000 - 0.1 - p), fixedpoint.One})
-	}
+// BenchmarkOrderBook_UpdateVolume measures applying an incremental update that only
+// changes the volume of existing price levels. This is the hot path: it runs on every
+// websocket diff message.
+func BenchmarkOrderBook_UpdateVolume(b *testing.B) {
+	benchmarkBackends(b, func(b *testing.B, backend orderBookBackend, snapshot SliceOrderBook) {
+		deltas := makeVolumeDeltas(snapshot.Symbol, snapshot)
+		book := backend.new(snapshot.Symbol)
+		book.Load(snapshot)
 
-	rbBook := NewRBOrderBook("ETHUSDT")
-	for _, ask := range asks {
-		rbBook.Asks.Upsert(ask.Price, ask.Volume)
-	}
-	for _, bid := range bids {
-		rbBook.Bids.Upsert(bid.Price, bid.Volume)
-	}
-
-	b.Run("RBTOrderBook", func(b *testing.B) {
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			var price = fixedpoint.NewFromFloat(rand.Float64() * 2000.0)
-			if price.Compare(fixedpoint.NewFromInt(1000)) >= 0 {
-				rbBook.Asks.Upsert(price, fixedpoint.One)
-			} else {
-				rbBook.Bids.Upsert(price, fixedpoint.One)
-			}
+			book.Update(deltas[i%len(deltas)])
 		}
 	})
+}
 
-	slBook := NewSkipListOrderBook("ETHUSDT")
-	for _, ask := range asks {
-		slBook.Asks.Set(ask.Price, ask.Volume)
-	}
-	for _, bid := range bids {
-		slBook.Bids.Set(bid.Price, bid.Volume)
-	}
+// BenchmarkOrderBook_UpdateChurn measures applying an incremental update that removes and
+// re-adds price levels, so the backend pays for structural changes rather than in-place
+// volume writes.
+func BenchmarkOrderBook_UpdateChurn(b *testing.B) {
+	benchmarkBackends(b, func(b *testing.B, backend orderBookBackend, snapshot SliceOrderBook) {
+		deltas := makeChurnDeltas(snapshot.Symbol, snapshot)
+		book := backend.new(snapshot.Symbol)
+		book.Load(snapshot)
 
-	b.Run("SkipListOrderBook", func(b *testing.B) {
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			var price = fixedpoint.NewFromFloat(rand.Float64() * 2000.0)
-			if price.Compare(fixedpoint.NewFromInt(1000)) >= 0 {
-				slBook.Asks.Set(price, fixedpoint.One)
-			} else {
-				slBook.Bids.Set(price, fixedpoint.One)
-			}
+			book.Update(deltas[i%len(deltas)])
 		}
 	})
+}
 
-	sliceBook := &SliceOrderBook{}
-	for i := 0; i < b.N; i++ {
-		for _, ask := range asks {
-			sliceBook.Asks = sliceBook.Asks.Upsert(ask, false)
-		}
-		for _, bid := range bids {
-			sliceBook.Bids = sliceBook.Bids.Upsert(bid, true)
-		}
-	}
-	b.Run("OrderBook", func(b *testing.B) {
+// BenchmarkOrderBook_BestBidAsk measures reading the top of the book, which strategies do
+// far more often than they write.
+func BenchmarkOrderBook_BestBidAsk(b *testing.B) {
+	benchmarkBackends(b, func(b *testing.B, backend orderBookBackend, snapshot SliceOrderBook) {
+		book := backend.new(snapshot.Symbol)
+		book.Load(snapshot)
+
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			var price = fixedpoint.NewFromFloat(rand.Float64() * 2000.0)
-			if price.Compare(fixedpoint.NewFromFloat(1000)) >= 0 {
-				sliceBook.Asks = sliceBook.Asks.Upsert(PriceVolume{Price: price, Volume: fixedpoint.NewFromFloat(1)}, false)
-			} else {
-				sliceBook.Bids = sliceBook.Bids.Upsert(PriceVolume{Price: price, Volume: fixedpoint.NewFromFloat(1)}, true)
-			}
+			book.BestBid()
+			book.BestAsk()
+		}
+	})
+}
+
+// BenchmarkOrderBook_CopyDepth measures materializing the top 20 levels of both sides,
+// which is what a strategy does when it needs a stable view of the book.
+//
+// Note this uses CopyDepth rather than SideBook: SliceOrderBook.SideBook hands back its
+// backing slice without copying or truncating, so comparing it against the tree backends
+// (which materialize a bounded slice) would not measure the same work.
+func BenchmarkOrderBook_CopyDepth(b *testing.B) {
+	benchmarkBackends(b, func(b *testing.B, backend orderBookBackend, snapshot SliceOrderBook) {
+		book := backend.new(snapshot.Symbol)
+		book.Load(snapshot)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			book.CopyDepth(20)
 		}
 	})
 }

--- a/pkg/types/skiplist/skiplist.go
+++ b/pkg/types/skiplist/skiplist.go
@@ -104,6 +104,10 @@ func (sl *SkipList[K, V]) Seed(seed int64) {
 // Len returns the number of elements in the skip list.
 func (sl *SkipList[K, V]) Len() int { return sl.length }
 
+// MaxLevel returns the maximum node height this skip list was configured with, which is
+// the number of segment lengths given to New.
+func (sl *SkipList[K, V]) MaxLevel() int { return sl.maxLevel }
+
 // Get finds and returns the Value associated with Key.
 func (sl *SkipList[K, V]) Get(key K) (V, bool) {
 	x := sl.head

--- a/pkg/types/skiplistorderbook.go
+++ b/pkg/types/skiplistorderbook.go
@@ -137,15 +137,17 @@ func (b *SkipListOrderBook) update(book SliceOrderBook) {
 	b.lastUpdateTime = time.Now()
 }
 
-func copySkipList(src *priceLevelSkipList, cmp skiplist.Comparator[fixedpoint.Value], limit int) *priceLevelSkipList {
-	dst := skiplist.New[fixedpoint.Value, fixedpoint.Value](cmp)
+// copySkipListInto copies up to limit entries from src into dst in src's own order.
+// A limit <= 0 copies everything. dst is written into rather than allocated here because
+// constructing a skip list is expensive (it seeds its own rand source), so the lists the
+// constructor already built are reused instead of being thrown away.
+func copySkipListInto(dst, src *priceLevelSkipList, limit int) {
 	n := 0
 	src.Ascend(func(price, volume fixedpoint.Value) bool {
 		dst.Set(price, volume)
 		n++
 		return !(limit > 0 && n >= limit)
 	})
-	return dst
 }
 
 func (b *SkipListOrderBook) Copy() OrderBook {
@@ -154,8 +156,8 @@ func (b *SkipListOrderBook) Copy() OrderBook {
 
 func (b *SkipListOrderBook) CopyDepth(limit int) OrderBook {
 	book := NewSkipListOrderBook(b.Symbol)
-	book.Bids = copySkipList(b.Bids, priceDescending, limit)
-	book.Asks = copySkipList(b.Asks, priceAscending, limit)
+	copySkipListInto(book.Bids, b.Bids, limit)
+	copySkipListInto(book.Asks, b.Asks, limit)
 	book.lastUpdateTime = b.lastUpdateTime
 	return book
 }

--- a/pkg/types/skiplistorderbook.go
+++ b/pkg/types/skiplistorderbook.go
@@ -12,6 +12,28 @@ import (
 
 const defaultSkipListSideBookLimit = 200
 
+// The skip list defaults (32 levels, promote with probability 1/2) are sized for lists of
+// billions of entries, while an order book side holds thousands. That oversizing is not
+// free: every Set and Delete allocates an update slice of maxLevel node pointers, so
+// maxLevel multiplies the cost of the websocket update path.
+//
+// These values address roughly 4^10 (~1M) price levels, which leaves ample headroom over
+// the deepest books we see, and measurably cut both time and allocation per update
+// compared to the package defaults. See BenchmarkOrderBook_UpdateVolume.
+const (
+	defaultSkipListMaxLevel      = 10
+	defaultSkipListSegmentLength = 4
+)
+
+func defaultSkipListSegmentLengths() []int {
+	segLens := make([]int, defaultSkipListMaxLevel)
+	for i := range segLens {
+		segLens[i] = defaultSkipListSegmentLength
+	}
+
+	return segLens
+}
+
 type priceLevelSkipList = skiplist.SkipList[fixedpoint.Value, fixedpoint.Value]
 
 // priceAscending orders prices from low to high, which is the natural order of the ask side.
@@ -34,17 +56,44 @@ type SkipListOrderBook struct {
 	Bids   *priceLevelSkipList
 	Asks   *priceLevelSkipList
 
+	// segLens is kept so that Reset and CopyDepth rebuild the sides with the same shape
+	// the book was created with, instead of silently falling back to the package defaults
+	// on every snapshot load and stream reconnect.
+	segLens []int
+
 	lastUpdateTime time.Time
 
 	loadCallbacks   []func(book *SkipListOrderBook)
 	updateCallbacks []func(book *SkipListOrderBook)
 }
 
+// newPriceLevelSkipList builds one side of the book. It hands skiplist.New its own copy of
+// segLens because New sanitizes the slice in place and then retains it.
+func newPriceLevelSkipList(cmp skiplist.Comparator[fixedpoint.Value], segLens []int) *priceLevelSkipList {
+	return skiplist.New[fixedpoint.Value, fixedpoint.Value](cmp, append([]int(nil), segLens...)...)
+}
+
 func NewSkipListOrderBook(symbol string) *SkipListOrderBook {
+	return NewSkipListOrderBookWithSegmentLengths(symbol, defaultSkipListSegmentLengths())
+}
+
+// NewSkipListOrderBookWithSegmentLengths creates a book whose sides use the given per-level
+// segment lengths, which control the maximum height of the skip list and the promotion
+// probability at each level. It exists for tests and benchmarks that compare shapes; normal
+// callers should use NewSkipListOrderBook and get the tuned defaults. An empty segLens
+// falls back to those defaults.
+func NewSkipListOrderBookWithSegmentLengths(symbol string, segLens []int) *SkipListOrderBook {
+	if len(segLens) == 0 {
+		segLens = defaultSkipListSegmentLengths()
+	} else {
+		segLens = append([]int(nil), segLens...)
+	}
+
 	return &SkipListOrderBook{
-		Symbol: symbol,
-		Bids:   skiplist.New[fixedpoint.Value, fixedpoint.Value](priceDescending),
-		Asks:   skiplist.New[fixedpoint.Value, fixedpoint.Value](priceAscending),
+		Symbol:  symbol,
+		Bids:    newPriceLevelSkipList(priceDescending, segLens),
+		Asks:    newPriceLevelSkipList(priceAscending, segLens),
+		segLens: segLens,
 	}
 }
 
@@ -117,8 +166,12 @@ func (b *SkipListOrderBook) Update(book SliceOrderBook) {
 }
 
 func (b *SkipListOrderBook) Reset() {
-	b.Bids = skiplist.New[fixedpoint.Value, fixedpoint.Value](priceDescending)
-	b.Asks = skiplist.New[fixedpoint.Value, fixedpoint.Value](priceAscending)
+	if len(b.segLens) == 0 {
+		b.segLens = defaultSkipListSegmentLengths()
+	}
+
+	b.Bids = newPriceLevelSkipList(priceDescending, b.segLens)
+	b.Asks = newPriceLevelSkipList(priceAscending, b.segLens)
 }
 
 func updateSkipListSide(sl *priceLevelSkipList, pvs PriceVolumeSlice) {
@@ -155,7 +208,7 @@ func (b *SkipListOrderBook) Copy() OrderBook {
 }
 
 func (b *SkipListOrderBook) CopyDepth(limit int) OrderBook {
-	book := NewSkipListOrderBook(b.Symbol)
+	book := NewSkipListOrderBookWithSegmentLengths(b.Symbol, b.segLens)
 	copySkipListInto(book.Bids, b.Bids, limit)
 	copySkipListInto(book.Asks, b.Asks, limit)
 	book.lastUpdateTime = b.lastUpdateTime

--- a/pkg/types/skiplistorderbook_test.go
+++ b/pkg/types/skiplistorderbook_test.go
@@ -164,3 +164,76 @@ func TestNewMutexOrderBook_SkipListBackend(t *testing.T) {
 	book := NewMutexOrderBook("BTCUSDT", ExchangeBinance)
 	assert.IsType(t, &SkipListOrderBook{}, book.orderBook)
 }
+
+func TestSkipListOrderBook_ResetPreservesSegmentLengths(t *testing.T) {
+	segLens := []int{2, 2, 2}
+	book := NewSkipListOrderBookWithSegmentLengths("BTCUSDT", segLens)
+
+	// Load resets both sides, which must not fall back to the package defaults
+	book.Load(SliceOrderBook{
+		Symbol: "BTCUSDT",
+		Bids:   pvSlice(2800, 1),
+		Asks:   pvSlice(2810, 1),
+	})
+	assert.Equal(t, segLens, book.segLens)
+	assert.Equal(t, 3, book.Bids.MaxLevel())
+	assert.Equal(t, 3, book.Asks.MaxLevel())
+
+	book.Reset()
+	assert.Equal(t, 3, book.Bids.MaxLevel())
+	assert.Equal(t, 3, book.Asks.MaxLevel())
+}
+
+func TestSkipListOrderBook_CopyPreservesSegmentLengths(t *testing.T) {
+	book := NewSkipListOrderBookWithSegmentLengths("BTCUSDT", []int{2, 2, 2})
+	book.Load(SliceOrderBook{
+		Symbol: "BTCUSDT",
+		Bids:   pvSlice(2800, 1, 2790, 2),
+		Asks:   pvSlice(2810, 1, 2820, 2),
+	})
+
+	c := book.CopyDepth(1).(*SkipListOrderBook)
+	assert.Equal(t, 3, c.Bids.MaxLevel())
+	assert.Equal(t, 3, c.Asks.MaxLevel())
+}
+
+func TestSkipListOrderBook_DefaultSegmentLengths(t *testing.T) {
+	book := NewSkipListOrderBook("BTCUSDT")
+	assert.Equal(t, defaultSkipListMaxLevel, book.Bids.MaxLevel())
+	assert.Equal(t, defaultSkipListMaxLevel, book.Asks.MaxLevel())
+
+	// the caller's slice must not be retained or mutated by the constructor
+	segLens := []int{1, 1}
+	custom := NewSkipListOrderBookWithSegmentLengths("BTCUSDT", segLens)
+	assert.Equal(t, []int{1, 1}, segLens, "constructor must not mutate the caller's slice")
+	assert.Equal(t, 2, custom.Bids.MaxLevel())
+
+	// an empty segLens falls back to the tuned defaults rather than an unusable book
+	fallback := NewSkipListOrderBookWithSegmentLengths("BTCUSDT", nil)
+	assert.Equal(t, defaultSkipListMaxLevel, fallback.Bids.MaxLevel())
+}
+
+// a book built with the tuned defaults must behave identically to one built with the
+// skiplist package defaults, at a depth well past what a real book reaches
+func TestSkipListOrderBook_SegmentLengthsDoNotChangeOrdering(t *testing.T) {
+	snapshot := makeOrderBookSnapshot("BTCUSDT", 8000)
+
+	ref := NewSkipListOrderBookWithSegmentLengths("BTCUSDT", segmentLengthsForTest(32, 2))
+	ref.Load(snapshot)
+
+	book := NewSkipListOrderBook("BTCUSDT")
+	book.Load(snapshot)
+
+	assert.Equal(t, 8000, book.Bids.Len())
+	assert.Equal(t, 8000, book.Asks.Len())
+	assert.Equal(t, ref.SideBook(SideTypeBuy), book.SideBook(SideTypeBuy))
+	assert.Equal(t, ref.SideBook(SideTypeSell), book.SideBook(SideTypeSell))
+}
+
+func segmentLengthsForTest(maxLevel, seg int) []int {
+	segLens := make([]int, maxLevel)
+	for i := range segLens {
+		segLens[i] = seg
+	}
+	return segLens
+}


### PR DESCRIPTION
Follow-up to #2639, which merged the `SkipListOrderBook` backend itself. These two commits landed on the branch after that merge, so they need their own PR.

## 1. Redesign the order book benchmarks for large books

The existing benchmarks only exercised ~1–2k price levels, reached into each backend's internals (`book.Asks.Upsert`) rather than going through the `OrderBook` interface, and built the slice book inside a `b.N` loop placed *outside* any sub-benchmark — so that work was neither timed nor meaningful.

They are now a table over all three backends × {1000, 5000, 8000} levels per side, driven entirely through the `OrderBook` interface so the workload is identical:

| Benchmark | What it measures |
| --- | --- |
| `Load` | full snapshot into an empty book (stream reconnect) |
| `UpdateVolume` | volume-only diff — the websocket hot path |
| `UpdateChurn` | diff that deletes and re-adds price levels |
| `BestBidAsk` | top-of-book read |
| `CopyDepth` | materialize the top 20 levels of both sides |

Update batches are pre-generated from a fixed seed and cycled, and churn batches alternate delete/restore so book size stays bounded rather than draining over a long run. Verified all three backends hold 5000 levels with identical top-of-book across the whole workload.

`CopyDepth` is used rather than `SideBook` because `SliceOrderBook.SideBook` returns its backing slice without copying or truncating, so it would not measure the same work as the tree backends.

**What the larger scale makes visible:** `SliceOrderBook` degrades badly on structural churn — 162 µs and 1.35 MB per diff at 8000 levels, because each insert/remove is an O(n) slice memmove. Both tree backends are flat in book size there. That is the case the alternate backends exist for.

## 2. Tune the skiplist level configuration

`NewSkipListOrderBook` was taking the skiplist package defaults: 32 levels, promotion probability ½. Those are sized for lists of billions of entries, while an order book side holds thousands — and the oversizing is not free, because `Set`/`Delete` each allocate an update slice of `maxLevel` node pointers, making `maxLevel` a direct multiplier on the websocket update path.

Defaulting to **10 levels, segment length 4** still addresses ~4¹⁰ ≈ 1M price levels (ample headroom over the deepest books) and measures better on every write path at 8000 levels/side:

| | before | after |
| --- | --- | --- |
| `UpdateVolume` | 7680 ns / 10240 B | **5261 ns / 3200 B** |
| `UpdateChurn` | 11633 ns / 11524 B | **7278 ns / 4372 B** |
| `Load` | 2745 µs / 5.15 MB | **1905 µs / 2.23 MB** |
| `CopyDepth(20)` | 22387 ns / 25052 B | **19922 ns / 17179 B** |

Read paths are unaffected — `BestBid`/`BestAsk` are head lookups and the depth walk is at level 0, neither of which depends on list height. I measured 13 levels/p½ as roughly comparable, but rejected it: 2¹³ = 8192 sits right on top of the 8000-level case, so a deeper book would degrade toward linear scan. Over-provisioning height is cheap in a way that under-provisioning is not.

**A correctness fix rides along:** `Reset()` rebuilt both sides from the package defaults, so any non-default shape was silently discarded on every snapshot load and stream reconnect. The segment lengths now live on the book and are read by `Reset`; `CopyDepth` propagates them to the copy for the same reason.

Deliberately **not** exposed as a YAML or env knob — the right value follows from book depth rather than operator preference, and a wrong value degrades silently instead of erroring. `NewSkipListOrderBookWithSegmentLengths` exists for tests and benchmarks. Backend *selection* stays on `ENABLE_SKIPLIST_ORDERBOOK`, matching the existing `ENABLE_RBT_ORDERBOOK` pattern.

Also adds `SkipList.MaxLevel()`, a read-only accessor so tests can assert the configured shape actually reaches the list.

## Remaining gap (not addressed here)

Tuning takes the skiplist from ~7× to ~5× slower than the RB tree on writes. The rest is structural and lives in `pkg/types/skiplist`: the per-op update-slice allocation (a reusable scratch buffer would take it to zero allocs, as the RB tree already is) and the ~7 µs `rand.NewSource` seeding per `New`, which dominates `CopyDepth`. Configuration alone will not make this backend win on writes.

## Test plan

- New tests cover `Reset` and `CopyDepth` preserving segment lengths, the constructor not retaining or mutating the caller's slice, empty-`segLens` fallback, and that a tuned book produces byte-identical ordering to a package-default one at 8000 levels.
- `go test ./pkg/types/...` passes. Under `-tags dnum` the only failure is `TestMarket_AdjustQuantityToContractSize`, which fails on `main` as well and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnM8vX1cw1n4eVwkeg9W7x