### PR TITLE
FIX: [bbgo] handle JumpIfEmpty when no records are sent in batch query

### DIFF
--- a/pkg/exchange/batch/time_range_query.go
+++ b/pkg/exchange/batch/time_range_query.go
@@ -144,6 +144,12 @@ func (q *AsyncTimeRangedBatchQuery) Query(ctx context.Context, ch interface{}, s
 
 			if !sentAny {
 				log.Debugf("batch querying %T: %d/%d records are not sent", q.Type, listLen, listLen)
+				if q.JumpIfEmpty > 0 {
+					startTime = startTime.Add(q.JumpIfEmpty)
+					if startTime.Before(endTime) {
+						continue
+					}
+				}
 				return
 			}
 		}


### PR DESCRIPTION
## Summary
Add support for `JumpIfEmpty` in `AsyncTimeRangedBatchQuery` to skip empty time ranges instead of stopping early.

## Changes
- In `pkg/exchange/batch/time_range_query.go`, when no records are sent in a batch (`!sentAny`) and `q.JumpIfEmpty > 0`, advance `startTime` by `q.JumpIfEmpty`.
- If the updated `startTime` is still before `endTime`, continue querying rather than returning immediately.
