### PR TITLE
FIX: [xfundingv2] adjust min holding intervals based on latest mid prices when ready

### DIFF
--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -1551,7 +1551,7 @@ func (r *ArbitrageRound) SetClosing(currentTime time.Time, duration types.Durati
 
 // setReady updates the round state to ready without locking. The caller must
 // already hold r.mu.
-func (r *ArbitrageRound) setReady(currentTime time.Time) {
+func (r *ArbitrageRound) setReady(currentTime time.Time, spotPrice, futuresPrice fixedpoint.Value) {
 	if !r.syncState.ReadyAt.IsZero() {
 		return
 	}
@@ -1562,6 +1562,22 @@ func (r *ArbitrageRound) setReady(currentTime time.Time) {
 	if oriOrder := r.futuresWorker.syncAndResetActiveOrder(); oriOrder != nil {
 		r.logger.Debugf("[setReady] reseting futures order: %s", oriOrder)
 	}
+
+	// adjust the holding intervals according to the latest mid prices.
+	// setReady is called with r.mu held, so use the unlocked variant to
+	// avoid re-acquiring the (non-reentrant) mutex.
+	unrealizedPnL := r.unrealizedPnL(spotPrice, futuresPrice)
+	totalPnL := unrealizedPnL.TotalPnL()
+	if totalPnL.Sign() < 0 {
+		fundingRate := r.syncState.TriggeredFundingRate
+		futuresNotional := unrealizedPnL.FuturesPosition.AverageCost.Mul(
+			unrealizedPnL.FuturesPosition.Base,
+		)
+		feeIncome := futuresNotional.Mul(fundingRate).Abs()
+		minHolding := unrealizedPnL.TotalPnL().Div(feeIncome).Round(0, fixedpoint.Up).Int()
+		r.syncState.MinHoldingIntervals = minHolding
+	}
+
 	r.syncState.State = RoundReady
 	r.syncState.ReadyAt = currentTime
 }
@@ -1721,7 +1737,7 @@ func (r *ArbitrageRound) Tick(ctx context.Context, currentTime time.Time, spotOr
 		futuresIsDust := r.futuresWorker.Market().IsDustQuantity(futuresRemaining.Abs(), futuresMidPrice)
 
 		if spotIsDust && futuresIsDust {
-			r.setReady(currentTime)
+			r.setReady(currentTime, spotMidPrice, futuresMidPrice)
 			return
 		}
 	}

--- a/pkg/strategy/xfundingv2/round_pnl.go
+++ b/pkg/strategy/xfundingv2/round_pnl.go
@@ -131,6 +131,12 @@ func (r *ArbitrageRound) UnrealizedPnL(spotPrice, futuresPrice fixedpoint.Value)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	return r.unrealizedPnL(spotPrice, futuresPrice)
+}
+
+// unrealizedPnL calculates the unrealized profit and loss of the round by the
+// given mark prices without locking. The caller must already hold r.mu.
+func (r *ArbitrageRound) unrealizedPnL(spotPrice, futuresPrice fixedpoint.Value) *RoundUnrealizedPnL {
 	realized := r.realizedPnL()
 
 	result := &RoundUnrealizedPnL{


### PR DESCRIPTION
### Summary
Dynamically recalculates the minimum holding intervals (`MinHoldingIntervals`) when transitioning an arbitrage round to the ready state based on the latest mid prices, unrealized PnL, and expected funding fee income.

### Changes
- **`pkg/strategy/xfundingv2/round.go`**:
  - Updated `ArbitrageRound.setReady` to accept `spotPrice` and `futuresPrice` (`fixedpoint.Value`).
  - Calculated `unrealizedPnL`, futures notional value, and expected funding fee income from `TriggeredFundingRate`.
  - Dynamically set `syncState.MinHoldingIntervals` based on the ratio of total PnL to expected fee income.
  - Updated `ArbitrageRound.Tick` to pass `spotMidPrice` and `futuresMidPrice` when invoking `setReady`.
