### PR TITLE
fix-binance-parse-twap-update

### DIFF
--- a/pkg/exchange/binance/parse.go
+++ b/pkg/exchange/binance/parse.go
@@ -32,6 +32,7 @@ const (
 	EventTypeTrade                   EventType = "trade"
 	EventTypeAggTrade                EventType = "aggTrade"
 	EventTypeForceOrder              EventType = "forceOrder"
+	EventTypeTwapUpdate              EventType = "TWAP_UPDATE"
 
 	// EventTypeListStatus is for OCO order update
 	// see https://developers.binance.com/docs/margin_trading/trade-data-stream/Event-Order-Update
@@ -351,6 +352,22 @@ type ResultEvent struct {
 	Status int            `json:"status"`
 }
 
+type TwapUpdateEvent struct {
+	EventBase
+	Update TwapUpdate `json:"tu"`
+}
+
+type TwapUpdate struct {
+	StrategyID       int64                      `json:"si"`
+	StrategyType     string                     `json:"st"`
+	Status           string                     `json:"ss"`
+	ExecutedQuantity fixedpoint.Value           `json:"eq"`
+	ExecutedAmount   fixedpoint.Value           `json:"ea"`
+	AveragePrice     fixedpoint.Value           `json:"ap"`
+	Symbol           string                     `json:"s"`
+	UpdateTime       types.MillisecondTimestamp `json:"ut"`
+}
+
 type ErrorEvent struct {
 	Id         int         `json:"id"`
 	Status     int         `json:"status"`
@@ -453,6 +470,10 @@ func parseWebSocketEvent(message []byte) (interface{}, error) {
 
 	case EventTypeForceOrder:
 		var event ForceOrderEvent
+		err = json.Unmarshal(message, &event)
+		return &event, err
+	case EventTypeTwapUpdate:
+		var event TwapUpdateEvent
 		err = json.Unmarshal(message, &event)
 		return &event, err
 	case EventServerShutdown:

--- a/pkg/exchange/binance/parse_test.go
+++ b/pkg/exchange/binance/parse_test.go
@@ -137,6 +137,17 @@ func TestMarginResponseParsing(t *testing.T) {
 	}
 }
 
+func TestParseTwapUpdate(t *testing.T) {
+	event, err := parseWebSocketEvent([]byte(`{"e":"TWAP_UPDATE","E":1774248826691,"tu":{"si":5172798,"st":"FUTURES_TWAP","ss":"EXPIRED","eq":"40.83","ea":"356.23770000","ap":"8.72490081","s":"LINKUSDT","ut":1774248826690}}`))
+
+	assert.NoError(t, err)
+	update, ok := event.(*TwapUpdateEvent)
+	assert.True(t, ok)
+	assert.Equal(t, int64(5172798), update.Update.StrategyID)
+	assert.Equal(t, "LINKUSDT", update.Update.Symbol)
+	assert.Equal(t, "EXPIRED", update.Update.Status)
+}
+
 func TestParseOrderUpdate(t *testing.T) {
 	payload := `{
   "e": "executionReport",        // Event type


### PR DESCRIPTION
## Summary

- parse Binance `TWAP_UPDATE` futures user-data events
- preserve TWAP status, symbol, quantities, amounts, price, and timestamps
- add a regression test for the reported payload

## Testing

- `gofmt -d pkg/exchange/binance/parse.go pkg/exchange/binance/parse_test.go`

Fixes #2432
