### PR TITLE
FEATURE: [xfundingv2] use taker orders for follower TWAP worker

### DIFF
--- a/pkg/strategy/xfundingv2/round.go
+++ b/pkg/strategy/xfundingv2/round.go
@@ -56,6 +56,11 @@ type ArbitrageRound struct {
 	futuresWorker *TWAPWorker
 	haltedAt      time.Time
 
+	// leader/follower TWAP configs, supplied by the strategy. The follower always
+	// uses taker orders. Not persisted; re-supplied on construction and restore.
+	leaderTWAPConfig   TWAPWorkerConfig
+	followerTWAPConfig TWAPWorkerConfig
+
 	lastRebalanceTime time.Time
 	rebalanceInterval time.Duration
 
@@ -1515,6 +1520,14 @@ func (r *ArbitrageRound) FuturesWorker() *TWAPWorker {
 	return r.futuresWorker
 }
 
+// SetTWAPConfigs supplies the leader and follower TWAP configs used to assign
+// worker order types when the round flips roles at closing. The follower config
+// uses taker orders.
+func (r *ArbitrageRound) SetTWAPConfigs(leader, follower TWAPWorkerConfig) {
+	r.leaderTWAPConfig = leader
+	r.followerTWAPConfig = follower
+}
+
 func (r *ArbitrageRound) FuturesMarket() types.Market {
 	return r.futuresWorker.Market()
 }
@@ -1541,6 +1554,11 @@ func (r *ArbitrageRound) SetClosing(currentTime time.Time, duration types.Durati
 	}
 	r.spotWorker.ResetTime(currentTime, duration)
 	r.futuresWorker.ResetTime(currentTime, duration)
+
+	// closing flips leader/follower: futures now leads (configured order type),
+	// spot now follows (taker orders to hedge reliably).
+	r.futuresWorker.SetConfig(r.leaderTWAPConfig)
+	r.spotWorker.SetConfig(r.followerTWAPConfig)
 
 	r.syncState.State = RoundClosing
 	r.syncState.ClosingAt = currentTime

--- a/pkg/strategy/xfundingv2/round_sync.go
+++ b/pkg/strategy/xfundingv2/round_sync.go
@@ -62,6 +62,10 @@ func (r *ArbitrageRound) Initialize(ctx context.Context, s *Strategy) error {
 	}
 	r.rebalanceInterval = s.RoundRebalanceInterval.Duration()
 
+	// re-supply leader/follower configs so a restored round flips roles correctly
+	// when it later closes. Restored workers keep their persisted order type.
+	r.SetTWAPConfigs(s.TWAPWorkerConfig, s.followerTWAPWorkerConfig)
+
 	return nil
 }
 

--- a/pkg/strategy/xfundingv2/round_test.go
+++ b/pkg/strategy/xfundingv2/round_test.go
@@ -719,3 +719,49 @@ func setupDeltaNeutralMockExchange(mockExchange *mocks.MockExchange, mockOrderQu
 		QueryOrderTrades(gomock.Any(), gomock.Any()).
 		Return([]types.Trade{}, nil).AnyTimes()
 }
+
+func TestArbitrageRound_FollowerUsesTakerOrders(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// leader keeps the configured (maker) order type; follower is derived as taker.
+	leaderConfig := TWAPWorkerConfig{
+		Duration:  types.Duration(10 * time.Minute),
+		NumSlices: 2,
+		OrderType: TWAPOrderTypeMaker,
+	}
+	followerConfig := leaderConfig
+	followerConfig.OrderType = TWAPOrderTypeTaker
+
+	// mirror checkOpenNewRound: spot (opening leader) uses the leader config,
+	// futures (opening follower) uses the follower config.
+	spotWorker, _, _, _ := newTestTWAPWorker(t, ctrl, leaderConfig)
+	spotWorker.SetTargetPosition(Number(1.0))
+	futuresWorker, _, _, _ := newTestTWAPWorker(t, ctrl, followerConfig)
+	futuresWorker.SetTargetPosition(Number(-1.0))
+
+	fundingRate := &types.PremiumIndex{
+		LastFundingRate: Number(0.001),
+		NextFundingTime: time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC),
+	}
+	round := NewArbitrageRound(
+		fundingRate,
+		types.ExchangeBinance, types.ExchangeBinance,
+		3, 8, Number(3), spotWorker, futuresWorker, &mockFuturesService{},
+		types.PositionShort, time.Minute)
+	round.SetLogger(logrus.WithField("test", "follower_taker"))
+	round.SetTWAPConfigs(leaderConfig, followerConfig)
+
+	// opening: spot leads (maker), futures follows (taker)
+	assert.Equal(t, TWAPOrderTypeMaker, round.SpotWorker().OrderType())
+	assert.Equal(t, TWAPOrderTypeTaker, round.FuturesWorker().OrderType())
+
+	round.SetClosing(time.Date(2024, 1, 1, 2, 0, 0, 0, time.UTC), types.Duration(time.Hour), fixedpoint.Zero)
+
+	// closing flips: futures leads (maker), spot follows (taker)
+	assert.Equal(t, TWAPOrderTypeTaker, round.SpotWorker().OrderType())
+	assert.Equal(t, TWAPOrderTypeMaker, round.FuturesWorker().OrderType())
+	// executor configs stay in sync with their workers
+	assert.Equal(t, TWAPOrderTypeTaker, round.SpotWorker().Executor().syncState.Config.OrderType)
+	assert.Equal(t, TWAPOrderTypeMaker, round.FuturesWorker().Executor().syncState.Config.OrderType)
+}

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -105,6 +105,11 @@ type Strategy struct {
 	MaxPendingRoundRetry    int              `json:"maxPendingRoundRetry"`
 	TWAPWorkerConfig        TWAPWorkerConfig `json:"twap"`
 
+	// followerTWAPWorkerConfig is derived from TWAPWorkerConfig (the leader config)
+	// with taker orders, so the follower TWAP worker can hedge the leader's fills
+	// reliably by crossing the spread. Set in Defaults.
+	followerTWAPWorkerConfig TWAPWorkerConfig
+
 	// Market selection criteria
 	MarketSelectionConfig *MarketSelectionConfig      `json:"marketSelection,omitempty"`
 	MaxPositionExposure   map[string]fixedpoint.Value `json:"maxPositionExposure"`
@@ -334,6 +339,11 @@ func (s *Strategy) Initialize() error {
 
 	s.futuresMarkPrices = make(map[string]fixedpoint.Value)
 	s.spotLastPrices = make(map[string]fixedpoint.Value)
+
+	// The follower TWAP worker always crosses the spread with taker orders so it can
+	// hedge the leader's fills reliably; the leader keeps the configured order type.
+	s.followerTWAPWorkerConfig = s.TWAPWorkerConfig
+	s.followerTWAPWorkerConfig.OrderType = TWAPOrderTypeTaker
 
 	return nil
 }
@@ -1400,7 +1410,8 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 		}
 		spotTwap.SetTargetPosition(selectedCandidate.TargetFuturesPosition.Neg())
 		futuresExecutor := s.futuresGeneralOrderExecutors[selectedCandidate.Symbol]
-		futuresTwap, err := NewTWAPWorker(ctx, selectedCandidate.Symbol, s.futuresSession, futuresExecutor, s.TWAPWorkerConfig)
+		// during opening, futures is the follower -> use taker orders to hedge reliably
+		futuresTwap, err := NewTWAPWorker(ctx, selectedCandidate.Symbol, s.futuresSession, futuresExecutor, s.followerTWAPWorkerConfig)
 		futuresTwap.SetLogger(s.logger)
 		futuresTwap.Executor().SetDryRun(s.DryRun)
 		if err != nil || futuresTwap == nil {
@@ -1422,6 +1433,8 @@ func (s *Strategy) checkOpenNewRound(ctx context.Context, currentTime time.Time)
 		)
 		round.SetupMetrics(s)
 		round.SetLogger(s.logger)
+		// provide the leader/follower configs so the round can flip roles when closing
+		round.SetTWAPConfigs(s.TWAPWorkerConfig, s.followerTWAPWorkerConfig)
 		round.SetSpotExchangeFeeRates(
 			s.costEstimator.GetSpotFeeRate(),
 		)

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -382,6 +382,11 @@ func (s *Strategy) Validate() error {
 	if s.MinNotionalMultiplier.Compare(fixedpoint.One) < 0 {
 		return fmt.Errorf("minNotionalMultiplier should be greater than or equal to 1: %s", s.MinNotionalMultiplier)
 	}
+
+	if err := s.TWAPWorkerConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid TWAP worker config: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/strategy/xfundingv2/twap.go
+++ b/pkg/strategy/xfundingv2/twap.go
@@ -625,9 +625,9 @@ func (w *TWAPWorker) shouldUpdateActiveOrder(orderBook types.OrderBook) bool {
 		return false
 	}
 
-	// taker orders are IOC — always refresh
+	// taker orders are IOC, if it's filled, do not update
 	if w.syncState.Config.OrderType == TWAPOrderTypeTaker {
-		return true
+		return w.activeOrder.Status != types.OrderStatusFilled
 	}
 
 	newPrice, err := w.syncState.TWAPExecutor.GetPrice(w.activeOrder.Side, orderBook)

--- a/pkg/strategy/xfundingv2/twap.go
+++ b/pkg/strategy/xfundingv2/twap.go
@@ -126,6 +126,19 @@ func (w *TWAPWorker) SetTargetPosition(targetPosition fixedpoint.Value) {
 	w.syncState.TargetPosition = targetPosition
 }
 
+// OrderType returns the worker's configured order type (maker or taker).
+func (w *TWAPWorker) OrderType() TWAPOrderType {
+	return w.syncState.Config.OrderType
+}
+
+// SetConfig replaces the worker's config parameters and propagates them to the
+// underlying executor. It only touches config (e.g. to switch order type when
+// the leader/follower role flips); runtime state is preserved.
+func (w *TWAPWorker) SetConfig(config TWAPWorkerConfig) {
+	w.syncState.Config = config
+	w.syncState.TWAPExecutor.SetConfig(config)
+}
+
 func (w *TWAPWorker) SetLogger(logger logrus.FieldLogger) {
 	accountType := "spot"
 	if w.syncState.TWAPExecutor.IsFutures() {

--- a/pkg/strategy/xfundingv2/twap.go
+++ b/pkg/strategy/xfundingv2/twap.go
@@ -76,6 +76,28 @@ func (c *TWAPWorkerConfig) Defaults() {
 	}
 }
 
+func (c *TWAPWorkerConfig) Validate() error {
+	if c.Duration <= 0 {
+		return fmt.Errorf("duration must be positive")
+	}
+	if c.ClosingDuration <= 0 {
+		return fmt.Errorf("closing duration must be positive")
+	}
+	if c.NumSlices <= 0 {
+		return fmt.Errorf("numSlices must be positive")
+	}
+	if c.OrderType != TWAPOrderTypeMaker && c.OrderType != TWAPOrderTypeTaker {
+		return fmt.Errorf("invalid order type: %s", c.OrderType)
+	}
+	if c.CheckInterval <= 0 {
+		return fmt.Errorf("check interval must be positive")
+	}
+	if c.MinSliceNotional.Sign() < 0 {
+		return fmt.Errorf("minSliceNotional must be non-negative")
+	}
+	return nil
+}
+
 type TWAPWorker struct {
 	syncState   TWAPWorkerSyncState
 	activeOrder *types.Order

--- a/pkg/strategy/xfundingv2/twap_order_executor.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor.go
@@ -66,6 +66,12 @@ func (o *TWAPExecutor) SetDryRun(dryRun bool) {
 	o.dryRun = dryRun
 }
 
+// SetConfig replaces the executor's config parameters (e.g. to switch order
+// type when the leader/follower role flips). Runtime state is preserved.
+func (o *TWAPExecutor) SetConfig(config TWAPWorkerConfig) {
+	o.syncState.Config = config
+}
+
 func (o *TWAPExecutor) Market() types.Market {
 	return o.syncState.Market
 }

--- a/pkg/strategy/xfundingv2/twap_order_executor.go
+++ b/pkg/strategy/xfundingv2/twap_order_executor.go
@@ -226,6 +226,7 @@ func (o *TWAPExecutor) PlaceOrder(quantity fixedpoint.Value, side types.SideType
 	timedCtx, cancel := context.WithTimeout(o.ctx, 500*time.Millisecond)
 	defer cancel()
 
+	o.logger.Infof("[TWAPExecutor] submitting order: %+v", order)
 	createdOrders, err := o.executor.SubmitOrders(timedCtx, order)
 	if err != nil || len(createdOrders) == 0 {
 		return nil, fmt.Errorf("failed to submit order: %+v, %v", order, err)

--- a/pkg/strategy/xfundingv2/twap_test.go
+++ b/pkg/strategy/xfundingv2/twap_test.go
@@ -1004,3 +1004,28 @@ func TestTWAPWorker_Misc(t *testing.T) {
 		assert.True(t, result)
 	})
 }
+
+func TestTWAPWorker_SetConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	makerConfig := TWAPWorkerConfig{
+		Duration:  types.Duration(10 * time.Minute),
+		NumSlices: 4,
+		OrderType: TWAPOrderTypeMaker,
+	}
+	worker, _, _, _ := newTestTWAPWorker(t, ctrl, makerConfig)
+
+	assert.Equal(t, TWAPOrderTypeMaker, worker.OrderType())
+	assert.Equal(t, TWAPOrderTypeMaker, worker.Executor().syncState.Config.OrderType)
+
+	takerConfig := makerConfig
+	takerConfig.OrderType = TWAPOrderTypeTaker
+	worker.SetConfig(takerConfig)
+
+	// both the worker and its underlying executor should reflect the new order type
+	assert.Equal(t, TWAPOrderTypeTaker, worker.OrderType())
+	assert.Equal(t, TWAPOrderTypeTaker, worker.Executor().syncState.Config.OrderType)
+	// unrelated config parameters are preserved
+	assert.Equal(t, 4, worker.syncState.Config.NumSlices)
+}


### PR DESCRIPTION
### Summary

Enforce taker orders for the follower TWAP worker in the `xfundingv2` strategy to ensure reliable hedging across the spread, and dynamically swap leader/follower order types when transitioning between opening and closing rounds.

### Key Changes

- **Strategy & Configuration**:
  - Derived `followerTWAPWorkerConfig` from `TWAPWorkerConfig` with `OrderType = TWAPOrderTypeTaker` so the follower reliably crosses the spread.
  - Added `TWAPWorkerConfig.Validate()` checking durations, slice counts, valid order types, intervals, and slice notionals, integrated into `Strategy.Validate()`.
  - Initialized the opening futures worker using `followerTWAPWorkerConfig`.

- **Worker Dynamic Reconfiguration**:
  - Added `SetConfig` and `OrderType` methods to `TWAPWorker` and `TWAPExecutor` to update configuration parameters (such as order type) without resetting runtime execution state.

- **Arbitrage Round Role Flipping & Restoration**:
  - Added `SetTWAPConfigs` to `ArbitrageRound` to store leader and follower configs.
  - Updated `ArbitrageRound.SetClosing` to flip roles at close: futures becomes the leader (configured order type) and spot becomes the follower (taker).
  - Re-supplied configs in `ArbitrageRound.Initialize` so restored rounds handle role flips properly upon closing.

- **Tests**:
  - Added `TestArbitrageRound_FollowerUsesTakerOrders` verifying order type assignments during opening and role inversion during closing.
  - Added `TestTWAPWorker_SetConfig` verifying config propagation to executors and preservation of existing settings.
