### PR TITLE
fix(grid2): skip market and non-pin orders in twin orderbook recovery (#1764)

### DIFF
--- a/pkg/strategy/grid2/recover.go
+++ b/pkg/strategy/grid2/recover.go
@@ -442,8 +442,18 @@ func queryTradesToUpdateTwinOrderBook(
 			// add 1 to avoid duplicate
 			fromTradeID = trade.ID + 1
 
+			if order.Type.IsMarket() || order.Price.IsZero() {
+				if logger != nil {
+					logger("[Recover] skip market order #%d", order.OrderID)
+				}
+				continue
+			}
+
 			if err := twinOrderBook.AddOrder(*order, true); err != nil {
-				return errors.Wrapf(err, "[Recover] failed to add queried order into twin orderbook: %s", order.String())
+				if logger != nil {
+					logger("[Recover] skip order #%d not in twin orderbook pins: %v", order.OrderID, err)
+				}
+				continue
 			}
 		}
 

--- a/pkg/strategy/grid2/recover_test.go
+++ b/pkg/strategy/grid2/recover_test.go
@@ -228,4 +228,38 @@ func TestQueryTradesToUpdateTwinOrderBook(t *testing.T) {
 		assert.True(book.GetTwinOrder(fixedpoint.NewFromInt(500)).Exist())
 		assert.Equal(orders[1].OrderID, book.GetTwinOrder(fixedpoint.NewFromInt(500)).GetOrder().OrderID)
 	})
+
+	t.Run("query trades skips market order without error", func(t *testing.T) {
+		book := newTwinOrderBook(pins)
+		mockTradeHistoryService := mocks.NewMockExchangeTradeHistoryService(mockCtrl)
+		mockOrderQueryService := mocks.NewMockExchangeOrderQueryService(mockCtrl)
+
+		trades := []types.Trade{
+			{
+				ID:      10,
+				OrderID: 10,
+				Symbol:  symbol,
+				Time:    types.Time(time.Now().Add(-1 * time.Hour)),
+			},
+		}
+		marketOrder := types.Order{
+			OrderID: 10,
+			Status:  types.OrderStatusFilled,
+			SubmitOrder: types.SubmitOrder{
+				Symbol:    symbol,
+				Side:      types.SideTypeSell,
+				OrderType: types.OrderTypeMarket,
+				Price:     fixedpoint.Zero,
+			},
+		}
+
+		mockTradeHistoryService.EXPECT().QueryTrades(gomock.Any(), gomock.Any(), gomock.Any()).Return(trades, nil).Times(1)
+		mockOrderQueryService.EXPECT().QueryOrder(gomock.Any(), types.OrderQuery{
+			Symbol:  symbol,
+			OrderID: "10",
+		}).Return(&marketOrder, nil)
+
+		assert.NoError(queryTradesToUpdateTwinOrderBook(ctx, symbol, book, mockTradeHistoryService, mockOrderQueryService, book.SyncOrderMap(), time.Now().Add(-24*time.Hour), time.Now(), nil))
+		assert.Equal(0, book.Size())
+	})
 }


### PR DESCRIPTION
### Problem
After a grid2 stop loss or market order triggers, `queryTradesToUpdateTwinOrderBook` queries historical trades and attempts to add every queried order (including market fills with price 0 or orders not matching grid pins) into the twin orderbook. `AddOrder` fails with `the order's price is not in pins`, causing `recoverPeriodically` to loop and fail repeatedly.

### Reproduction
1. Run grid2 strategy with a stop loss configured.
2. Trigger stop loss execution (which submits a market order).
3. Observe `recoverPeriodically` failing with `failed to add queried order into twin orderbook: ORDER ... MARKET SELL ... @ 0 | FILLED: the order's price (0) is not in pins`.

### Root Cause
Market orders (such as stop-loss market fills) and non-grid orders do not sit on grid pins. When `queryTradesToUpdateTwinOrderBook` fetched order details for trade history, it attempted to insert these market/non-pin orders into `twinOrderBook`, which rejected them because price 0 / non-pin prices do not exist in `pinIdx`.

### Fix
In `queryTradesToUpdateTwinOrderBook`, skip market orders (`order.Type.IsMarket() || order.Price.IsZero()`) and orders whose price does not exist in `twinOrderBook` pins, instead of returning an unhandled error that aborts grid recovery.

### Regression Test
Added `t.Run("query trades skips market order without error")` in `pkg/strategy/grid2/recover_test.go`.

### Verification
- `go test -v ./pkg/strategy/grid2/...` passes cleanly.

Fixes #1764
