### PR TITLE
FEATURE: [xfundingv2] interactive closing round button for ready rounds

### DIFF
--- a/pkg/notifier/slacknotifier/slack.go
+++ b/pkg/notifier/slacknotifier/slack.go
@@ -448,7 +448,7 @@ func (n *Notifier) Notify(obj interface{}, args ...interface{}) {
 	n.NotifyTo(n.channel, obj, args...)
 }
 
-func filterSlackAttachments(args []interface{}) (slackAttachments []slack.Attachment, pureArgs []interface{}) {
+func filterSlackAttachments(args []interface{}) (slackAttachments []slack.Attachment, slackBlocks []slack.Block, pureArgs []interface{}) {
 	var firstAttachmentOffset = -1
 	for idx, arg := range args {
 		switch a := arg.(type) {
@@ -486,6 +486,10 @@ func filterSlackAttachments(args []interface{}) (slackAttachments []slack.Attach
 			slackAttachments = append(slackAttachments, slack.Attachment{
 				Title: text,
 			})
+		case slack.Block:
+			slackBlocks = append(slackBlocks, a)
+		case SlackBlocksCreator:
+			slackBlocks = append(slackBlocks, a.SlackBlocks()...)
 		}
 	}
 
@@ -494,7 +498,7 @@ func filterSlackAttachments(args []interface{}) (slackAttachments []slack.Attach
 		pureArgs = args[:firstAttachmentOffset]
 	}
 
-	return slackAttachments, pureArgs
+	return slackAttachments, slackBlocks, pureArgs
 }
 
 func (n *Notifier) NotifyTo(channel string, obj interface{}, args ...interface{}) {
@@ -502,27 +506,33 @@ func (n *Notifier) NotifyTo(channel string, obj interface{}, args ...interface{}
 		channel = n.channel
 	}
 
-	slackAttachments, pureArgs := filterSlackAttachments(args)
+	slackAttachments, blocks, pureArgs := filterSlackAttachments(args)
 
 	var opts []slack.MsgOption
 
 	switch a := obj.(type) {
 	case string:
 		opts = append(opts, slack.MsgOptionText(fmt.Sprintf(a, pureArgs...), true),
-			slack.MsgOptionAttachments(slackAttachments...))
+			slack.MsgOptionAttachments(slackAttachments...),
+			slack.MsgOptionBlocks(blocks...),
+		)
 
 	case slack.Attachment:
 		opts = append(opts, slack.MsgOptionAttachments(append([]slack.Attachment{a}, slackAttachments...)...))
+		opts = append(opts, slack.MsgOptionBlocks(blocks...))
 
 	case *slack.Attachment:
 		opts = append(opts, slack.MsgOptionAttachments(append([]slack.Attachment{*a}, slackAttachments...)...))
+		opts = append(opts, slack.MsgOptionBlocks(blocks...))
 
 	case SlackBlocksCreator:
 		opts = append(opts, slack.MsgOptionBlocks(a.SlackBlocks()...))
+		opts = append(opts, slack.MsgOptionBlocks(blocks...))
 
 	case SlackAttachmentCreator:
 		// convert object to slack attachment (if supported)
 		opts = append(opts, slack.MsgOptionAttachments(append([]slack.Attachment{a.SlackAttachment()}, slackAttachments...)...))
+		opts = append(opts, slack.MsgOptionBlocks(blocks...))
 
 	default:
 		log.Errorf("slack message conversion error, unsupported object: %T %+v", a, a)

--- a/pkg/strategy/xfundingv2/slack.go
+++ b/pkg/strategy/xfundingv2/slack.go
@@ -3,10 +3,12 @@ package xfundingv2
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/slack-go/slack"
 
 	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/interact"
 	"github.com/c9s/bbgo/pkg/notifier/slacknotifier"
 )
 
@@ -153,4 +155,93 @@ func removeBlockByID(oriBlocks []slack.Block, id string) []slack.Block {
 		blocks = append(blocks, block)
 	}
 	return blocks
+}
+
+// setupCloseRoundInteraction registers the button-click handler for this
+// strategy instance, keyed by s.slackEvtID. All interactive close-round messages
+// emitted by this instance carry that slackEvtID context block, so their clicks
+// route here. The clicked button's value is the round's spot symbol.
+func setupCloseRoundInteraction(s *Strategy, dispatcher *interact.InteractiveMessageDispatcher) {
+	dispatcher.Register(s.slackEvtID, newCloseRoundHandler(s))
+}
+
+// newCloseRoundHandler builds the interactive-message handler closure over the
+// strategy. It is split out from setupCloseRoundInteraction so it can be invoked
+// directly in tests without a dispatcher.
+func newCloseRoundHandler(s *Strategy) interact.InteractiveMessageHandler {
+	return func(
+		user slack.User, oriMessage slack.Message, actionID string, actionValue string,
+	) ([]interact.InteractionMessageUpdate, error) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		symbol, roundID := decodeCloseRoundValue(actionValue)
+		round, ok := s.ActiveRounds[symbol]
+		// The close only affects the exact round the notification was attached
+		// to: the live round under this symbol must still be the same round ID.
+		if !ok || round.ID() != roundID {
+			return []interact.InteractionMessageUpdate{
+				{
+					Blocks: removeBlockByID(
+						oriMessage.Blocks.BlockSet,
+						buttonsBlockID,
+					),
+					PostInThread: false,
+				},
+				{
+					Blocks: []slack.Block{
+						buildTextBlock(fmt.Sprintf(
+							"🔴 Round `%s` (`%s`) is no longer closeable (requested by %s)",
+							symbol, roundID, user.Name,
+						)),
+					},
+					PostInThread: true,
+				},
+			}, nil
+		}
+
+		switch actionID {
+		case closeRoundActionID:
+			// first click: swap the single button for Confirm / Cancel. No state change.
+			blocks := removeBlockByID(
+				oriMessage.Blocks.BlockSet,
+				buttonsBlockID,
+			)
+			blocks = append(blocks, buildConfirmButtonsBlock(symbol, roundID))
+			return []interact.InteractionMessageUpdate{
+				{
+					Blocks:       blocks,
+					PostInThread: false,
+				},
+			}, nil
+		case confirmCloseActionID:
+			_, futuresPrice, _ := s.getLastPrices(round.SpotSymbol(), round.FuturesSymbol())
+			round.SetClosing(time.Now(), s.TWAPWorkerConfig.ClosingDuration, futuresPrice)
+			return []interact.InteractionMessageUpdate{
+				{
+					Blocks:       removeBlockByID(oriMessage.Blocks.BlockSet, buttonsBlockID),
+					PostInThread: false,
+				},
+				{
+					Blocks: []slack.Block{
+						buildTextBlock(fmt.Sprintf("✅ Round `%s` (`%s`) set to closing by %s", symbol, roundID, user.Name))},
+					PostInThread: true,
+				},
+			}, nil
+
+		default:
+			return []interact.InteractionMessageUpdate{
+				{
+					Blocks: removeBlockByID(oriMessage.Blocks.BlockSet,
+						buttonsBlockID,
+					),
+					PostInThread: false,
+				},
+				{
+					Blocks:       []slack.Block{buildTextBlock("Invalid action ID: " + actionID)},
+					PostInThread: true,
+				},
+			}, nil
+		}
+	}
 }

--- a/pkg/strategy/xfundingv2/slack.go
+++ b/pkg/strategy/xfundingv2/slack.go
@@ -1,0 +1,156 @@
+package xfundingv2
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/slack-go/slack"
+
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/notifier/slacknotifier"
+)
+
+var (
+	_ slacknotifier.SlackBlocksCreator = &interactiveCloseRound{}
+)
+
+// buttonsBlockID is the block ID of the action block that holds the
+// interactive buttons. It is removed/replaced after a click.
+const buttonsBlockID = "xfundingv2_close_round_buttons"
+
+// action IDs for the interactive close-round buttons.
+const (
+	closeRoundActionID   = "close_round"
+	confirmCloseActionID = "confirm_close_round"
+)
+
+// interactiveCloseRound renders a periodic, block-based Slack message carrying a
+// "Close Round" button for a Ready round. It implements
+// slacknotifier.SlackBlocksCreator so bbgo.Notify emits it as a blocks message
+// (interactive buttons require blocks, not attachments).
+//
+// There is no registry: the target round is carried in the button value (the
+// round's spot symbol) and re-located from s.ActiveRounds under s.mu when the
+// operator confirms. This is idempotent and leak-free under periodic re-emission.
+type interactiveCloseRound struct {
+	// slackEvtID is the dispatch key. It is rendered as a context block so the
+	// dispatcher can route button clicks on this message to the handler
+	// registered for this strategy instance. IMPORTANT: do not omit it.
+	slackEvtID string
+
+	// symbol is the round's spot symbol; used to look up the live round.
+	symbol string
+
+	// roundID is the round's unique ID. Together with symbol it is encoded into
+	// the button value so a click only affects the exact round the notification
+	// was attached to (a symbol may host a different round by the time an older,
+	// periodically re-emitted message is clicked).
+	roundID string
+
+	spotPrice, futuresPrice fixedpoint.Value
+
+	round *ArbitrageRound
+}
+
+func newInteractiveCloseRound(
+	round *ArbitrageRound, slackEvtID string, spotPrice, futuresPrice fixedpoint.Value,
+) *interactiveCloseRound {
+	return &interactiveCloseRound{
+		slackEvtID:   slackEvtID,
+		symbol:       round.SpotSymbol(),
+		roundID:      round.ID(),
+		spotPrice:    spotPrice,
+		futuresPrice: futuresPrice,
+		round:        round,
+	}
+}
+
+// closeRoundValueSep separates the symbol and round ID inside a button value.
+// Neither a spot symbol nor a UUID round ID contains it.
+const closeRoundValueSep = "||"
+
+// encodeCloseRoundValue packs symbol and round ID into a single button value.
+func encodeCloseRoundValue(symbol, roundID string) string {
+	return symbol + closeRoundValueSep + roundID
+}
+
+// decodeCloseRoundValue splits a button value back into symbol and round ID.
+func decodeCloseRoundValue(value string) (symbol, roundID string) {
+	symbol, roundID, _ = strings.Cut(value, closeRoundValueSep)
+	return symbol, roundID
+}
+
+func (c *interactiveCloseRound) SlackBlocks() []slack.Block {
+	// The context block ID is the dispatch key. IMPORTANT: keep this block.
+	blocks := []slack.Block{
+		slack.NewContextBlock(
+			c.slackEvtID,
+			slack.NewTextBlockObject(
+				slack.MarkdownType,
+				"   ",
+				false,
+				false,
+			),
+		),
+	}
+
+	blocks = append(blocks, buildTextBlock(fmt.Sprintf(
+		"🟢 Ready Round %s (%s)\nPress *Close Round* to close it.",
+		c.symbol,
+		c.roundID,
+	)))
+
+	blocks = append(blocks, buildCloseRoundButtonsBlock(c.symbol, c.roundID))
+	return blocks
+}
+
+// buildCloseRoundButtonsBlock builds the initial single "Close Round" button.
+// The button value carries the round's spot symbol and round ID so the handler
+// can re-locate the exact live round on confirm.
+func buildCloseRoundButtonsBlock(symbol, roundID string) slack.Block {
+	return slack.NewActionBlock(
+		buttonsBlockID,
+		slack.NewButtonBlockElement(
+			closeRoundActionID,
+			encodeCloseRoundValue(symbol, roundID),
+			slack.NewTextBlockObject(slack.PlainTextType, "Close Round", false, false),
+		).WithStyle(slack.StyleDefault),
+	)
+}
+
+// buildConfirmButtonsBlock builds the two-step confirmation buttons that
+// replace the initial "Close Round" button after the first click.
+func buildConfirmButtonsBlock(symbol, roundID string) slack.Block {
+	value := encodeCloseRoundValue(symbol, roundID)
+	return slack.NewActionBlock(
+		buttonsBlockID,
+		slack.NewButtonBlockElement(
+			confirmCloseActionID,
+			value,
+			slack.NewTextBlockObject(slack.PlainTextType, "Confirm Close", false, false),
+		).WithStyle(slack.StyleDanger),
+	)
+}
+
+func buildTextBlock(text string) slack.Block {
+	return slack.NewSectionBlock(
+		slack.NewTextBlockObject(
+			slack.MarkdownType,
+			text,
+			false,
+			false,
+		),
+		nil, nil,
+	)
+}
+
+func removeBlockByID(oriBlocks []slack.Block, id string) []slack.Block {
+	var blocks []slack.Block
+	for _, block := range oriBlocks {
+		if block.ID() == id {
+			continue // skip block
+		}
+		blocks = append(blocks, block)
+	}
+	return blocks
+}

--- a/pkg/strategy/xfundingv2/slack_test.go
+++ b/pkg/strategy/xfundingv2/slack_test.go
@@ -1,0 +1,190 @@
+package xfundingv2
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/c9s/bbgo/pkg/bbgo"
+	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/interact"
+	"github.com/c9s/bbgo/pkg/notifier/slacknotifier"
+	"github.com/c9s/bbgo/pkg/types"
+
+	. "github.com/c9s/bbgo/pkg/testing/testhelper"
+)
+
+// blockIDs returns the IDs of the given blocks, for assertions.
+func blockIDs(blocks []slack.Block) []string {
+	ids := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		ids = append(ids, b.ID())
+	}
+	return ids
+}
+
+// hasBlockID reports whether any block has the given ID.
+func hasBlockID(blocks []slack.Block, id string) bool {
+	for _, got := range blockIDs(blocks) {
+		if got == id {
+			return true
+		}
+	}
+	return false
+}
+
+// closeRoundMessage builds a slack.Message carrying the interactive close-round
+// blocks, as it would appear when a click callback arrives.
+func closeRoundMessage(c *interactiveCloseRound) slack.Message {
+	return slack.Message{
+		Msg: slack.Msg{
+			Blocks:    slack.Blocks{BlockSet: c.SlackBlocks()},
+			Timestamp: "123456.789",
+		},
+	}
+}
+
+// newStrategyFixture builds a Strategy fixture for testing
+func newStrategyFixture(
+	t *testing.T, ctrl *gomock.Controller, symbol, slackEvtID string,
+) (*Strategy, *ArbitrageRound) {
+	nextFundingTime := time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC)
+	round, _ := newTestArbitrageRound(t, ctrl, 8, 3, nextFundingTime)
+	round.syncState.StartAt = time.Date(2024, 1, 1, 0, 30, 0, 0, time.UTC)
+	round.syncState.State = RoundReady
+
+	s := &Strategy{
+		slackEvtID:        slackEvtID,
+		ActiveRounds:      map[string]*ArbitrageRound{symbol: round},
+		spotLastPrices:    map[string]fixedpoint.Value{symbol: Number(50000.0)},
+		futuresMarkPrices: map[string]fixedpoint.Value{symbol: Number(50010.0)},
+	}
+	s.TWAPWorkerConfig.ClosingDuration = types.Duration(time.Hour)
+	return s, round
+}
+
+// TestNotifyInteractiveCloseRound builds an interactive close-round notification
+// and sends it through bbgo.Notify.
+func TestNotifyInteractiveCloseRound(t *testing.T) {
+	slackBotToken := os.Getenv("SLACK_BOT_TOKEN")
+	slackAppToken := os.Getenv("SLACK_APP_TOKEN")
+	channel := os.Getenv("SLACK_CHANNEL")
+	if slackBotToken == "" || slackAppToken == "" || channel == "" {
+		t.Skip("SLACK_BOT_TOKEN, SLACK_APP_TOKEN and SLACK_CHANNEL must be set")
+	}
+	if !strings.HasPrefix(slackBotToken, "xoxb-") {
+		t.Fatal("SLACK_BOT_TOKEN must have the prefix \"xoxb-\"")
+	}
+	if !strings.HasPrefix(slackAppToken, "xapp-") {
+		t.Fatal("SLACK_APP_TOKEN must have the prefix \"xapp-\"")
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// build a live strategy fixture
+	s, round := newStrategyFixture(t, ctrl, "BTCUSDT", "test-slack-evt-id")
+
+	// wire a real Slack notifier into bbgo's notification hub
+	client := slack.New(slackBotToken, slack.OptionAppLevelToken(slackAppToken))
+	bbgo.Notification.AddNotifier(slacknotifier.New(client, channel))
+
+	// wire the interactive button handler
+	messenger := interact.NewSlack(client)
+	dispatcher := interact.NewInteractiveMessageDispatcher(messenger)
+	setupCloseRoundInteraction(s, dispatcher)
+
+	go messenger.Start(context.Background())
+
+	spotPrice, futuresPrice, _ := s.getLastPrices("BTCUSDT", "BTCUSDT")
+	c := newInteractiveCloseRound(round, s.slackEvtID, Number(50000.0), Number(50010.0))
+	bbgo.Notify("Active Rounds", round.NewNotification(spotPrice, futuresPrice), c)
+
+	// the Slack notifier posts asynchronously and socket mode delivers clicks on
+	// its own goroutine; keep the process alive so the handler can run.
+	for {
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func TestCloseRoundInteraction(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const symbol = "BTCUSDT"
+	const slackEvtID = "test-slack-evt-id"
+
+	t.Run("SlackBlocks include dispatch key and buttons", func(t *testing.T) {
+		s, round := newStrategyFixture(t, ctrl, symbol, slackEvtID)
+		c := newInteractiveCloseRound(round, s.slackEvtID, Number(50000.0), Number(50010.0))
+		blocks := c.SlackBlocks()
+
+		assert.True(t, hasBlockID(blocks, slackEvtID), "must carry the slackEvtID context block")
+		assert.True(t, hasBlockID(blocks, buttonsBlockID), "must carry the buttons block")
+	})
+
+	t.Run("Close reveals confirm/cancel without changing state", func(t *testing.T) {
+		s, round := newStrategyFixture(t, ctrl, symbol, slackEvtID)
+		c := newInteractiveCloseRound(round, s.slackEvtID, Number(50000.0), Number(50010.0))
+		handler := newCloseRoundHandler(s)
+
+		value := encodeCloseRoundValue(symbol, round.ID())
+		updates, err := handler(slack.User{Name: "alice"}, closeRoundMessage(c), closeRoundActionID, value)
+		assert.NoError(t, err)
+		assert.Len(t, updates, 1)
+		// buttons block is replaced (same block ID), and no state change yet
+		assert.True(t, hasBlockID(updates[0].Blocks, buttonsBlockID))
+		assert.Equal(t, RoundReady, round.State(), "state must not change on first click")
+	})
+
+	t.Run("Confirm drives the round to closing", func(t *testing.T) {
+		s, round := newStrategyFixture(t, ctrl, symbol, slackEvtID)
+		c := newInteractiveCloseRound(round, s.slackEvtID, Number(50000.0), Number(50010.0))
+		handler := newCloseRoundHandler(s)
+
+		value := encodeCloseRoundValue(symbol, round.ID())
+		updates, err := handler(slack.User{Name: "alice"}, closeRoundMessage(c), confirmCloseActionID, value)
+		assert.NoError(t, err)
+		// confirm produces the main update plus a threaded acknowledgement
+		assert.Len(t, updates, 2)
+		// the buttons block is stripped after confirm
+		assert.False(t, hasBlockID(updates[0].Blocks, buttonsBlockID))
+		assert.Equal(t, RoundClosing, round.State(), "confirm must set the round to closing")
+	})
+
+	t.Run("Confirm on unknown symbol is a no-op", func(t *testing.T) {
+		s, round := newStrategyFixture(t, ctrl, symbol, slackEvtID)
+		c := newInteractiveCloseRound(round, s.slackEvtID, Number(50000.0), Number(50010.0))
+		handler := newCloseRoundHandler(s)
+
+		value := encodeCloseRoundValue("DOGEUSDT", round.ID())
+		updates, err := handler(slack.User{Name: "alice"}, closeRoundMessage(c), confirmCloseActionID, value)
+		assert.NoError(t, err)
+		// no-op still emits the main update plus a threaded "not closeable" reply
+		assert.Len(t, updates, 2)
+		// original round is untouched
+		assert.Equal(t, RoundReady, round.State())
+	})
+
+	t.Run("Confirm with a stale round ID is a no-op", func(t *testing.T) {
+		s, round := newStrategyFixture(t, ctrl, symbol, slackEvtID)
+		c := newInteractiveCloseRound(round, s.slackEvtID, Number(50000.0), Number(50010.0))
+		handler := newCloseRoundHandler(s)
+
+		// same symbol, but the notification points at a round ID that is no longer
+		// the live round under this symbol — the click must not close it.
+		value := encodeCloseRoundValue(symbol, "some-other-round-id")
+		updates, err := handler(slack.User{Name: "alice"}, closeRoundMessage(c), confirmCloseActionID, value)
+		assert.NoError(t, err)
+		// no-op still emits the main update plus a threaded "not closeable" reply
+		assert.Len(t, updates, 2)
+		assert.Equal(t, RoundReady, round.State(), "a stale round ID must not close the live round")
+		assert.False(t, hasBlockID(updates[0].Blocks, buttonsBlockID))
+	})
+}

--- a/pkg/strategy/xfundingv2/strategy.go
+++ b/pkg/strategy/xfundingv2/strategy.go
@@ -14,10 +14,12 @@ import (
 	"github.com/c9s/bbgo/pkg/exchange/binance"
 	"github.com/c9s/bbgo/pkg/exchange/binance/binanceapi"
 	"github.com/c9s/bbgo/pkg/fixedpoint"
+	"github.com/c9s/bbgo/pkg/interact"
 	"github.com/c9s/bbgo/pkg/profile/timeprofile"
 	"github.com/c9s/bbgo/pkg/risk/circuitbreaker"
 	"github.com/c9s/bbgo/pkg/slack/slackalert"
 	"github.com/c9s/bbgo/pkg/types"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
@@ -176,6 +178,10 @@ type Strategy struct {
 
 	logger     logrus.FieldLogger
 	logLimiter *rate.Limiter
+
+	// slackEvtID is the interactive-message dispatch key for this strategy
+	// instance. It's for the interactive close round feature.
+	slackEvtID string
 
 	lastTickTime time.Time
 
@@ -883,6 +889,15 @@ func (s *Strategy) CrossRun(
 		s.candidateSymbols,
 	)
 
+	// wire the interactive "Close Round" button. It's always on when a Slack
+	// interaction dispatcher is available; silently skipped otherwise.
+	if dispatcher, err := interact.GetDispatcher(); err != nil {
+		s.logger.Warnf("xfundingv2 interactive close round disabled: %s", err)
+	} else {
+		s.slackEvtID = uuid.NewString()
+		setupCloseRoundInteraction(s, dispatcher)
+	}
+
 	// Register shutdown handler to persist state
 	bbgo.OnShutdown(s.ctx, func(ctx context.Context, wg *sync.WaitGroup) {
 		defer wg.Done()
@@ -1237,7 +1252,6 @@ func (s *Strategy) transitOpeningOrReadyRoundToClosing(round *ArbitrageRound, in
 		} else {
 			bbgo.Notify("⚠️ Round funding rate flipped %s -> %s (%s)",
 				round.TriggeredFundingRate(), index.LastFundingRate, round.SpotSymbol(),
-				round.NewNotification(spotPrice, futuresPrice),
 			)
 		}
 
@@ -1780,14 +1794,9 @@ func (s *Strategy) handleClosedRound(ctx context.Context, task *CloseRoundTask, 
 			if err := s.futuresService.TransferFuturesAccountAsset(ctx, asset, residualAmount, types.TransferOut); err != nil {
 				return fmt.Errorf("[handleClosedRound] failed to transfer %s %s during round exit: %w", balance.Available, asset, err)
 			}
-			spotPrice, futuresPrice, _ := s.getLastPrices(
-				round.SpotSymbol(),
-				round.FuturesSymbol(),
-			)
 			bbgo.Notify("⬅️ Transferred %s %s back to spot account",
 				residualAmount,
 				asset,
-				round.NewNotification(spotPrice, futuresPrice),
 			)
 		}
 	}
@@ -1872,23 +1881,6 @@ func (s *Strategy) newDebugLogger() *logrus.Entry {
 }
 
 func (s *Strategy) notifyStats() {
-	var activeRoundNotifications []any
-	for _, round := range s.sortedActiveRounds() {
-		spotPrice, futuresPrice, ok := s.getLastPrices(
-			round.SpotSymbol(),
-			round.FuturesSymbol(),
-		)
-		if !ok {
-			continue
-		}
-		activeRoundNotifications = append(activeRoundNotifications, round.NewNotification(spotPrice, futuresPrice))
-		if s.roundInsertService != nil {
-			if err := s.roundInsertService.InsertActiveRound(round, spotPrice, futuresPrice); err != nil {
-				s.logger.WithError(err).Warnf("failed to insert active round to database: %s", round)
-			}
-		}
-	}
-
 	var pendingRoundNotifications []any
 	for _, pendingRound := range s.PendingRounds {
 		spotPrice, futuresPrice, _ := s.getLastPrices(
@@ -1902,8 +1894,36 @@ func (s *Strategy) notifyStats() {
 		len(s.ActiveRounds),
 		len(s.PendingRounds),
 	)
-	if len(activeRoundNotifications) > 0 {
-		bbgo.Notify("Active Rounds", activeRoundNotifications...)
+	for _, round := range s.sortedActiveRounds() {
+		spotPrice, futuresPrice, ok := s.getLastPrices(
+			round.SpotSymbol(),
+			round.FuturesSymbol(),
+		)
+		if !ok {
+			s.logger.Warnf(
+				"failed to get last prices, skipping notification: %s",
+				round.String(),
+			)
+			continue
+		}
+
+		// additionally emit an interactive "Close Round" message for Ready rounds
+		// so an operator can close them on demand. The plain attachment above is
+		// left unchanged, so the round still appears in the "Active Rounds" batch.
+		if s.slackEvtID != "" && round.State() == RoundReady {
+			bbgo.Notify(
+				newInteractiveCloseRound(round, s.slackEvtID, spotPrice, futuresPrice),
+				round.NewNotification(spotPrice, futuresPrice),
+			)
+		} else {
+			bbgo.Notify(round.NewNotification(spotPrice, futuresPrice))
+		}
+
+		if s.roundInsertService != nil {
+			if err := s.roundInsertService.InsertActiveRound(round, spotPrice, futuresPrice); err != nil {
+				s.logger.WithError(err).Warnf("failed to insert active round to database: %s", round)
+			}
+		}
 	}
 	if len(pendingRoundNotifications) > 0 {
 		bbgo.Notify("Pending Rounds", pendingRoundNotifications...)


### PR DESCRIPTION
Interactive closing button for ready rounds
<img width="541" height="198" alt="截圖 2026-09-11 晚上9 26 09" src="https://github.com/user-attachments/assets/5a8f1934-6f91-444c-a7ca-ef609980da7c" />

For safety, it has a 2-step confirmation before closing the round:
<img width="516" height="145" alt="截圖 2026-09-11 晚上9 26 20" src="https://github.com/user-attachments/assets/a2b5b72a-5e90-49f7-903d-e47b63081509" />
